### PR TITLE
Remove unwrap() from main library

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -347,18 +347,14 @@ impl AuxInfoParticipant {
             .other_participant_ids
             .iter()
             .map(|&other_participant_id| {
-                let decom: AuxInfoDecommit = deserialize!(&self
-                    .storage
-                    .retrieve(
-                        StorableType::AuxInfoDecommit,
-                        message.id(),
-                        other_participant_id
-                    )
-                    .unwrap())
-                .unwrap();
-                decom.rid
+                let decom: AuxInfoDecommit = deserialize!(&self.storage.retrieve(
+                    StorableType::AuxInfoDecommit,
+                    message.id(),
+                    other_participant_id
+                )?)?;
+                Ok(decom.rid)
             })
-            .collect();
+            .collect::<Result<Vec<[u8; 32]>>>()?;
         let my_decom: AuxInfoDecommit = deserialize!(&self.storage.retrieve(
             StorableType::AuxInfoDecommit,
             message.id(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,14 @@ pub enum InternalError {
     BailError(String),
     /// Represents some code assumption that was checked at runtime but failed to be true.
     InternalInvariantFailed,
+    /// The inputs to a homomorphic operation on a paillier ciphertext were malformed
+    InvalidPaillierOperation,
+    /// The attemped decryption of a pailler ciphertext failed
+    PaillierDecryptionFailed,
+    /// Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)
+    CouldNotConvertToScalar,
+    /// Could not invert a Scaler
+    CouldNotInvertScalar,
 }
 
 macro_rules! serialize {

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -5,6 +5,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use crate::errors::{InternalError::PaillierDecryptionFailed, Result};
 use crate::utils::random_bn_in_z_star;
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
@@ -37,7 +38,7 @@ impl PaillierEncryptionKey {
 pub(crate) struct PaillierDecryptionKey(pub(crate) libpaillier::DecryptionKey);
 
 impl PaillierDecryptionKey {
-    pub(crate) fn decrypt(&self, c: &BigNumber) -> Option<Vec<u8>> {
-        self.0.decrypt(c)
+    pub(crate) fn decrypt(&self, c: &BigNumber) -> Result<Vec<u8>> {
+        self.0.decrypt(c).ok_or(PaillierDecryptionFailed)
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -233,7 +233,7 @@ impl Participant {
             self.main_storage
                 .retrieve(StorableType::PresignRecord, presign_identifier, self.id)?;
         let presign_record: PresignRecord = deserialize!(&pr_bytes)?;
-        let (r, s) = presign_record.sign(digest);
+        let (r, s) = presign_record.sign(digest)?;
         let ret = SignatureShare { r: Some(r), s };
 
         // Clear the presign record after being used once
@@ -290,7 +290,7 @@ impl SignatureShare {
     /// Converts the [SignatureShare] into a signature
     pub fn finish(&self) -> Result<k256::ecdsa::Signature> {
         let mut s = self.s;
-        if s.is_high().unwrap_u8() == 1 {
+        if bool::from(s.is_high()) {
             s = s.negate();
         }
 

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -147,7 +147,7 @@ impl Proof for PiAffgProof {
             };
             a.modmul(&b, &N0_squared)
         };
-        let B_x = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha).unwrap());
+        let B_x = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
         let B_y = {
             let a = modpow(&(BigNumber::one() + &input.N1), &beta, &N1_squared);
             let b = modpow(&r_y, &input.N1, &N1_squared);
@@ -182,7 +182,7 @@ impl Proof for PiAffgProof {
                 S.to_bytes(),
                 T.to_bytes(),
                 A.to_bytes(),
-                bincode::serialize(&B_x).unwrap(),
+                serialize!(&B_x)?,
                 B_y.to_bytes(),
                 E.to_bytes(),
                 F.to_bytes(),
@@ -234,7 +234,7 @@ impl Proof for PiAffgProof {
                 self.S.to_bytes(),
                 self.T.to_bytes(),
                 self.A.to_bytes(),
-                bincode::serialize(&self.B_x).unwrap(),
+                serialize!(&self.B_x)?,
                 self.B_y.to_bytes(),
                 self.E.to_bytes(),
                 self.F.to_bytes(),
@@ -269,8 +269,8 @@ impl Proof for PiAffgProof {
         }
 
         let eq_check_2 = {
-            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z1).unwrap());
-            let rhs = CurvePoint(self.B_x.0 + input.X.0 * utils::bn_to_scalar(&self.e).unwrap());
+            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z1)?);
+            let rhs = CurvePoint(self.B_x.0 + input.X.0 * utils::bn_to_scalar(&self.e)?);
             lhs == rhs
         };
         if !eq_check_2 {

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -118,7 +118,7 @@ impl Proof for PiLogProof {
             let b = modpow(&r, &input.N0, &N0_squared);
             a.modmul(&b, &N0_squared)
         };
-        let Y = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha).unwrap());
+        let Y = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
         let D = {
             let a = modpow(&input.setup_params.s, &alpha, &input.setup_params.N);
             let b = modpow(&input.setup_params.t, &gamma, &input.setup_params.N);
@@ -129,13 +129,7 @@ impl Proof for PiLogProof {
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(S, A, Y, D)",
-            &[
-                S.to_bytes(),
-                A.to_bytes(),
-                bincode::serialize(&Y).unwrap(),
-                D.to_bytes(),
-            ]
-            .concat(),
+            &[S.to_bytes(), A.to_bytes(), serialize!(&Y)?, D.to_bytes()].concat(),
         );
 
         // Verifier samples from e in +- q (where q is the group order)
@@ -170,7 +164,7 @@ impl Proof for PiLogProof {
             &[
                 self.S.to_bytes(),
                 self.A.to_bytes(),
-                bincode::serialize(&self.Y).unwrap(),
+                serialize!(&self.Y)?,
                 self.D.to_bytes(),
             ]
             .concat(),
@@ -201,8 +195,8 @@ impl Proof for PiLogProof {
         }
 
         let eq_check_2 = {
-            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z1).unwrap());
-            let rhs = CurvePoint(self.Y.0 + input.X.0 * utils::bn_to_scalar(&self.e).unwrap());
+            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z1)?);
+            let rhs = CurvePoint(self.Y.0 + input.X.0 * utils::bn_to_scalar(&self.e)?);
             lhs == rhs
         };
         if !eq_check_2 {

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -76,7 +76,7 @@ impl Proof for PiSchProof {
     ) -> Result<Self> {
         // Sample alpha from F_q
         let alpha = crate::utils::random_positive_bn(rng, &input.q);
-        let A = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha).unwrap());
+        let A = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
 
         let mut transcript = Transcript::new(b"PiSchProof");
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
@@ -108,8 +108,8 @@ impl Proof for PiSchProof {
         // Do equality checks
 
         let eq_check_1 = {
-            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z).unwrap());
-            let rhs = CurvePoint(self.A.0 + input.X.0 * utils::bn_to_scalar(&self.e).unwrap());
+            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z)?);
+            let rhs = CurvePoint(self.A.0 + input.X.0 * utils::bn_to_scalar(&self.e)?);
             lhs == rhs
         };
         if !eq_check_1 {
@@ -127,7 +127,7 @@ impl PiSchProof {
     ) -> Result<PiSchPrecommit> {
         // Sample alpha from F_q
         let alpha = crate::utils::random_positive_bn(rng, &input.q);
-        let A = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha).unwrap());
+        let A = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
         Ok(PiSchPrecommit { A, alpha })
     }
 
@@ -168,8 +168,8 @@ impl PiSchProof {
         // Do equality checks
 
         let eq_check_1 = {
-            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z).unwrap());
-            let rhs = CurvePoint(self.A.0 + input.X.0 * utils::bn_to_scalar(&self.e).unwrap());
+            let lhs = CurvePoint(input.g.0 * utils::bn_to_scalar(&self.z)?);
+            let rhs = CurvePoint(self.A.0 + input.X.0 * utils::bn_to_scalar(&self.e)?);
             lhs == rhs
         };
         if !eq_check_1 {


### PR DESCRIPTION
This PR addresses the `unwrap() `removal portion of #13 by replacing unwraps in the main library with errors.
It does not attempt to remove unwraps from tests, nor does it touch any of the example programs