### PR TITLE
Move libpaillier keys into paillier module

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,8 @@ use core::fmt::Debug;
 use displaydoc::Display;
 use thiserror::Error;
 
+use crate::paillier::PaillierError;
+
 /// The default Result type used in this crate
 pub type Result<T> = std::result::Result<T, InternalError>;
 
@@ -36,10 +38,8 @@ pub enum InternalError {
     BailError(String),
     /// Represents some code assumption that was checked at runtime but failed to be true.
     InternalInvariantFailed,
-    /// The inputs to a homomorphic operation on a paillier ciphertext were malformed
-    InvalidPaillierOperation,
-    /// The attemped decryption of a pailler ciphertext failed
-    PaillierDecryptionFailed,
+    /// Paillier error: `{0}`
+    PaillierError(PaillierError),
     /// Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)
     CouldNotConvertToScalar,
     /// Could not invert a Scaler

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -5,10 +5,29 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use crate::errors::{InternalError::PaillierDecryptionFailed, Result};
+use crate::errors::{InternalError, Result};
 use crate::utils::random_bn_in_z_star;
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Paillier-specific errors
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PaillierError {
+    #[error("Failed to create a Paillier decryption key from inputs")]
+    CouldNotCreateKey,
+    #[error("The inputs to a homomorphic operation on a Paillier ciphertext were malformed")]
+    InvalidOperation,
+    #[error("The attemped decryption of a Pailler ciphertext failed")]
+    DecryptionFailed,
+}
+
+/// TODO: Remove this once `InternalError` is instantiated with thiserror.
+impl From<PaillierError> for InternalError {
+    fn from(err: PaillierError) -> Self {
+        InternalError::PaillierError(err)
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierCiphertext(pub(crate) BigNumber);
@@ -35,10 +54,27 @@ impl PaillierEncryptionKey {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct PaillierDecryptionKey(pub(crate) libpaillier::DecryptionKey);
+pub(crate) struct PaillierDecryptionKey(libpaillier::DecryptionKey);
 
 impl PaillierDecryptionKey {
     pub(crate) fn decrypt(&self, c: &BigNumber) -> Result<Vec<u8>> {
-        self.0.decrypt(c).ok_or(PaillierDecryptionFailed)
+        Ok(self.0.decrypt(c).ok_or(PaillierError::DecryptionFailed)?)
+    }
+
+    /// Generate a new [`PaillierDecryptionKey`] from two primes.
+    ///
+    /// The inputs `p` and `q` are checked for primality but not for _safe_ primality.
+    /// TODO #56: Check prime size and output size.
+    pub(crate) fn from_primes(p: &BigNumber, q: &BigNumber) -> Result<Self> {
+        Ok(PaillierDecryptionKey(
+            libpaillier::DecryptionKey::with_primes(p, q)
+                .ok_or(PaillierError::CouldNotCreateKey)?,
+        ))
+    }
+
+    /// Retrieve the public [`PaillierEncryptionKey`] corresponding to this secret
+    /// [`PaillierDecryptionKey`].
+    pub fn encryption_key(&self) -> PaillierEncryptionKey {
+        PaillierEncryptionKey(libpaillier::EncryptionKey::from(&self.0))
     }
 }

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -7,7 +7,8 @@
 // of this source tree.
 
 use crate::broadcast::participant::BroadcastTag;
-use crate::errors::InternalError::{InternalInvariantFailed, InvalidPaillierOperation};
+use crate::errors::InternalError::InternalInvariantFailed;
+use crate::paillier::PaillierError;
 use crate::{
     auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant},
@@ -1007,10 +1008,10 @@ impl PresignKeyShareAndInfo {
                     .pk
                     .0
                     .mul(&receiver_r1_pub_broadcast.K.0, &sender_r1_priv.gamma)
-                    .ok_or(InvalidPaillierOperation)?,
+                    .ok_or(PaillierError::InvalidOperation)?,
                 &beta_ciphertext,
             )
-            .ok_or(InvalidPaillierOperation)?;
+            .ok_or(PaillierError::InvalidOperation)?;
 
         let D_hat = receiver_aux_info
             .pk
@@ -1020,10 +1021,10 @@ impl PresignKeyShareAndInfo {
                     .pk
                     .0
                     .mul(&receiver_r1_pub_broadcast.K.0, &self.keyshare_private.x)
-                    .ok_or(InvalidPaillierOperation)?,
+                    .ok_or(PaillierError::InvalidOperation)?,
                 &beta_hat_ciphertext,
             )
-            .ok_or(InvalidPaillierOperation)?;
+            .ok_or(PaillierError::InvalidOperation)?;
 
         let (F, r) = self.aux_info_public.pk.encrypt(&beta);
         let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(&beta_hat);

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -337,8 +337,7 @@ impl Proof for PiAffgProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{paillier::PaillierEncryptionKey, utils::random_bn_in_range_min};
-    use libpaillier::*;
+    use crate::{paillier::PaillierDecryptionKey, utils::random_bn_in_range_min};
     use rand::rngs::OsRng;
 
     fn random_paillier_affg_proof(x: &BigNumber, y: &BigNumber) -> Result<()> {
@@ -349,11 +348,8 @@ mod tests {
         let (p1, q1) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N1 = &p1 * &q1;
 
-        let sk0 = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();
-        let pk0 = PaillierEncryptionKey(EncryptionKey::from(&sk0));
-
-        let sk1 = DecryptionKey::with_primes_unchecked(&p1, &q1).unwrap();
-        let pk1 = PaillierEncryptionKey(EncryptionKey::from(&sk1));
+        let pk0 = PaillierDecryptionKey::from_primes(&p0, &q0)?.encryption_key();
+        let pk1 = PaillierDecryptionKey::from_primes(&p1, &q1)?.encryption_key();
 
         let g = k256::ProjectivePoint::GENERATOR;
 

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -210,8 +210,7 @@ impl Proof for PiEncProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{paillier::PaillierEncryptionKey, utils::random_bn_in_range_min};
-    use libpaillier::*;
+    use crate::{paillier::PaillierDecryptionKey, utils::random_bn_in_range_min};
     use rand::rngs::OsRng;
 
     fn random_paillier_encryption_in_range_proof(k: &BigNumber) -> Result<()> {
@@ -220,8 +219,7 @@ mod tests {
         let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
-        let sk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();
-        let pk = PaillierEncryptionKey(EncryptionKey::from(&sk));
+        let pk = PaillierDecryptionKey::from_primes(&p, &q)?.encryption_key();
 
         let (K, rho) = pk.encrypt(k);
         let setup_params = ZkSetupParameters::gen(&mut rng)?;

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -232,8 +232,7 @@ impl Proof for PiLogProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{paillier::*, utils::random_bn_in_range_min};
-    use libpaillier::*;
+    use crate::{paillier::PaillierDecryptionKey, utils::random_bn_in_range_min};
     use rand::rngs::OsRng;
 
     fn random_paillier_log_proof(x: &BigNumber) -> Result<()> {
@@ -242,8 +241,7 @@ mod tests {
         let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
 
-        let sk = DecryptionKey::with_primes_unchecked(&p0, &q0).unwrap();
-        let pk = PaillierEncryptionKey(EncryptionKey::from(&sk));
+        let pk = PaillierDecryptionKey::from_primes(&p0, &q0)?.encryption_key();
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
 


### PR DESCRIPTION
Fixes #60 

- Adds generation method in the Paillier module to create a decryption key and derive an encryption key
- Removes all direct calls to `libpaillier` constructors outside of the `paillier` module
- Adds an error enum to the paillier module. I decided not to try to fix the big `InternalError` enum at this point -- will leave that to #58. I just moved the Paillier-specific errors into this module and wrote a manual conversion into `InternalError`.

I was hoping to remove all direct access to the `libpaillier` types, but I found a few places where they're accessed to do homomorphic operations. Made #64 to address that.
