### PR TITLE
add github workflow to run slow tests separately

### DIFF
--- a/.github/workflows/ignored_tests.yml
+++ b/.github/workflows/ignored_tests.yml
@@ -1,0 +1,25 @@
+name: Ignored Rust Tests
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: ignored tests
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run ignored tests (only!)
+        run: cargo test -- --ignored

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    name: test
+    name: ci
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         with:
           command: install
           args: --debug cargo-make
-      - name: Run Tests
+      - name: Run full CI (fmt, clippy, build, test, doctest, docs)
         run: cargo make ci
 
   deny-check:

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -638,6 +638,7 @@ mod tests {
 
     #[cfg_attr(feature = "flame_it", flame)]
     #[test]
+    #[ignore = "slow"]
     // This test is cheap. Try a bunch of message permutations to decrease error
     // likelihood
     fn test_run_auxinfo_protocol_many_times() -> Result<()> {

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -635,6 +635,7 @@ mod tests {
 
     #[cfg_attr(feature = "flame_it", flame)]
     #[test]
+    #[ignore = "slow"]
     // This test is cheap. Try a bunch of message permutations to decrease error
     // likelihood
     fn test_run_keygen_protocol_many_times() -> Result<()> {


### PR DESCRIPTION
Address #65

This PR actually shouldn't run the new CI, since it's only run on _push_ to main, not PR. So if it looks good, I will push and iterate if it doesn't work as expected.

The best news is, a local run of `cargo make ci` only takes ~1min on my machine now! 