### PR TITLE
Add Broadcasting and Out-of-Order message handling to Presign 

### DIFF
--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -256,7 +256,7 @@ async fn presign(state: &State<ParticipantState>, parameters: Json<PresignParame
         auxinfo_identifier,
         keygen_identifier,
         presign_identifier,
-    );
+    )?;
 
     *state_participant = Some(participant.clone());
     drop(state_participant); // Release the lock

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use crate::broadcast::participant::BroadcastTag;
 use crate::{
     auxinfo::{
         auxinfo_commit::{AuxInfoCommit, AuxInfoDecommit},
@@ -179,7 +180,7 @@ impl AuxInfoParticipant {
             &MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash),
             com_bytes.clone(),
             message.id(),
-            "AuxinfoR1CommitHash",
+            BroadcastTag::AuxinfoR1CommitHash,
         )?;
         Ok(messages)
     }
@@ -191,7 +192,7 @@ impl AuxInfoParticipant {
         broadcast_message: &BroadcastOutput,
         main_storage: &mut Storage,
     ) -> Result<Vec<Message>> {
-        if broadcast_message.tag != "AuxinfoR1CommitHash" {
+        if broadcast_message.tag != BroadcastTag::AuxinfoR1CommitHash {
             return bail!("Incorrect tag for Auxinfo R1!");
         }
         let message = &broadcast_message.msg;

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use super::participant::BroadcastTag;
 use crate::{
     errors::Result,
     messages::{BroadcastMessageType, Message, MessageType},
@@ -15,7 +16,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub(crate) struct BroadcastData {
     pub(crate) leader: ParticipantIdentifier,
-    pub(crate) tag: String,
+    pub(crate) tag: BroadcastTag,
     pub(crate) message_type: MessageType,
     pub(crate) data: Vec<u8>,
 }

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -30,16 +30,23 @@ pub(crate) struct BroadcastParticipant {
     storage: Storage,
 }
 
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Debug)]
+pub(crate) enum BroadcastTag {
+    AuxinfoR1CommitHash,
+    KeyGenR1CommitHash,
+    PresignR1Ciphertexts,
+}
+
 #[derive(Serialize, Deserialize, Hash, PartialEq, Eq)]
-struct BroadcastIndex {
-    tag: String,
+pub(crate) struct BroadcastIndex {
+    tag: BroadcastTag,
     leader: ParticipantIdentifier,
     other_id: ParticipantIdentifier,
 }
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct BroadcastOutput {
-    pub(crate) tag: String,
+    pub(crate) tag: BroadcastTag,
     pub(crate) msg: Message,
 }
 
@@ -95,11 +102,11 @@ impl BroadcastParticipant {
         message_type: &MessageType,
         data: Vec<u8>,
         sid: Identifier,
-        tag: &str,
+        tag: BroadcastTag,
     ) -> Result<Vec<Message>> {
         let b_data = BroadcastData {
             leader: self.id,
-            tag: tag.to_owned(),
+            tag,
             message_type: *message_type,
             data,
         };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,8 @@ pub enum InternalError {
     FailedToVerifyProof(String),
     /// `{0}`
     BailError(String),
+    /// Represents some code assumption that was checked at runtime but failed to be true.
+    InternalInvariantFailed,
 }
 
 macro_rules! serialize {

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use crate::broadcast::participant::BroadcastTag;
 use crate::{
     broadcast::participant::{BroadcastOutput, BroadcastParticipant},
     errors::Result,
@@ -182,7 +183,7 @@ impl KeygenParticipant {
             &MessageType::Keygen(KeygenMessageType::R1CommitHash),
             com_bytes.clone(),
             message.id(),
-            "KeyGenR1CommitHash",
+            BroadcastTag::KeyGenR1CommitHash,
         )?;
         Ok(messages)
     }
@@ -194,7 +195,7 @@ impl KeygenParticipant {
         broadcast_message: &BroadcastOutput,
         main_storage: &mut Storage,
     ) -> Result<Vec<Message>> {
-        if broadcast_message.tag != "KeyGenR1CommitHash" {
+        if broadcast_message.tag != BroadcastTag::KeyGenR1CommitHash {
             return bail!("Incorrect tag for Keygen R1!");
         }
         let message = &broadcast_message.msg;

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -9,15 +9,14 @@ use crate::{
     errors::Result,
     messages::{Message, MessageType},
     protocol::Identifier,
+    ParticipantIdentifier,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt::Debug};
 
-/// A message that can be posted to (and read from) the broadcast channel
 #[derive(Debug, Serialize, Deserialize)]
 struct MessageIndex {
     message_type: MessageType,
-    /// The unique identifier associated with this stored value
     identifier: Identifier,
 }
 
@@ -29,42 +28,71 @@ impl MessageQueue {
         Self(HashMap::new())
     }
 
+    /// Store a message in the MessageQueue.
     pub(crate) fn store(
         &mut self,
         message_type: MessageType,
         identifier: Identifier,
         message: Message,
     ) -> Result<()> {
-        let message_index = MessageIndex {
-            message_type,
-            identifier,
-        };
-        let key = serialize!(&message_index)?;
-        let mut queue = match self.0.remove(&key) {
-            Some(a) => a,
-            None => vec![],
-        };
-        queue.push(message);
-        let _ = self.0.insert(key, queue);
+        let key = Self::get_key(message_type, identifier)?;
+        self.0.entry(key).or_default().push(message);
         Ok(())
     }
 
+    /// Retrieve (and remove) all messages of a given type from the
+    /// MessageQueue.
     pub(crate) fn retrieve_all(
         &mut self,
         message_type: MessageType,
         identifier: Identifier,
     ) -> Result<Vec<Message>> {
+        self.do_retrieve(message_type, identifier, None)
+    }
+
+    /// Retrieve (and remove) all messages of a given type from a given sender
+    /// from the MessageQueue.
+    pub(crate) fn retrieve(
+        &mut self,
+        message_type: MessageType,
+        identifier: Identifier,
+        sender: ParticipantIdentifier,
+    ) -> Result<Vec<Message>> {
+        self.do_retrieve(message_type, identifier, Some(sender))
+    }
+
+    fn do_retrieve(
+        &mut self,
+        message_type: MessageType,
+        identifier: Identifier,
+        sender: Option<ParticipantIdentifier>,
+    ) -> Result<Vec<Message>> {
+        let key = Self::get_key(message_type, identifier)?;
+        // delete retrieved messages from storage so that they aren't accidentally
+        // processed again.
+        let queue = self.0.remove(&key).unwrap_or_default();
+
+        match sender {
+            None => Ok(queue),
+            Some(sender) => {
+                // separate messages we want to retrieve
+                let (out, new_queue): (Vec<_>, Vec<_>) =
+                    queue.into_iter().partition(|msg| msg.from() == sender);
+
+                // re-add updated queue
+                if !new_queue.is_empty() {
+                    let _ = self.0.insert(key, new_queue);
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    fn get_key(message_type: MessageType, identifier: Identifier) -> Result<Vec<u8>> {
         let message_index = MessageIndex {
             message_type,
             identifier,
         };
-        let key = serialize!(&message_index)?;
-        // delete retrieved messages from storage so that they aren't accidentally
-        // processed again
-        let queue = match self.0.remove(&key) {
-            Some(a) => a,
-            None => vec![],
-        };
-        Ok(queue)
+        Ok(serialize!(&message_index)?)
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -68,6 +68,8 @@ pub enum PresignMessageType {
     Ready,
     /// First round of presigning
     RoundOne,
+    /// Broadcasted portion of the first round
+    RoundOneBroadcast,
     /// Second round of presigning
     RoundTwo,
     /// Third round of presigning

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use crate::broadcast::participant::BroadcastTag;
 use crate::{
     broadcast::participant::{BroadcastOutput, BroadcastParticipant},
     errors::Result,
@@ -54,7 +55,26 @@ pub(crate) trait ProtocolParticipant {
         message_type: MessageType,
         sid: Identifier,
     ) -> Result<Vec<Message>> {
-        let mut message_storage =
+        let mut message_storage = self.get_message_queue(sid)?;
+        let messages = message_storage.retrieve_all(message_type, sid)?;
+        self.write_message_queue(sid, message_storage)?;
+        Ok(messages)
+    }
+
+    fn fetch_messages_by_sender(
+        &mut self,
+        message_type: MessageType,
+        sid: Identifier,
+        sender: ParticipantIdentifier,
+    ) -> Result<Vec<Message>> {
+        let mut message_storage = self.get_message_queue(sid)?;
+        let messages = message_storage.retrieve(message_type, sid, sender)?;
+        self.write_message_queue(sid, message_storage)?;
+        Ok(messages)
+    }
+
+    fn get_message_queue(&mut self, sid: Identifier) -> Result<MessageQueue> {
+        let message_storage =
             match self
                 .storage()
                 .retrieve(StorableType::MessageQueue, sid, self.id())
@@ -62,15 +82,17 @@ pub(crate) trait ProtocolParticipant {
                 Err(_) => MessageQueue::new(),
                 Ok(message_storage_bytes) => deserialize!(&message_storage_bytes)?,
             };
-        let messages = message_storage.retrieve_all(message_type, sid)?;
+        Ok(message_storage)
+    }
+
+    fn write_message_queue(&mut self, sid: Identifier, message_queue: MessageQueue) -> Result<()> {
         let my_id = self.id();
         self.storage_mut().store(
             StorableType::MessageQueue,
             sid,
             my_id,
-            &serialize!(&message_storage)?,
-        )?;
-        Ok(messages)
+            &serialize!(&message_queue)?,
+        )
     }
 
     fn write_progress(&mut self, func_name: String, sid: Identifier) -> Result<()> {
@@ -111,6 +133,7 @@ pub(crate) trait ProtocolParticipant {
         Ok(result)
     }
 }
+
 pub(crate) trait Broadcast {
     fn broadcast_participant(&mut self) -> &mut BroadcastParticipant;
 
@@ -120,7 +143,7 @@ pub(crate) trait Broadcast {
         message_type: &MessageType,
         data: Vec<u8>,
         sid: Identifier,
-        tag: &str,
+        tag: BroadcastTag,
     ) -> Result<Vec<Message>> {
         let mut messages =
             self.broadcast_participant()
@@ -170,7 +193,8 @@ macro_rules! run_only_once {
 /// a given session
 macro_rules! run_only_once_per_tag {
     ($self:ident . $func_name:ident $args:tt, $sid:expr, $tag:expr) => {{
-        if $self.read_progress(stringify!($func_name).to_string() + $tag, $sid)? {
+        let tag_str = format!("{:?}", $tag);
+        if $self.read_progress(stringify!($func_name).to_string() + &tag_str, $sid)? {
             println!("Attempted to rerun a run_only_once_per_tag function");
             Ok(vec![])
         } else {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,13 +18,12 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
 #[derive(Debug, Copy, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub(crate) enum StorableType {
-    AuxInfoReady,
     KeygenReady,
     KeygenCommit,
     KeygenDecommit,
     KeygenSchnorrPrecom,
     KeygenGlobalRid,
-    PresignReady,
+    AuxInfoReady,
     AuxInfoPrivate,
     AuxInfoPublic,
     AuxInfoCommit,
@@ -33,12 +32,14 @@ pub(crate) enum StorableType {
     AuxInfoWitnesses,
     PrivateKeyshare,
     PublicKeyshare,
-    RoundOnePrivate,
-    RoundOnePublic,
-    RoundTwoPrivate,
-    RoundTwoPublic,
-    RoundThreePrivate,
-    RoundThreePublic,
+    PresignReady,
+    PresignRoundOnePrivate,
+    PresignRoundOnePublic,
+    PresignRoundOnePublicBroadcast,
+    PresignRoundTwoPrivate,
+    PresignRoundTwoPublic,
+    PresignRoundThreePrivate,
+    PresignRoundThreePublic,
     PresignRecord,
     MessageQueue,
     ProgressStore,
@@ -100,7 +101,7 @@ impl Storage {
         storable_type: StorableType,
         identifier: Identifier,
         participant: ParticipantIdentifier,
-    ) -> Result<()> {
+    ) -> Result<Vec<u8>> {
         self.delete_index(StorableIndex {
             storable_type,
             identifier,
@@ -162,15 +163,14 @@ impl Storage {
         Ok(ret)
     }
 
-    fn delete_index<I: Storable>(&mut self, storable_index: I) -> Result<()> {
+    fn delete_index<I: Storable>(&mut self, storable_index: I) -> Result<Vec<u8>> {
         let key = serialize!(&storable_index)?;
-        let _ = self.0.remove(&key).ok_or_else(|| {
+        self.0.remove(&key).ok_or_else(|| {
             bail_context!(
                 "Could not find {:?} when getting from storage",
                 storable_index
             )
-        })?;
-        Ok(())
+        })
     }
 
     fn contains_index_batch<I: Storable>(&self, storable_indices: &[I]) -> Result<()> {


### PR DESCRIPTION
This PR addresses issues #11 and #5 

Adding support for broadcasting to Presign ended up being a bit more complicated than I was anticipating. Round one of the protocol (Figure 7) contains sending unique messages to each party and a broadcast (all recipients interact to ensure they all received the same message), and so I split up round one into these two portions. RoundOnePublic is the non-broadcast portion and RoundOnePublicBroadcast deals with the broadcasted portion. 

In order to deal with the added complexity of handling two types of round one messages at the same time, I ended up adding the Participant trait to Presign, allowing it to stash messages and retrieve them later. I also extended the functionality of the Participant trait to allow retrieving only messages from a given sender, as this was needed to allow for rounds in which incoming messages are responded to directly. 

In making these changes and fixing the various ordering-related bugs that started popping up, I inadvertently ended up addressing the Out-of-Order message handling issue as well. To confirm this, I modified the main end-to-end test in protocol.rs to order all messages randomly. I have tested 50 different random message permutations locally and all have resulted in a successful protocol execution.