### PR TITLE
Patch to sample safe primes in release builds

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -511,6 +511,8 @@ impl AuxInfoParticipant {
 fn new_auxinfo<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses)> {
+    // As generating safe primes is very computationally expensive (> one minute per prime in github CI),
+    // we read precomputed ones from a file (but only in tests!)
     #[cfg(not(test))]
     let (p, q) = (
         crate::utils::get_random_safe_prime_512(rng),

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -511,8 +511,13 @@ impl AuxInfoParticipant {
 fn new_auxinfo<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses)> {
-    let p = crate::utils::get_random_safe_prime_512(rng);
-    let q = crate::utils::get_random_safe_prime_512(rng);
+    #[cfg(not(test))]
+    let (p, q) = (
+        crate::utils::get_random_safe_prime_512(rng),
+        crate::utils::get_random_safe_prime_512(rng),
+    );
+    #[cfg(test)]
+    let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(rng);
 
     let sk = PaillierDecryptionKey(
         DecryptionKey::with_primes_unchecked(&p, &q)
@@ -659,7 +664,7 @@ mod tests {
         let mut osrng = OsRng;
         let seed = osrng.next_u64();
         // uncomment this line to test a specific seed
-        // let seed: u64 = 11129769151581080362;
+        // let seed: u64 = 14167330344348201948;
         let mut rng = StdRng::seed_from_u64(seed);
         println!("Initializing run with seed {}", seed);
         let mut quorum = AuxInfoParticipant::new_quorum(3, &mut rng)?;

--- a/src/safe_primes_512.rs
+++ b/src/safe_primes_512.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+#[cfg(test)]
 pub(crate) const SAFE_PRIMES: &[&str] = &[
    "85c8c2ced07b104334097906e117c1b733632a391f9319bb5a68e69dcd7f2f46868d9508585a4945092c989c35b4056b6fe139ce567b6c598ef5f39e75ea3dbb",
    "ee22d7946155f99b09cfe8d4e1c3af0235c87d252a415909c069fdf460630d1eaf4ac93401a7c8bf0b0aced93c6b9452c13ac9f2f0c363361afde667661123f7",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -218,6 +218,16 @@ mod tests {
         let scalar = bn_to_scalar(&neg1).unwrap();
         assert_eq!(k256::Scalar::ZERO, scalar.add(&k256::Scalar::ONE));
     }
+
+    #[test]
+    fn test_get_random_safe_prime_512() -> Result<()> {
+        let mut rng = OsRng;
+        let p = get_random_safe_prime_512(&mut rng);
+        assert!(p.is_prime());
+        let q: BigNumber = (p - 1) / 2;
+        assert!(q.is_prime());
+        Ok(())
+    }
 }
 
 // Prime generation functions
@@ -247,6 +257,22 @@ pub(crate) fn get_random_safe_prime_512<R: RngCore + CryptoRng>(rng: &mut R) -> 
 #[cfg(test)]
 pub(crate) fn get_prime_from_pool_insecure<R: RngCore + CryptoRng>(rng: &mut R) -> BigNumber {
     POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone()
+}
+
+/// Function to read from a precompiled list of safe primes. For testing purposes only
+/// Returns two unique primes
+#[cfg(test)]
+pub(crate) fn get_prime_pair_from_pool_insecure<R: RngCore + CryptoRng>(
+    rng: &mut R,
+) -> (BigNumber, BigNumber) {
+    let p = POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone();
+    let q = loop {
+        let q = POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone();
+        if p != q {
+            break q;
+        }
+    };
+    (p, q)
 }
 
 ////////////////////////////////

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -234,10 +234,12 @@ mod tests {
 
 // Generate safe primes from a file. Usually, generating safe primes takes
 // awhile (0-5 minutes per 512-bit safe prime on my laptop, average 50 seconds)
+#[cfg(test)]
 lazy_static::lazy_static! {
     static ref POOL_OF_PRIMES: Vec<BigNumber> = get_safe_primes_from_file();
 }
 
+#[cfg(test)]
 fn get_safe_primes_from_file() -> Vec<BigNumber> {
     let safe_primes: Vec<BigNumber> = crate::safe_primes_512::SAFE_PRIMES
         .iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,7 +25,6 @@ use crate::{
 
 const MAX_ITER: usize = 50_000usize;
 
-#[cfg(not(debug_assertions))]
 use crate::parameters::PRIME_BITS;
 
 /// Wrapper around k256::ProjectivePoint so that we can define our own
@@ -241,16 +240,13 @@ fn get_safe_primes_from_file() -> Vec<BigNumber> {
 /// parameter setting of κ = 128, and safe primes being of length 4κ (Figure 6,
 /// Round 1 of the CGGMP'21 paper)
 pub(crate) fn get_random_safe_prime_512<R: RngCore + CryptoRng>(rng: &mut R) -> BigNumber {
-    // If we're building in release mode, generate fresh safe primes.
-    // Otherwise, use pre-generated ones so that tests run faster.
-    #[cfg(not(debug_assertions))]
-    {
-        BigNumber::safe_prime_from_rng(PRIME_BITS, rng)
-    }
-    #[cfg(debug_assertions)]
-    {
-        POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone()
-    }
+    BigNumber::safe_prime_from_rng(PRIME_BITS, rng)
+}
+
+/// Function to read from a precompiled list of safe primes. For testing purposes only
+#[cfg(test)]
+pub(crate) fn get_prime_from_pool_insecure<R: RngCore + CryptoRng>(rng: &mut R) -> BigNumber {
+    POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone()
 }
 
 ////////////////////////////////

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -343,9 +343,9 @@ mod tests {
     fn random_paillier_affg_proof(x: &BigNumber, y: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
+            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
             if p0 != q0 {
                 break q0;
             }
@@ -353,9 +353,9 @@ mod tests {
 
         let N0 = &p0 * &q0;
 
-        let p1 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p1 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let q1 = loop {
-            let q1 = crate::utils::get_random_safe_prime_512(&mut rng);
+            let q1 = crate::utils::get_prime_from_pool_insecure(&mut rng);
             if p1 != q1 {
                 break q1;
             }

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -342,24 +342,10 @@ mod tests {
 
     fn random_paillier_affg_proof(x: &BigNumber, y: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
-
-        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q0 = loop {
-            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-            if p0 != q0 {
-                break q0;
-            }
-        };
-
+        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
 
-        let p1 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q1 = loop {
-            let q1 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-            if p1 != q1 {
-                break q1;
-            }
-        };
+        let (p1, q1) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N1 = &p1 * &q1;
 
         let sk0 = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -343,9 +343,9 @@ mod tests {
     fn random_paillier_affg_proof(x: &BigNumber, y: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512();
+        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512();
+            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
             if p0 != q0 {
                 break q0;
             }
@@ -353,9 +353,9 @@ mod tests {
 
         let N0 = &p0 * &q0;
 
-        let p1 = crate::utils::get_random_safe_prime_512();
+        let p1 = crate::utils::get_random_safe_prime_512(&mut rng);
         let q1 = loop {
-            let q1 = crate::utils::get_random_safe_prime_512();
+            let q1 = crate::utils::get_random_safe_prime_512(&mut rng);
             if p1 != q1 {
                 break q1;
             }

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -216,8 +216,7 @@ mod tests {
     fn random_paillier_encryption_in_range_proof(k: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         let sk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -216,8 +216,8 @@ mod tests {
     fn random_paillier_encryption_in_range_proof(k: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p = crate::utils::get_random_safe_prime_512(&mut rng);
-        let q = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let q = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         let sk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -216,8 +216,8 @@ mod tests {
     fn random_paillier_encryption_in_range_proof(k: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p = crate::utils::get_random_safe_prime_512();
-        let q = crate::utils::get_random_safe_prime_512();
+        let p = crate::utils::get_random_safe_prime_512(&mut rng);
+        let q = crate::utils::get_random_safe_prime_512(&mut rng);
         let N = &p * &q;
 
         let sk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -432,9 +432,9 @@ mod tests {
     fn random_no_small_factors_proof() -> Result<(PiFacInput, PiFacProof)> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
+            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
             if p0 != q0 {
                 break q0;
             }
@@ -463,7 +463,7 @@ mod tests {
 
         let incorrect_N = PiFacInput::new(
             &input.setup_params,
-            &crate::utils::get_random_safe_prime_512(&mut rng),
+            &crate::utils::get_prime_from_pool_insecure(&mut rng),
         );
         assert!(proof.verify(&incorrect_N).is_err());
 
@@ -471,9 +471,9 @@ mod tests {
             PiFacInput::new(&ZkSetupParameters::gen(&mut rng)?, &input.N0);
         assert!(proof.verify(&incorrect_startup_params).is_err());
 
-        let not_p0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let not_p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let not_q0 = loop {
-            let not_q0 = crate::utils::get_random_safe_prime_512(&mut rng);
+            let not_q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
             if not_p0 != not_q0 {
                 break not_q0;
             }
@@ -490,7 +490,7 @@ mod tests {
             PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&small_p, &small_q))?;
         assert!(small_proof.verify(&small_input).is_err());
 
-        let regular_sized_q = crate::utils::get_random_safe_prime_512(&mut rng);
+        let regular_sized_q = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let mixed_input = PiFacInput::new(&setup_params, &(&small_p * &regular_sized_q));
         let mixed_proof = PiFacProof::prove(
             &mut rng,
@@ -516,9 +516,9 @@ mod tests {
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
         let mut rng = OsRng;
-        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
+            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
             if p0 != q0 {
                 break q0;
             }

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -432,14 +432,7 @@ mod tests {
     fn random_no_small_factors_proof() -> Result<(PiFacInput, PiFacProof)> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q0 = loop {
-            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-            if p0 != q0 {
-                break q0;
-            }
-        };
-
+        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
         let setup_params = ZkSetupParameters::gen(&mut rng)?;
 
@@ -471,13 +464,7 @@ mod tests {
             PiFacInput::new(&ZkSetupParameters::gen(&mut rng)?, &input.N0);
         assert!(proof.verify(&incorrect_startup_params).is_err());
 
-        let not_p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let not_q0 = loop {
-            let not_q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-            if not_p0 != not_q0 {
-                break not_q0;
-            }
-        };
+        let (not_p0, not_q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let incorrect_factors =
             PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&not_p0, &not_q0))?;
         assert!(incorrect_factors.verify(&input).is_err());
@@ -516,13 +503,7 @@ mod tests {
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
         let mut rng = OsRng;
-        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q0 = loop {
-            let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-            if p0 != q0 {
-                break q0;
-            }
-        };
+        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
 
         let num = &p0 * &q0;
         let num_bigint: BigInt = BigInt::from_bytes_be(Sign::Plus, &num.to_bytes());

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -432,9 +432,9 @@ mod tests {
     fn random_no_small_factors_proof() -> Result<(PiFacInput, PiFacProof)> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512();
+        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512();
+            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
             if p0 != q0 {
                 break q0;
             }
@@ -463,7 +463,7 @@ mod tests {
 
         let incorrect_N = PiFacInput::new(
             &input.setup_params,
-            &crate::utils::get_random_safe_prime_512(),
+            &crate::utils::get_random_safe_prime_512(&mut rng),
         );
         assert!(proof.verify(&incorrect_N).is_err());
 
@@ -471,9 +471,9 @@ mod tests {
             PiFacInput::new(&ZkSetupParameters::gen(&mut rng)?, &input.N0);
         assert!(proof.verify(&incorrect_startup_params).is_err());
 
-        let not_p0 = crate::utils::get_random_safe_prime_512();
+        let not_p0 = crate::utils::get_random_safe_prime_512(&mut rng);
         let not_q0 = loop {
-            let not_q0 = crate::utils::get_random_safe_prime_512();
+            let not_q0 = crate::utils::get_random_safe_prime_512(&mut rng);
             if not_p0 != not_q0 {
                 break not_q0;
             }
@@ -490,7 +490,7 @@ mod tests {
             PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&small_p, &small_q))?;
         assert!(small_proof.verify(&small_input).is_err());
 
-        let regular_sized_q = crate::utils::get_random_safe_prime_512();
+        let regular_sized_q = crate::utils::get_random_safe_prime_512(&mut rng);
         let mixed_input = PiFacInput::new(&setup_params, &(&small_p * &regular_sized_q));
         let mixed_proof = PiFacProof::prove(
             &mut rng,
@@ -515,9 +515,10 @@ mod tests {
     // Make sure the bytes representations for BigNum and BigInt
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
-        let p0 = crate::utils::get_random_safe_prime_512();
+        let mut rng = OsRng;
+        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
         let q0 = loop {
-            let q0 = crate::utils::get_random_safe_prime_512();
+            let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
             if p0 != q0 {
                 break q0;
             }

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -244,8 +244,8 @@ mod tests {
     fn random_paillier_log_proof(x: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
-        let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
 
         let sk = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -244,8 +244,8 @@ mod tests {
     fn random_paillier_log_proof(x: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_random_safe_prime_512();
-        let q0 = crate::utils::get_random_safe_prime_512();
+        let p0 = crate::utils::get_random_safe_prime_512(&mut rng);
+        let q0 = crate::utils::get_random_safe_prime_512(&mut rng);
         let N0 = &p0 * &q0;
 
         let sk = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -244,8 +244,7 @@ mod tests {
     fn random_paillier_log_proof(x: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let p0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q0 = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
 
         let sk = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -441,8 +441,7 @@ mod tests {
     #[test]
     fn test_jacobi() {
         let mut rng = OsRng;
-        let p = get_prime_from_pool_insecure(&mut rng);
-        let q = get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         for _ in 0..100 {
@@ -498,8 +497,7 @@ mod tests {
     #[test]
     fn test_square_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_prime_from_pool_insecure(&mut rng);
-        let q = get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -530,8 +528,7 @@ mod tests {
     #[test]
     fn test_fourth_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_prime_from_pool_insecure(&mut rng);
-        let q = get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -562,8 +559,7 @@ mod tests {
     #[test]
     fn test_chinese_remainder_theorem() {
         let mut rng = OsRng;
-        let p = get_prime_from_pool_insecure(&mut rng);
-        let q = get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
 
         for _ in 0..100 {
             let a1 = BigNumber::from_rng(&p, &mut rng);

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -435,14 +435,14 @@ fn y_prime_combinations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::get_random_safe_prime_512;
+    use crate::utils::get_prime_from_pool_insecure;
     use rand::{rngs::OsRng, RngCore};
 
     #[test]
     fn test_jacobi() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512(&mut rng);
-        let q = get_random_safe_prime_512(&mut rng);
+        let p = get_prime_from_pool_insecure(&mut rng);
+        let q = get_prime_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         for _ in 0..100 {
@@ -472,7 +472,7 @@ mod tests {
     #[test]
     fn test_square_roots_mod_prime() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512(&mut rng);
+        let p = get_prime_from_pool_insecure(&mut rng);
 
         for _ in 0..100 {
             let a = BigNumber::from_rng(&p, &mut rng);
@@ -498,8 +498,8 @@ mod tests {
     #[test]
     fn test_square_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512(&mut rng);
-        let q = get_random_safe_prime_512(&mut rng);
+        let p = get_prime_from_pool_insecure(&mut rng);
+        let q = get_prime_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -530,8 +530,8 @@ mod tests {
     #[test]
     fn test_fourth_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512(&mut rng);
-        let q = get_random_safe_prime_512(&mut rng);
+        let p = get_prime_from_pool_insecure(&mut rng);
+        let q = get_prime_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -562,8 +562,8 @@ mod tests {
     #[test]
     fn test_chinese_remainder_theorem() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512(&mut rng);
-        let q = get_random_safe_prime_512(&mut rng);
+        let p = get_prime_from_pool_insecure(&mut rng);
+        let q = get_prime_from_pool_insecure(&mut rng);
 
         for _ in 0..100 {
             let a1 = BigNumber::from_rng(&p, &mut rng);

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -441,9 +441,8 @@ mod tests {
     #[test]
     fn test_jacobi() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512();
-        let q = get_random_safe_prime_512();
-
+        let p = get_random_safe_prime_512(&mut rng);
+        let q = get_random_safe_prime_512(&mut rng);
         let N = &p * &q;
 
         for _ in 0..100 {
@@ -473,7 +472,7 @@ mod tests {
     #[test]
     fn test_square_roots_mod_prime() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512();
+        let p = get_random_safe_prime_512(&mut rng);
 
         for _ in 0..100 {
             let a = BigNumber::from_rng(&p, &mut rng);
@@ -499,8 +498,8 @@ mod tests {
     #[test]
     fn test_square_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512();
-        let q = get_random_safe_prime_512();
+        let p = get_random_safe_prime_512(&mut rng);
+        let q = get_random_safe_prime_512(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -531,8 +530,8 @@ mod tests {
     #[test]
     fn test_fourth_roots_mod_composite() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512();
-        let q = get_random_safe_prime_512();
+        let p = get_random_safe_prime_512(&mut rng);
+        let q = get_random_safe_prime_512(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -563,8 +562,8 @@ mod tests {
     #[test]
     fn test_chinese_remainder_theorem() {
         let mut rng = OsRng;
-        let p = get_random_safe_prime_512();
-        let q = get_random_safe_prime_512();
+        let p = get_random_safe_prime_512(&mut rng);
+        let q = get_random_safe_prime_512(&mut rng);
 
         for _ in 0..100 {
             let a1 = BigNumber::from_rng(&p, &mut rng);

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -155,8 +155,8 @@ mod tests {
 
     fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
         let mut rng = OsRng;
-        let p = crate::utils::get_random_safe_prime_512();
-        let q = crate::utils::get_random_safe_prime_512();
+        let p = crate::utils::get_random_safe_prime_512(&mut rng);
+        let q = crate::utils::get_random_safe_prime_512(&mut rng);
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
         let tau = BigNumber::from_rng(&N, &mut rng);

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -155,8 +155,7 @@ mod tests {
 
     fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
         let mut rng = OsRng;
-        let p = crate::utils::get_prime_from_pool_insecure(&mut rng);
-        let q = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
         let tau = BigNumber::from_rng(&N, &mut rng);

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -155,8 +155,8 @@ mod tests {
 
     fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
         let mut rng = OsRng;
-        let p = crate::utils::get_random_safe_prime_512(&mut rng);
-        let q = crate::utils::get_random_safe_prime_512(&mut rng);
+        let p = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let q = crate::utils::get_prime_from_pool_insecure(&mut rng);
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
         let tau = BigNumber::from_rng(&N, &mut rng);

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -28,8 +28,7 @@ pub(crate) struct ZkSetupParameters {
 impl ZkSetupParameters {
     #[cfg(test)]
     pub(crate) fn gen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
-        let p = crate::utils::get_prime_from_pool_insecure(rng);
-        let q = crate::utils::get_prime_from_pool_insecure(rng);
+        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(rng);
         let N = &p * &q;
         Self::gen_from_primes(rng, &N, &p, &q)
     }

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -29,8 +29,8 @@ pub(crate) struct ZkSetupParameters {
 impl ZkSetupParameters {
     #[cfg(test)]
     pub(crate) fn gen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
-        let p = crate::utils::get_random_safe_prime_512();
-        let q = crate::utils::get_random_safe_prime_512();
+        let p = crate::utils::get_random_safe_prime_512(rng);
+        let q = crate::utils::get_random_safe_prime_512(rng);
         let N = &p * &q;
         Self::gen_from_primes(rng, &N, &p, &q)
     }

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -22,15 +22,14 @@ pub(crate) struct ZkSetupParameters {
     pub(crate) N: BigNumber,
     pub(crate) s: BigNumber,
     pub(crate) t: BigNumber,
-    //pimod: PiModProof,
     piprm: PiPrmProof,
 }
 
 impl ZkSetupParameters {
     #[cfg(test)]
     pub(crate) fn gen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
-        let p = crate::utils::get_random_safe_prime_512(rng);
-        let q = crate::utils::get_random_safe_prime_512(rng);
+        let p = crate::utils::get_prime_from_pool_insecure(rng);
+        let q = crate::utils::get_prime_from_pool_insecure(rng);
         let N = &p * &q;
         Self::gen_from_primes(rng, &N, &p, &q)
     }


### PR DESCRIPTION
Currently, safe primes are read from a pregenerated file so that tests will be faster (as generating safe primes is expensive). However, as we do not want to do this in production, this PR changes the code so that release builds will sample safe primes on the fly.

If this PR is successful, it will close #36 and make progress towards #29 as it rewrites the internal safe prime generation function to always take an rng.

This can also be considered a prerequisite for #34 to be successful, as safe prime sampling is significant enough to affect end to end benchmark timings.