### PR TITLE
Benchmarking

### DIFF
--- a/dev/flame.py
+++ b/dev/flame.py
@@ -1,0 +1,63 @@
+import json
+import re
+def merge(blob):
+    if len(blob['children']) == 0:
+        return
+    new_children = dict()
+    for child in blob['children']:
+        name = child['name']
+        if name not in new_children.keys():
+            new_children[name] = child
+        else:
+            new_children[name]['value'] += child['value']
+            new_children[name]['children'] += child['children']
+    new_children_list = list(new_children.values())
+    blob['children'] = new_children_list
+    for new_child_idx in range(len(new_children_list)):
+        merge(new_children_list[new_child_idx])
+    
+def organize_children(blob):
+    # assumes the children are all uniquely named
+    parent_start = blob['start']
+    last_end = parent_start
+    for child_idx in range(len(blob['children'])):
+        blob['children'][child_idx]['start'] = last_end
+        blob['children'][child_idx]['end'] = last_end + blob['children'][child_idx]['value']
+        last_end = blob['children'][child_idx]['end']
+        if len(blob['children'][child_idx]['children']) > 0:
+            organize_children(blob['children'][child_idx])
+
+def parse_html():
+    #d3.select("body").datum({ children:
+    f = open("flame-graph.html", "r")
+    text = "".join(f.readlines())
+    
+    jsonish_re = re.search('d3\.select\("body"\)\.datum\(\{ children: ', text)
+    span = jsonish_re.span()
+    head = text[0:span[1]]
+    jsonish = text[span[1]:-59]
+    tail = text[-59:]
+    
+    jsonish = jsonish.replace('name:', '"name":')
+    jsonish = jsonish.replace('start:', '"start":')
+    jsonish = jsonish.replace('end:', '"end":')
+    jsonish = jsonish.replace('value:', '"value":')
+    jsonish = jsonish.replace('children:', '"children":')
+    jsonish = jsonish.replace('\n', '')
+    jsonish = jsonish.replace(',}', '}')
+    jsonish = jsonish.replace(',]', ']')
+    
+    return (head, jsonish, tail)
+    
+head, jsonish, tail = parse_html()
+blob = dict()
+blob['name'] = 'root'
+blob['start'] = 0
+blob['children'] = json.loads(jsonish)
+merge(blob)
+organize_children(blob)
+
+f = open("flame-graph-new.html", "w")
+f.write(head)
+f.write(str(blob['children']))
+f.write(tail)

--- a/dev/flame.py
+++ b/dev/flame.py
@@ -1,5 +1,26 @@
+# flame.py: a script to reorganize flame-graph.html
+# running this script while a copy of flame-graph.html is found in the same directory
+# will produce a new file called flame-graph-new.html in which all invocations of the
+# same subfunction within a given function are grouped together
+#
+# context: the "flame" rust crate produces flame graphs which can help visualize which
+# parts of the program require the most time to execute. This flamegraph orders functions 
+# chronologically on the x axis, but if the same function is called in multiple places in 
+# the general execution flow, then it will appear broken up into various chunks, making 
+# it hard to tell how much of the overall execution is attributable to that function.
+#
+# This code essentially parses the json in the flame-graph.html file output by the flame 
+# crate, reorganizes it, and writes a new html flame graph which groups together invocations
+# in a more convenient way.
+
+
 import json
 import re
+
+# merges any separate timings of the same function with the same parent together 
+# e.g. if function A() calls C() twice and function B() calls C() four times,
+# this would show A() and C() both calling B() once, but it taking around twice as long in C()
+# (assuming in this example that all calls to C() take roughly the same amount of time)
 def merge(blob):
     if len(blob['children']) == 0:
         return
@@ -15,9 +36,10 @@ def merge(blob):
     blob['children'] = new_children_list
     for new_child_idx in range(len(new_children_list)):
         merge(new_children_list[new_child_idx])
-    
+
+# aligns a function's subfunctions (children) to all be positioned sequentially along the x axis
+# and start at the same time as their parent
 def organize_children(blob):
-    # assumes the children are all uniquely named
     parent_start = blob['start']
     last_end = parent_start
     for child_idx in range(len(blob['children'])):
@@ -27,17 +49,23 @@ def organize_children(blob):
         if len(blob['children'][child_idx]['children']) > 0:
             organize_children(blob['children'][child_idx])
 
+# flame-graph.html is composed of a large json data blob and some code to process and display it
+# this parses out the json part specifically and formats it in a way the python json module can handle
 def parse_html():
     #d3.select("body").datum({ children:
     f = open("flame-graph.html", "r")
     text = "".join(f.readlines())
     
+    # search the file for the specific substring d3.select("body").datum({ children:
+    # everthing between this substring and the last 59 characters of the file is json data
     jsonish_re = re.search('d3\.select\("body"\)\.datum\(\{ children: ', text)
     span = jsonish_re.span()
     head = text[0:span[1]]
     jsonish = text[span[1]:-59]
     tail = text[-59:]
     
+    # the "json-ish" text from the html file needs to be modified slightly so that
+    # the python json parser can handle it
     jsonish = jsonish.replace('name:', '"name":')
     jsonish = jsonish.replace('start:', '"start":')
     jsonish = jsonish.replace('end:', '"end":')

--- a/dev/flame.py
+++ b/dev/flame.py
@@ -52,7 +52,6 @@ def organize_children(blob):
 # flame-graph.html is composed of a large json data blob and some code to process and display it
 # this parses out the json part specifically and formats it in a way the python json module can handle
 def parse_html():
-    #d3.select("body").datum({ children:
     f = open("flame-graph.html", "r")
     text = "".join(f.readlines())
     

--- a/dev/flame.py
+++ b/dev/flame.py
@@ -1,9 +1,9 @@
 # flame.py: a script to reorganize flame-graph.html
-# running this script while a copy of flame-graph.html is found in the same directory
+# Running this script while a copy of flame-graph.html is found in the same directory
 # will produce a new file called flame-graph-new.html in which all invocations of the
-# same subfunction within a given function are grouped together
+# same subfunction within a given function are grouped together.
 #
-# context: the "flame" rust crate produces flame graphs which can help visualize which
+# Context: The "flame" rust crate produces flame graphs which can help visualize which
 # parts of the program require the most time to execute. This flamegraph orders functions 
 # chronologically on the x axis, but if the same function is called in multiple places in 
 # the general execution flow, then it will appear broken up into various chunks, making 
@@ -17,10 +17,10 @@
 import json
 import re
 
-# merges any separate timings of the same function with the same parent together 
-# e.g. if function A() calls C() twice and function B() calls C() four times,
+# Merges any separate timings of the same function with the same parent together.
+# For example, if function A() calls C() twice and function B() calls C() four times,
 # this would show A() and C() both calling B() once, but it taking around twice as long in C()
-# (assuming in this example that all calls to C() take roughly the same amount of time)
+# (assuming in this example that all calls to C() take roughly the same amount of time).
 def merge(blob):
     if len(blob['children']) == 0:
         return
@@ -37,8 +37,8 @@ def merge(blob):
     for new_child_idx in range(len(new_children_list)):
         merge(new_children_list[new_child_idx])
 
-# aligns a function's subfunctions (children) to all be positioned sequentially along the x axis
-# and start at the same time as their parent
+# Aligns a function's subfunctions (children) to all be positioned sequentially along the x axis
+# and start at the same time as their parent.
 def organize_children(blob):
     parent_start = blob['start']
     last_end = parent_start
@@ -49,8 +49,8 @@ def organize_children(blob):
         if len(blob['children'][child_idx]['children']) > 0:
             organize_children(blob['children'][child_idx])
 
-# flame-graph.html is composed of a large json data blob and some code to process and display it
-# this parses out the json part specifically and formats it in a way the python json module can handle
+# flame-graph.html is composed of a large json data blob and some code to process and display it.
+# This parses out the json part specifically and formats it in a way the python json module can handle.
 def parse_html():
     f = open("flame-graph.html", "r")
     text = "".join(f.readlines())

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -74,6 +74,7 @@ impl AuxInfoParticipant {
         }
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     pub(crate) fn process_message<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -108,6 +109,7 @@ impl AuxInfoParticipant {
         }
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn handle_ready_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -129,6 +131,7 @@ impl AuxInfoParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn gen_round_one_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -181,6 +184,7 @@ impl AuxInfoParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn handle_round_one_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -228,6 +232,7 @@ impl AuxInfoParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn gen_round_two_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -264,6 +269,7 @@ impl AuxInfoParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn handle_round_two_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -329,6 +335,7 @@ impl AuxInfoParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn gen_round_three_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -408,6 +415,7 @@ impl AuxInfoParticipant {
         Ok(more_messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
     fn handle_round_three_msg<R: RngCore + CryptoRng>(
         &mut self,
         _rng: &mut R,
@@ -497,6 +505,7 @@ impl AuxInfoParticipant {
     }
 }
 
+#[cfg_attr(feature = "flame_it", flame("auxinfo"))]
 fn new_auxinfo<R: RngCore + CryptoRng>(
     rng: &mut R,
     _prime_bits: usize,

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -73,6 +73,7 @@ impl KeygenParticipant {
     /// Processes the incoming message given the storage from the protocol participant
     /// (containing auxinfo and keygen artifacts). Optionally produces a [KeysharePrivate]
     /// and [KeysharePublic] once keygen is complete.
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     pub(crate) fn process_message<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -105,6 +106,7 @@ impl KeygenParticipant {
         }
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn handle_ready_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -126,6 +128,7 @@ impl KeygenParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn gen_round_one_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -181,6 +184,7 @@ impl KeygenParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn handle_round_one_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -228,6 +232,7 @@ impl KeygenParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn gen_round_two_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -264,6 +269,7 @@ impl KeygenParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn handle_round_two_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -327,6 +333,7 @@ impl KeygenParticipant {
         Ok(messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn gen_round_three_msgs<R: RngCore + CryptoRng>(
         &mut self,
         _rng: &mut R,
@@ -414,6 +421,7 @@ impl KeygenParticipant {
         Ok(more_messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("keygen"))]
     fn handle_round_three_msg<R: RngCore + CryptoRng>(
         &mut self,
         _rng: &mut R,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -64,6 +64,7 @@ impl PresignParticipant {
     /// Processes the incoming message given the storage from the protocol participant
     /// (containing auxinfo and keygen artifacts). Optionally produces a [PresignRecord]
     /// once presigning is complete.
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     pub(crate) fn process_message<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -139,7 +140,7 @@ impl PresignParticipant {
     /// stores a round one secret, and publishes a unique public component to every other participant.
     ///
     /// This can only be run after all participants have finished with key generation.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn gen_round_one_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -198,7 +199,7 @@ impl PresignParticipant {
     /// This can be run as soon as each round one message to this participant has been published.
     /// These round two messages are returned in response to the sender, without having to
     /// rely on any other round one messages from other participants aside from the sender.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn handle_round_one_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -270,6 +271,7 @@ impl PresignParticipant {
         Ok(vec![message])
     }
 
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn handle_round_two_msg<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -329,7 +331,7 @@ impl PresignParticipant {
     /// and produces a set of per-participant round 3 public values and one private value.
     ///
     /// Each participant is only going to run round three once.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn gen_round_three_msgs<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
@@ -386,6 +388,7 @@ impl PresignParticipant {
         Ok(ret_messages)
     }
 
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn handle_round_three_msg<R: RngCore + CryptoRng>(
         &mut self,
         _rng: &mut R,
@@ -414,7 +417,7 @@ impl PresignParticipant {
     ///
     /// In this step, the participant simply collects all r3 public values and its r3
     /// private value, and assembles them into a PresignRecord.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn do_presign_finish(&mut self, message: &Message) -> Result<PresignRecord> {
         let r3_pubs = self.get_other_participants_round_three_publics(message.id())?;
 
@@ -452,6 +455,7 @@ impl PresignParticipant {
         Ok((*id1, *id2))
     }
 
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn validate_and_store_round_two_public(
         &mut self,
         main_storage: &Storage,
@@ -504,6 +508,7 @@ impl PresignParticipant {
         Ok(())
     }
 
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn validate_and_store_round_three_public(
         &mut self,
         main_storage: &Storage,
@@ -686,7 +691,7 @@ impl PresignKeyShareAndInfo {
     ///
     /// The public_keys parameter corresponds to a KeygenPublic for
     /// each of the other parties.
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     pub(crate) fn round_one<R: RngCore + CryptoRng>(
         &self,
         rng: &mut R,
@@ -755,7 +760,7 @@ impl PresignKeyShareAndInfo {
     ///
     /// Constructs a D = gamma * K and D_hat = x * K, and Gamma = g * gamma.
     ///
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     pub(crate) fn round_two<R: RngCore + CryptoRng>(
         &self,
         rng: &mut R,
@@ -872,7 +877,7 @@ impl PresignKeyShareAndInfo {
     ///
     /// First computes alpha = dec(D), alpha_hat = dec(D_hat).
     /// Computes a delta = gamma * k
-    #[cfg_attr(feature = "flame_it", flame)]
+    #[cfg_attr(feature = "flame_it", flame("presign"))]
     pub(crate) fn round_three<R: RngCore + CryptoRng>(
         &self,
         rng: &mut R,

--- a/stats/README.md
+++ b/stats/README.md
@@ -9,3 +9,8 @@ cargo +nightly test --features flame_it
 For details on how to expand the flame graph, see here: https://github.com/llogiq/flamer
 
 Also, note that this is currently being generated on tests, which is not as accurate as building in release mode and running it. But at least we can figure out what is slowing down our testing.
+
+To create a flame graph for release mode performance and target a specific test case for benchmarking, a command like the following can be used:
+```
+cargo +nightly test --release --features flame_it --package tss-ecdsa --lib -- protocol::tests::test_run_protocol --exact --nocapture
+```


### PR DESCRIPTION
This PR adds marks to many of the main functions that get executed in various protocols so that they will appear in flamegraphs. Running `cargo +nightly test --release --features flame_it --package tss-ecdsa --lib -- protocol::tests::test_run_protocol --exact --nocapture` will produce a flamegraph in stats/flame-graph.html

This flamegraph orders functions chronologically on the x axis, but if the same function is called in multiple places in the general execution flow, then it will appear broken up into various chunks, making it hard to tell how much of the overall execution is attributable to that function. 

To address this I wrote a python script (dev/flame.py) which reorganizes the flamegraph (it expects a file named flame-graph.html to be found in the same directory as it) in order to group all invocations of a given function together 