### PR TITLE
Update Facebook Licensing Info

### DIFF
--- a/examples/gen_primes.rs
+++ b/examples/gen_primes.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/gen_primes.rs
+++ b/examples/gen_primes.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/gen_primes.rs
+++ b/examples/gen_primes.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/cli.rs
+++ b/examples/network/cli.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/cli.rs
+++ b/examples/network/cli.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/cli.rs
+++ b/examples/network/cli.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/client.rs
+++ b/examples/network/client.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/client.rs
+++ b/examples/network/client.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/client.rs
+++ b/examples/network/client.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/common.rs
+++ b/examples/network/common.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/common.rs
+++ b/examples/network/common.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/common.rs
+++ b/examples/network/common.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/main.rs
+++ b/examples/network/main.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/main.rs
+++ b/examples/network/main.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/main.rs
+++ b/examples/network/main.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/mod.rs
+++ b/src/presign/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/mod.rs
+++ b/src/presign/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/mod.rs
+++ b/src/presign/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+//Modifications Copyright (c) 2022 Bolt Labs LLC
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
+// Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-//Modifications Copyright (c) 2022 Bolt Labs LLC
+//Modifications Copyright (c) 2022 Bolt Labs Holdings, Inc
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache


### PR DESCRIPTION
Closes #12  (Omar's stealth edit)

The source files which we have thus far modified now include the line
`Modifications Copyright (c) 2022 Bolt Labs LLC`

The files which we have not yet modified are:
[paillier.rs](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/paillier.rs)
[parameters.rs](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/parameters.rs)
[safe_primes_512.rs](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/safe_primes_512.rs)
[mod.rs](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/zkp/mod.rs)
[mod.rs](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/broadcast/mod.rs)

Was there anything else that needed to be done, such as a changelog file?
And did we reach a final decision on whether a year was needed or whether it should be Bolt Labs LLC or something else?