### PR TITLE
Replace calls of BigNumber::random() with BigNumber::from_rng()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ flame_it = ["flame", "flamer"]
 [dependencies]
 thiserror = "1"
 k256 = { version = "0.10", features = ["arithmetic", "digest", "sha256", "ecdsa", "serde"] }
-libpaillier = "0.2"
+libpaillier = { version = "0.5", default-features = false, features = ["rust"] }
 num-bigint = "0.4"
 bincode = "1"
 displaydoc = { version = "0.2", default-features = false }
@@ -28,7 +28,6 @@ generic-array = "0.14"
 merlin = "3"
 integer-encoding = "3"
 lazy_static = "1"
-glass_pumpkin = "~1.3.0"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.3", optional = true }
 

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -526,7 +526,7 @@ fn new_auxinfo<R: RngCore + CryptoRng>(
     let q = two_safe_primes[1].clone();
 
     let sk = PaillierDecryptionKey(
-        DecryptionKey::with_safe_primes_unchecked(&p, &q)
+        DecryptionKey::with_primes_unchecked(&p, &q)
             .ok_or_else(|| bail_context!("Could not generate decryption key"))?,
     );
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -137,7 +137,7 @@ impl KeygenParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<Vec<Message>> {
-        let (keyshare_private, keyshare_public) = new_keyshare()?;
+        let (keyshare_private, keyshare_public) = new_keyshare(rng)?;
         self.storage.store(
             StorableType::PrivateKeyshare,
             message.id(),
@@ -516,9 +516,9 @@ impl KeygenParticipant {
 }
 
 /// Generates a new [KeySharePrivate] and [KeySharePublic]
-fn new_keyshare() -> Result<(KeySharePrivate, KeySharePublic)> {
+fn new_keyshare<R: RngCore + CryptoRng>(rng: &mut R) -> Result<(KeySharePrivate, KeySharePublic)> {
     let order = k256_order();
-    let x = BigNumber::random(&order);
+    let x = BigNumber::from_rng(&order, rng);
     let g = CurvePoint::GENERATOR;
     let X = CurvePoint(
         g.0 * crate::utils::bn_to_scalar(&x)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,13 +70,13 @@ pub(crate) fn modpow(a: &BigNumber, e: &BigNumber, n: &BigNumber) -> BigNumber {
 }
 
 /// Generate a random BigNumber in the range 0, ..., n
-pub(crate) fn random_positive_bn<R: RngCore + CryptoRng>(_rng: &mut R, n: &BigNumber) -> BigNumber {
-    BigNumber::random(n)
+pub(crate) fn random_positive_bn<R: RngCore + CryptoRng>(rng: &mut R, n: &BigNumber) -> BigNumber {
+    BigNumber::from_rng(n, rng)
 }
 
 /// Generate a random BigNumber in the range -n, ..., n
 pub(crate) fn random_bn_plusminus<R: RngCore + CryptoRng>(rng: &mut R, n: &BigNumber) -> BigNumber {
-    let val = BigNumber::random(n);
+    let val = BigNumber::from_rng(n, rng);
     let is_positive: bool = rng.gen();
     match is_positive {
         true => val,
@@ -86,7 +86,7 @@ pub(crate) fn random_bn_plusminus<R: RngCore + CryptoRng>(rng: &mut R, n: &BigNu
 
 /// Generate a random BigNumber in the range -2^n, ..., 0, ..., 2^n
 pub(crate) fn random_bn_in_range<R: RngCore + CryptoRng>(rng: &mut R, n: usize) -> BigNumber {
-    let val = BigNumber::random(&(BigNumber::one() << n));
+    let val = BigNumber::from_rng(&(BigNumber::one() << n), rng);
     let is_positive: bool = rng.gen();
     match is_positive {
         true => val,
@@ -106,7 +106,7 @@ pub(crate) fn random_bn_in_range_min<R: RngCore + CryptoRng>(
         return bail!("min_bound needs to be less than n");
     }
     let min_bound_bn = (BigNumber::one() << n) - (BigNumber::one() << min_bound);
-    let val = BigNumber::random(&(min_bound_bn + (BigNumber::one() << min_bound)));
+    let val = BigNumber::from_rng(&(min_bound_bn + (BigNumber::one() << min_bound)), rng);
     let is_positive: bool = rng.gen();
     Ok(match is_positive {
         true => val,
@@ -147,12 +147,9 @@ pub(crate) fn positive_bn_random_from_transcript(
 }
 
 /// Generate a random BigNumber in the range 1..N-1 (Z_N^*) (non-zero)
-pub(crate) fn random_bn_in_z_star<R: RngCore + CryptoRng>(
-    _rng: &mut R,
-    n: &BigNumber,
-) -> BigNumber {
+pub(crate) fn random_bn_in_z_star<R: RngCore + CryptoRng>(rng: &mut R, n: &BigNumber) -> BigNumber {
     for _ in 0..MAX_ITER {
-        let bn = BigNumber::random(n);
+        let bn = BigNumber::from_rng(n, rng);
         if bn != BigNumber::zero() {
             return bn;
         }

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -362,10 +362,10 @@ mod tests {
         };
         let N1 = &p1 * &q1;
 
-        let sk0 = DecryptionKey::with_safe_primes_unchecked(&p0, &q0).unwrap();
+        let sk0 = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();
         let pk0 = PaillierEncryptionKey(EncryptionKey::from(&sk0));
 
-        let sk1 = DecryptionKey::with_safe_primes_unchecked(&p1, &q1).unwrap();
+        let sk1 = DecryptionKey::with_primes_unchecked(&p1, &q1).unwrap();
         let pk1 = PaillierEncryptionKey(EncryptionKey::from(&sk1));
 
         let g = k256::ProjectivePoint::GENERATOR;

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -220,7 +220,7 @@ mod tests {
         let q = crate::utils::get_random_safe_prime_512();
         let N = &p * &q;
 
-        let sk = DecryptionKey::with_safe_primes_unchecked(&p, &q).unwrap();
+        let sk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();
         let pk = PaillierEncryptionKey(EncryptionKey::from(&sk));
 
         let (K, rho) = pk.encrypt(k);

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -248,7 +248,7 @@ mod tests {
         let q0 = crate::utils::get_random_safe_prime_512();
         let N0 = &p0 * &q0;
 
-        let sk = DecryptionKey::with_safe_primes_unchecked(&p0, &q0).unwrap();
+        let sk = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();
         let pk = PaillierEncryptionKey(EncryptionKey::from(&sk));
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -440,13 +440,14 @@ mod tests {
 
     #[test]
     fn test_jacobi() {
+        let mut rng = OsRng;
         let p = get_random_safe_prime_512();
         let q = get_random_safe_prime_512();
 
         let N = &p * &q;
 
         for _ in 0..100 {
-            let a = BigNumber::random(&N);
+            let a = BigNumber::from_rng(&N, &mut rng);
 
             let a_p = jacobi(&a, &p);
             let a_q = jacobi(&a, &q);
@@ -471,10 +472,11 @@ mod tests {
 
     #[test]
     fn test_square_roots_mod_prime() {
+        let mut rng = OsRng;
         let p = get_random_safe_prime_512();
 
         for _ in 0..100 {
-            let a = BigNumber::random(&p);
+            let a = BigNumber::from_rng(&p, &mut rng);
             let a_p = jacobi(&a, &p);
 
             let roots = square_roots_mod_prime(&a, &p);
@@ -496,6 +498,7 @@ mod tests {
 
     #[test]
     fn test_square_roots_mod_composite() {
+        let mut rng = OsRng;
         let p = get_random_safe_prime_512();
         let q = get_random_safe_prime_512();
         let N = &p * &q;
@@ -506,7 +509,7 @@ mod tests {
             if success == 10 {
                 return;
             }
-            let a = BigNumber::random(&N);
+            let a = BigNumber::from_rng(&N, &mut rng);
             let a_n = jacobi(&a, &N);
 
             let roots = square_roots_mod_composite(&a, &p, &q);
@@ -527,6 +530,7 @@ mod tests {
 
     #[test]
     fn test_fourth_roots_mod_composite() {
+        let mut rng = OsRng;
         let p = get_random_safe_prime_512();
         let q = get_random_safe_prime_512();
         let N = &p * &q;
@@ -537,7 +541,7 @@ mod tests {
             if success == 10 {
                 return;
             }
-            let a = BigNumber::random(&N);
+            let a = BigNumber::from_rng(&N, &mut rng);
             let a_n = jacobi(&a, &N);
 
             let roots = fourth_roots_mod_composite(&a, &p, &q);
@@ -558,12 +562,13 @@ mod tests {
 
     #[test]
     fn test_chinese_remainder_theorem() {
+        let mut rng = OsRng;
         let p = get_random_safe_prime_512();
         let q = get_random_safe_prime_512();
 
         for _ in 0..100 {
-            let a1 = BigNumber::random(&p);
-            let a2 = BigNumber::random(&q);
+            let a1 = BigNumber::from_rng(&p, &mut rng);
+            let a2 = BigNumber::from_rng(&q, &mut rng);
 
             let x = chinese_remainder_theorem(&a1, &a2, &p, &q).unwrap();
 

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -154,12 +154,13 @@ mod tests {
     use rand::rngs::OsRng;
 
     fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
+        let mut rng = OsRng;
         let p = crate::utils::get_random_safe_prime_512();
         let q = crate::utils::get_random_safe_prime_512();
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
-        let tau = BigNumber::random(&N);
-        let lambda = BigNumber::random(&phi_n);
+        let tau = BigNumber::from_rng(&N, &mut rng);
+        let lambda = BigNumber::from_rng(&phi_n, &mut rng);
         let t = modpow(&tau, &BigNumber::from(2), &N);
         let s = modpow(&t, &lambda, &N);
 

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -42,8 +42,8 @@ impl ZkSetupParameters {
         q: &BigNumber,
     ) -> Result<Self> {
         let phi_n = (p - 1) * (q - 1);
-        let tau = BigNumber::random(N);
-        let lambda = BigNumber::random(&phi_n);
+        let tau = BigNumber::from_rng(N, rng);
+        let lambda = BigNumber::from_rng(&phi_n, rng);
         let t = tau.modpow(&BigNumber::from(2), N);
         let s = t.modpow(&lambda, N);
 


### PR DESCRIPTION
Addresses #8, makes progress towards #24.
This PR replaces calls to `BigNumber::random` (which does not take an rng) to `BigNumber::from_rng` (which does). Doing so requires updating the `unknown_order` package which is re-exported through `libpaillier`, so that must be updated as well. As `libpaillier` changed its default backend for `unknown_order` to openssl, a feature flag was added to revert it to continue using the rust `num_bigint` library as a backend instead, for ease of compilation. It also appears that glass_pumpkin no longer needs to be pinned to an old version.