### PR TITLE
Fix error handling when drawing random ZStar

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -46,16 +46,16 @@ impl PaillierEncryptionKey {
         self.0.n()
     }
 
-    pub(crate) fn encrypt(&self, x: &BigNumber) -> (BigNumber, BigNumber) {
+    pub(crate) fn encrypt(&self, x: &BigNumber) -> Result<(BigNumber, BigNumber)> {
         let mut rng = rand::rngs::OsRng;
-        let nonce = random_bn_in_z_star(&mut rng, self.0.n());
+        let nonce = random_bn_in_z_star(&mut rng, self.0.n())?;
 
         let one = BigNumber::one();
         let base = one + self.n();
         let a = base.modpow(x, self.0.nn());
         let b = nonce.modpow(self.n(), self.0.nn());
         let c = a.modmul(&b, self.0.nn());
-        (c, nonce)
+        Ok((c, nonce))
     }
 }
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -930,7 +930,7 @@ impl PresignKeyShareAndInfo {
 
         // Sample rho <- Z_N^* and set K = enc(k; rho)
         let (K, rho) = loop {
-            let (K, rho) = self.aux_info_public.pk.encrypt(&k);
+            let (K, rho) = self.aux_info_public.pk.encrypt(&k)?;
             if !BigNumber::is_zero(&rho) {
                 break (K, rho);
             }
@@ -938,7 +938,7 @@ impl PresignKeyShareAndInfo {
 
         // Sample nu <- Z_N^* and set G = enc(gamma; nu)
         let (G, nu) = loop {
-            let (G, nu) = self.aux_info_public.pk.encrypt(&gamma);
+            let (G, nu) = self.aux_info_public.pk.encrypt(&gamma)?;
 
             if !BigNumber::is_zero(&nu) {
                 break (G, nu);
@@ -997,8 +997,8 @@ impl PresignKeyShareAndInfo {
         let beta = random_bn_in_range(rng, ELL);
         let beta_hat = random_bn_in_range(rng, ELL);
 
-        let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(&beta);
-        let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(&beta_hat);
+        let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(&beta)?;
+        let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(&beta_hat)?;
 
         let D = receiver_aux_info
             .pk
@@ -1026,8 +1026,8 @@ impl PresignKeyShareAndInfo {
             )
             .ok_or(PaillierError::InvalidOperation)?;
 
-        let (F, r) = self.aux_info_public.pk.encrypt(&beta);
-        let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(&beta_hat);
+        let (F, r) = self.aux_info_public.pk.encrypt(&beta)?;
+        let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(&beta_hat)?;
 
         let g = CurvePoint::GENERATOR;
         let Gamma = CurvePoint(g.0 * bn_to_scalar(&sender_r1_priv.gamma)?);

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -123,8 +123,8 @@ impl Proof for PiAffgProof {
         // Sample beta from 2^{ELL_PRIME + EPSILON}.
         let beta = random_bn_in_range(rng, ELL_PRIME + EPSILON);
 
-        let r = random_bn_in_z_star(rng, &input.N0);
-        let r_y = random_bn_in_z_star(rng, &input.N1);
+        let r = random_bn_in_z_star(rng, &input.N0)?;
+        let r_y = random_bn_in_z_star(rng, &input.N1)?;
 
         // range_ell_eps = 2^{ELL + EPSILON} * N_hat
         let range_ell_eps = (BigNumber::one() << (ELL + EPSILON)) * &input.setup_params.N;
@@ -354,14 +354,14 @@ mod tests {
         let g = k256::ProjectivePoint::GENERATOR;
 
         let X = CurvePoint(g * utils::bn_to_scalar(x).unwrap());
-        let (Y, rho_y) = pk1.encrypt(y);
+        let (Y, rho_y) = pk1.encrypt(y)?;
 
         let N0_squared = &N0 * &N0;
         let C = crate::utils::random_positive_bn(&mut rng, &N0_squared);
 
         // Compute D = C^x * (1 + N0)^y rho^N0 (mod N0^2)
         let (D, rho) = {
-            let (D_intermediate, rho) = pk0.encrypt(y);
+            let (D_intermediate, rho) = pk0.encrypt(y)?;
             let D = modpow(&C, x, &N0_squared).modmul(&D_intermediate, &N0_squared);
             (D, rho)
         };

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -92,7 +92,7 @@ impl Proof for PiEncProof {
         let alpha = random_bn_in_range(rng, ELL + EPSILON);
 
         let mu = random_bn_in_range(rng, ELL) * &input.setup_params.N;
-        let r = random_bn_in_z_star(rng, &input.N0);
+        let r = random_bn_in_z_star(rng, &input.N0)?;
         let gamma = random_bn_in_range(rng, ELL + EPSILON) * &input.setup_params.N;
 
         let N0_squared = &input.N0 * &input.N0;
@@ -220,7 +220,7 @@ mod tests {
         let pk = decryption_key.encryption_key();
         let N = &p * &q;
 
-        let (K, rho) = pk.encrypt(k);
+        let (K, rho) = pk.encrypt(k)?;
         let setup_params = ZkSetupParameters::gen(&mut rng)?;
 
         let input = PiEncInput {

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -97,7 +97,7 @@ impl Proof for PiLogProof {
         // Sample alpha from 2^{ELL + EPSILON}
         let alpha = random_bn_in_range(rng, ELL + EPSILON);
 
-        let r = random_bn_in_z_star(rng, &input.N0);
+        let r = random_bn_in_z_star(rng, &input.N0)?;
 
         // range = 2^{ELL} * N_hat
         let range_ell = (BigNumber::one() << ELL) * &input.setup_params.N;
@@ -245,7 +245,7 @@ mod tests {
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
 
         let X = CurvePoint(g.0 * utils::bn_to_scalar(x).unwrap());
-        let (C, rho) = pk.encrypt(x);
+        let (C, rho) = pk.encrypt(x)?;
 
         let setup_params = ZkSetupParameters::gen(&mut rng)?;
 


### PR DESCRIPTION
Fix #41 

This adds error handling and, uh, correctness to drawing elements from `ZStar` (not a real type yet). 

Future design thought: The coprimality test we have now works for any modulus `N`, but we only call this function on Paillier encryption keys. Once all the ZKPs have encryption keys typed everywhere (instead of plain `BigNumber`s), we could change this function signature to take `n: PaillierEncryptionKey`. It would fit our use case but isn't required for the general definition.