### PR TITLE
Fix key-size bug

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -507,17 +507,7 @@ impl AuxInfoParticipant {
 fn new_auxinfo<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses)> {
-    // As generating safe primes is very computationally expensive (> one minute per prime in github CI),
-    // we read precomputed ones from a file (but only in tests!)
-    #[cfg(not(test))]
-    let (p, q) = (
-        crate::utils::get_random_safe_prime_512(rng),
-        crate::utils::get_random_safe_prime_512(rng),
-    );
-    #[cfg(test)]
-    let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(rng);
-
-    let decryption_key = PaillierDecryptionKey::from_primes(&p, &q)?;
+    let (decryption_key, p, q) = PaillierDecryptionKey::new(rng)?;
     let encryption_key = decryption_key.encryption_key();
     let params = ZkSetupParameters::gen_from_primes(rng, &(&p * &q), &p, &q)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,6 +44,8 @@ pub enum InternalError {
     CouldNotConvertToScalar,
     /// Could not invert a Scaler
     CouldNotInvertScalar,
+    /// Reached the maximum allowed number of retries.
+    RetryFailed,
 }
 
 macro_rules! serialize {

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -6,8 +6,10 @@
 // of this source tree.
 
 use crate::errors::{InternalError, Result};
-use crate::utils::random_bn_in_z_star;
+use crate::parameters::PRIME_BITS;
+use crate::utils::{random_bn_in_z_star, CRYPTOGRAPHIC_RETRY_MAX};
 use libpaillier::unknown_order::BigNumber;
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -61,20 +63,178 @@ impl PaillierDecryptionKey {
         Ok(self.0.decrypt(c).ok_or(PaillierError::DecryptionFailed)?)
     }
 
-    /// Generate a new [`PaillierDecryptionKey`] from two primes.
+    /// Generate a new [`PaillierDecryptionKey`] and its factors.
     ///
-    /// The inputs `p` and `q` are checked for primality but not for _safe_ primality.
-    /// TODO #56: Check prime size and output size.
-    pub(crate) fn from_primes(p: &BigNumber, q: &BigNumber) -> Result<Self> {
-        Ok(PaillierDecryptionKey(
-            libpaillier::DecryptionKey::with_primes(p, q)
+    /// The factors `p` and `q` are `PRIME_BITS`-long safe primes, and the resulting
+    /// modulus is `2 * PRIME_BITS` long.
+    pub(crate) fn new(
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> Result<(Self, BigNumber, BigNumber)> {
+        // Generate a pair of safe primes that are `PRIME_BITS` long and return them if
+        // their product is `2 * PRIME_BITS` long (otherwise return `None`).
+        let generate_prime_pair = || {
+            // As generating safe primes can be computationally expensive (> one minute per prime
+            // in github CI), we read precomputed ones from a file (but only in tests!)
+            #[cfg(not(test))]
+            let (p, q) = (
+                prime_gen::get_random_safe_prime_512(rng),
+                prime_gen::get_random_safe_prime_512(rng),
+            );
+            #[cfg(test)]
+            let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(rng);
+
+            if p.bit_length() == PRIME_BITS
+                && q.bit_length() == PRIME_BITS
+                && (&p * &q).bit_length() == 2 * PRIME_BITS
+            {
+                Some((p, q))
+            } else {
+                None
+            }
+        };
+
+        // A Paillier decryption key is the product of the two primes, but sometimes two n/2-bit
+        // primes can produce an n-1 bit modulus. Allow some (lazily evaluated) retries to handle
+        // that error.
+        let (p, q) = std::iter::repeat_with(generate_prime_pair)
+            .take(CRYPTOGRAPHIC_RETRY_MAX)
+            .find(|result| result.is_some())
+            // We hit the maximum number of retries without getting an acceptable pair.
+            .ok_or(InternalError::RetryFailed)?
+            // The `find` function failed to actually give us `Some`.
+            .ok_or(InternalError::InternalInvariantFailed)?;
+
+        let decryption_key = PaillierDecryptionKey(
+            libpaillier::DecryptionKey::with_primes(&p, &q)
                 .ok_or(PaillierError::CouldNotCreateKey)?,
-        ))
+        );
+
+        // Double check that the modulus is the correct size.
+        if decryption_key.0.n().bit_length() == 2 * PRIME_BITS {
+            Ok((decryption_key, p, q))
+        } else {
+            Err(PaillierError::CouldNotCreateKey)?
+        }
     }
 
     /// Retrieve the public [`PaillierEncryptionKey`] corresponding to this secret
     /// [`PaillierDecryptionKey`].
     pub fn encryption_key(&self) -> PaillierEncryptionKey {
         PaillierEncryptionKey(libpaillier::EncryptionKey::from(&self.0))
+    }
+}
+
+// Safe prime generation functions for production and testing.
+pub(crate) mod prime_gen {
+    use super::*;
+    #[cfg(test)]
+    use rand::Rng;
+    use rand::{CryptoRng, RngCore};
+
+    /// Sample a 512-bit safe prime uniformly at random.
+    ///
+    /// Prime size is derived from the security
+    /// parameter setting of κ = 128, and safe primes being of length 4κ (Figure 6,
+    /// Round 1 of the CGGMP'21 paper)
+    pub(crate) fn get_random_safe_prime_512<R: RngCore + CryptoRng>(rng: &mut R) -> BigNumber {
+        BigNumber::safe_prime_from_rng(PRIME_BITS, rng)
+    }
+
+    // Generate safe primes from a file. Usually, generating safe primes takes
+    // awhile (0-5 minutes per 512-bit safe prime on my laptop, average 50 seconds)
+    #[cfg(test)]
+    lazy_static::lazy_static! {
+        static ref POOL_OF_PRIMES: Vec<BigNumber> = get_safe_primes_from_file();
+    }
+
+    #[cfg(test)]
+    fn get_safe_primes_from_file() -> Vec<BigNumber> {
+        // The currently-generated file includes safe primes of different lengths (511-514), so
+        // we filter them to get only the ones exactly `PRIME_BITS` long.
+        crate::safe_primes_512::SAFE_PRIMES
+            .iter()
+            .map(|s| BigNumber::from_slice(hex::decode(s).unwrap()))
+            .filter(|prime| prime.bit_length() == PRIME_BITS)
+            .collect()
+    }
+
+    /// Sample a safe prime from a precompiled list. For testing purposes only!!
+    #[cfg(test)]
+    pub(crate) fn get_prime_from_pool_insecure<R: RngCore + CryptoRng>(rng: &mut R) -> BigNumber {
+        POOL_OF_PRIMES[rng.gen_range(0..POOL_OF_PRIMES.len())].clone()
+    }
+
+    /// Sample a pair of independent, non-matching safe primes from a precompiled list.
+    /// For testing purposes only!!
+    #[cfg(test)]
+    pub(crate) fn get_prime_pair_from_pool_insecure<R: RngCore + CryptoRng>(
+        rng: &mut R,
+    ) -> (BigNumber, BigNumber) {
+        let p = get_prime_from_pool_insecure(rng);
+        loop {
+            let q = get_prime_from_pool_insecure(rng);
+            if p != q {
+                break (p, q);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use libpaillier::unknown_order::BigNumber;
+    use rand::{
+        rngs::{OsRng, StdRng},
+        Rng, SeedableRng,
+    };
+
+    use crate::parameters::PRIME_BITS;
+
+    use super::{prime_gen, PaillierDecryptionKey};
+
+    fn rng() -> StdRng {
+        let mut seeder = OsRng;
+        let seed = seeder.gen();
+        eprintln!("seed: {:?}", seed);
+        StdRng::from_seed(seed)
+    }
+
+    #[test]
+    fn get_random_safe_prime_512_produces_safe_primes() {
+        let mut rng = rng();
+        let p = prime_gen::get_random_safe_prime_512(&mut rng);
+        assert!(p.is_prime());
+        let q: BigNumber = (p - 1) / 2;
+        assert!(q.is_prime());
+    }
+
+    #[test]
+    fn paillier_keygen_produces_good_primes() {
+        let mut rng = rng();
+
+        let (decryption_key, p, q) = PaillierDecryptionKey::new(&mut rng).unwrap();
+
+        assert!(p.is_prime());
+        assert!(q.is_prime());
+
+        let safe_p: BigNumber = (&p - 1) / 2;
+        assert!(safe_p.is_prime());
+        let safe_q: BigNumber = (&q - 1) / 2;
+        assert!(safe_q.is_prime());
+
+        assert_eq!(p.bit_length(), PRIME_BITS);
+        assert_eq!(q.bit_length(), PRIME_BITS);
+
+        let modulus = &p * &q;
+        assert_eq!(decryption_key.0.n(), &modulus);
+        assert_eq!(modulus.bit_length(), 2 * PRIME_BITS);
+    }
+
+    #[test]
+    #[ignore = "slow"]
+    fn paillier_keygen_always_produces_good_primes() {
+        for _ in 0..100 {
+            paillier_keygen_produces_good_primes()
+        }
     }
 }

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -342,14 +342,14 @@ mod tests {
 
     fn random_paillier_affg_proof(x: &BigNumber, y: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
-        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+
+        let (decryption_key_0, p0, q0) = PaillierDecryptionKey::new(&mut rng)?;
         let N0 = &p0 * &q0;
+        let pk0 = decryption_key_0.encryption_key();
 
-        let (p1, q1) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (decryption_key_1, p1, q1) = PaillierDecryptionKey::new(&mut rng)?;
         let N1 = &p1 * &q1;
-
-        let pk0 = PaillierDecryptionKey::from_primes(&p0, &q0)?.encryption_key();
-        let pk1 = PaillierDecryptionKey::from_primes(&p1, &q1)?.encryption_key();
+        let pk1 = decryption_key_1.encryption_key();
 
         let g = k256::ProjectivePoint::GENERATOR;
 

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -216,10 +216,9 @@ mod tests {
     fn random_paillier_encryption_in_range_proof(k: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (decryption_key, p, q) = PaillierDecryptionKey::new(&mut rng)?;
+        let pk = decryption_key.encryption_key();
         let N = &p * &q;
-
-        let pk = PaillierDecryptionKey::from_primes(&p, &q)?.encryption_key();
 
         let (K, rho) = pk.encrypt(k);
         let setup_params = ZkSetupParameters::gen(&mut rng)?;

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -426,13 +426,15 @@ impl PiFacProof {
 
 #[cfg(test)]
 mod tests {
+    use crate::paillier::prime_gen;
+
     use super::*;
     use rand::rngs::OsRng;
 
     fn random_no_small_factors_proof() -> Result<(PiFacInput, PiFacProof)> {
         let mut rng = OsRng;
 
-        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let N0 = &p0 * &q0;
         let setup_params = ZkSetupParameters::gen(&mut rng)?;
 
@@ -456,7 +458,7 @@ mod tests {
 
         let incorrect_N = PiFacInput::new(
             &input.setup_params,
-            &crate::utils::get_prime_from_pool_insecure(&mut rng),
+            &prime_gen::get_prime_from_pool_insecure(&mut rng),
         );
         assert!(proof.verify(&incorrect_N).is_err());
 
@@ -464,7 +466,7 @@ mod tests {
             PiFacInput::new(&ZkSetupParameters::gen(&mut rng)?, &input.N0);
         assert!(proof.verify(&incorrect_startup_params).is_err());
 
-        let (not_p0, not_q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (not_p0, not_q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let incorrect_factors =
             PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&not_p0, &not_q0))?;
         assert!(incorrect_factors.verify(&input).is_err());
@@ -477,7 +479,7 @@ mod tests {
             PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&small_p, &small_q))?;
         assert!(small_proof.verify(&small_input).is_err());
 
-        let regular_sized_q = crate::utils::get_prime_from_pool_insecure(&mut rng);
+        let regular_sized_q = prime_gen::get_prime_from_pool_insecure(&mut rng);
         let mixed_input = PiFacInput::new(&setup_params, &(&small_p * &regular_sized_q));
         let mixed_proof = PiFacProof::prove(
             &mut rng,
@@ -503,7 +505,7 @@ mod tests {
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
         let mut rng = OsRng;
-        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
 
         let num = &p0 * &q0;
         let num_bigint: BigInt = BigInt::from_bytes_be(Sign::Plus, &num.to_bytes());

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -238,10 +238,9 @@ mod tests {
     fn random_paillier_log_proof(x: &BigNumber) -> Result<()> {
         let mut rng = OsRng;
 
-        let (p0, q0) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (decryption_key, p0, q0) = PaillierDecryptionKey::new(&mut rng)?;
+        let pk = decryption_key.encryption_key();
         let N0 = &p0 * &q0;
-
-        let pk = PaillierDecryptionKey::from_primes(&p0, &q0)?.encryption_key();
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
 

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -436,13 +436,13 @@ fn y_prime_combinations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::get_prime_from_pool_insecure;
+    use crate::paillier::prime_gen;
     use rand::{rngs::OsRng, RngCore};
 
     #[test]
     fn test_jacobi() {
         let mut rng = OsRng;
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         for _ in 0..100 {
@@ -472,7 +472,7 @@ mod tests {
     #[test]
     fn test_square_roots_mod_prime() {
         let mut rng = OsRng;
-        let p = get_prime_from_pool_insecure(&mut rng);
+        let p = prime_gen::get_prime_from_pool_insecure(&mut rng);
 
         for _ in 0..100 {
             let a = BigNumber::from_rng(&p, &mut rng);
@@ -498,7 +498,7 @@ mod tests {
     #[test]
     fn test_square_roots_mod_composite() {
         let mut rng = OsRng;
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -529,7 +529,7 @@ mod tests {
     #[test]
     fn test_fourth_roots_mod_composite() {
         let mut rng = OsRng;
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
 
         // Loop until we've confirmed enough successes
@@ -560,7 +560,7 @@ mod tests {
     #[test]
     fn test_chinese_remainder_theorem() {
         let mut rng = OsRng;
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
 
         for _ in 0..100 {
             let a1 = BigNumber::from_rng(&p, &mut rng);

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -151,12 +151,14 @@ impl Proof for PiPrmProof {
 
 #[cfg(test)]
 mod tests {
+    use crate::paillier::prime_gen;
+
     use super::*;
     use rand::rngs::OsRng;
 
     fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
         let mut rng = OsRng;
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(&mut rng);
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng);
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
         let tau = BigNumber::from_rng(&N, &mut rng);

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -29,7 +29,9 @@ pub(crate) struct ZkSetupParameters {
 impl ZkSetupParameters {
     #[cfg(test)]
     pub(crate) fn gen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
-        let (p, q) = crate::utils::get_prime_pair_from_pool_insecure(rng);
+        use crate::paillier::PaillierDecryptionKey;
+
+        let (_, p, q) = PaillierDecryptionKey::new(rng)?;
         let N = &p * &q;
         Self::gen_from_primes(rng, &N, &p, &q)
     }


### PR DESCRIPTION
Fixes #56 

This PR ballooned a little bit. In #60, I made an API for key generation that takes primes as parameters. However, I realized here that 
1. we never create a new Paillier key from primes that we didn't just generate, and
2. we never generate primes that aren't used in Paillier keys (outside of tests).

So, I decided to move all the prime generation methods into a mini-module within the Paillier module, and to update the key generation API to just take an RNG and generate the primes internally. It now also returns the prime factors, since they're not directly retrievable from the decryption key but we need them in subsequent operations.

The prime generation module didn't change functionally; I cleaned up some documentation and consolidated function calls a little bit.

The prime generation steps only change in order to address the actual issue I was trying to solve: adding size checks to the primes we generate and the modulus that results. I also built in a retry mechanism that adds some complexity, but I hopefully added enough inline documentation that it's understandable.

Specific reviewer requests:
- @gatoWololo : I will put one or two Rust questions inline
- @tyurek : Are there any additional properties of the primes used for Paillier moduli that you think I missed? 

Design thoughts
- Maybe the prime factors generated for a `PaillierDecryptionKey` should be in their own wrapper type, like `PaillierFactor`. It might be useful to distinguish them from arbitrary big numbers in the proofs, and then we could tag them with `zeroize` because they're very sensitive data.
- A very common pattern in tests is to generate a Paillier decryption key, derive the encryption key, and then use the factors from decryption to compute `N = p * q`. `N` is a public part of the encryption key, though. I think this will go away when we encode the proofs with Paillier types instead of `BigNumber`s. If not, we should think about making an explicit method on the encryption key to retrieve `N` and `N^2` to remove some of that extra multiplication.