### PR TITLE
remove unused dependencies #68

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,34 +14,31 @@ default = []
 flame_it = ["flame", "flamer"]
 
 [dependencies]
-thiserror = "1"
-k256 = { version = "0.10", features = ["arithmetic", "digest", "sha256", "ecdsa", "serde"] }
-libpaillier = { version = "0.5", default-features = false, features = ["rust"] }
-num-bigint = "0.4"
 bincode = "1"
 displaydoc = { version = "0.2", default-features = false }
-hex = "0.4"
-rand = "0.8"
-sha2 = "0.9"
-serde = "1"
-generic-array = "0.14"
-merlin = "3"
-integer-encoding = "3"
-lazy_static = "1"
 flame = { version = "0.2", optional = true }
 flamer = { version = "0.3", optional = true }
+generic-array = "0.14"
+hex = "0.4"
+k256 = { version = "0.10", features = ["arithmetic", "digest", "sha256", "ecdsa", "serde"] }
+lazy_static = "1"
+libpaillier = { version = "0.5", default-features = false, features = ["rust"] }
+merlin = "3"
+num-bigint = "0.4"
+rand = "0.8"
+serde = "1"
+sha2 = "0.9"
+thiserror = "1"
 
 [dev-dependencies]
-clap = { version = "3", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-rocket = { version = "0.5.0-rc", default-features = false, features = ["json"] }
-reqwest = { version = "0.11", features = ["json"] }
-bytes = "1"
 anyhow = "1"
-futures = "0.3"
+clap = { version = "3", features = ["derive"] }
+criterion = "0.3"
 dialoguer = "0.10"
 indicatif = "0.16"
-criterion = "0.3"
+reqwest = { version = "0.11", features = ["json"] }
+rocket = { version = "0.5.0-rc", default-features = false, features = ["json"] }
+tokio = { version = "1", features = ["full"] }
 
 [[bench]]
 name = "my_benchmark"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -143,7 +143,7 @@ pub(crate) fn positive_bn_random_from_transcript(
     n: &BigNumber,
 ) -> BigNumber {
     let len = n.to_bytes().len();
-    let mut t = vec![0u8; len as usize];
+    let mut t = vec![0u8; len];
     loop {
         transcript.challenge_bytes(b"sampling randomness", t.as_mut_slice());
         let b = BigNumber::from_slice(t.as_slice());
@@ -248,7 +248,7 @@ lazy_static::lazy_static! {
 fn get_safe_primes_from_file() -> Vec<BigNumber> {
     let safe_primes: Vec<BigNumber> = crate::safe_primes_512::SAFE_PRIMES
         .iter()
-        .map(|s| BigNumber::from_slice(&hex::decode(s).unwrap()))
+        .map(|s| BigNumber::from_slice(hex::decode(s).unwrap()))
         .collect();
     safe_primes
 }

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -246,8 +246,7 @@ fn sqrt(num: &BigNumber) -> BigNumber {
     // convert to a struct with a square root function first
     let num_bigint: BigInt = BigInt::from_bytes_be(Sign::Plus, &num.to_bytes());
     let sqrt = num_bigint.sqrt();
-    let sqrt_bignum: BigNumber = BigNumber::from_slice(&sqrt.to_bytes_be().1);
-    sqrt_bignum
+    BigNumber::from_slice(sqrt.to_bytes_be().1)
 }
 
 impl PiFacProof {
@@ -508,9 +507,9 @@ mod tests {
 
         let num = &p0 * &q0;
         let num_bigint: BigInt = BigInt::from_bytes_be(Sign::Plus, &num.to_bytes());
-        let num_bignum: BigNumber = BigNumber::from_slice(&num_bigint.to_bytes_be().1);
-        assert!(num == num_bignum);
-        assert!(num.to_string() == num_bigint.to_string());
+        let num_bignum: BigNumber = BigNumber::from_slice(num_bigint.to_bytes_be().1);
+        assert_eq!(num, num_bignum);
+        assert_eq!(num.to_string(), num_bigint.to_string());
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #68

Unused dependency is `integer-encoding`. Unused dev dependencies are `bytes` and `futures`.

Also alphabetizes the toml file and fixes Clippy errors from the latest Rust update.