### PR TITLE
Parameterize all random functions with an RNG

### DIFF
--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -13,7 +13,7 @@ use crate::{
     protocol::{Identifier, ParticipantIdentifier},
 };
 use merlin::Transcript;
-use rand::RngCore;
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,12 +40,12 @@ pub(crate) struct AuxInfoDecommit {
 }
 
 impl AuxInfoDecommit {
-    pub(crate) fn new(
+    pub(crate) fn new<R: RngCore + CryptoRng>(
+        rng: &mut R,
         sid: &Identifier,
         sender: &ParticipantIdentifier,
         pk: &AuxInfoPublic,
     ) -> Self {
-        let mut rng = rand::rngs::OsRng;
         let mut rid = [0u8; 32];
         let mut u_i = [0u8; 32];
         rng.fill_bytes(rid.as_mut_slice());

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -157,7 +157,7 @@ impl AuxInfoParticipant {
             &serialize!(&auxinfo_witnesses)?,
         )?;
 
-        let decom = AuxInfoDecommit::new(&message.id(), &self.id, &auxinfo_public);
+        let decom = AuxInfoDecommit::new(rng, &message.id(), &self.id, &auxinfo_public);
         let com = decom.commit()?;
         let com_bytes = &serialize!(&com)?;
 
@@ -525,10 +525,7 @@ fn new_auxinfo<R: RngCore + CryptoRng>(
 mod tests {
     use super::*;
     use crate::Identifier;
-    use rand::{
-        rngs::{OsRng, StdRng},
-        CryptoRng, Rng, RngCore, SeedableRng,
-    };
+    use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
 
     impl AuxInfoParticipant {
@@ -649,12 +646,7 @@ mod tests {
     }
     #[test]
     fn test_run_auxinfo_protocol() -> Result<()> {
-        let mut osrng = OsRng;
-        let seed = osrng.next_u64();
-        // uncomment this line to test a specific seed
-        // let seed: u64 = 14167330344348201948;
-        let mut rng = StdRng::seed_from_u64(seed);
-        println!("Initializing run with seed {}", seed);
+        let mut rng = crate::utils::get_test_rng();
         let mut quorum = AuxInfoParticipant::new_quorum(3, &mut rng)?;
         let mut inboxes = HashMap::new();
         let mut main_storages: Vec<Storage> = vec![];

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -15,7 +15,7 @@ use crate::{
     zkp::pisch::PiSchPrecommit,
 };
 use merlin::Transcript;
-use rand::RngCore;
+use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -45,13 +45,13 @@ pub(crate) struct KeygenDecommit {
 }
 
 impl KeygenDecommit {
-    pub(crate) fn new(
+    pub(crate) fn new<R: RngCore + CryptoRng>(
+        rng: &mut R,
         sid: &Identifier,
         sender: &ParticipantIdentifier,
         pk: &KeySharePublic,
         sch_precom: &PiSchPrecommit,
     ) -> Self {
-        let mut rng = rand::rngs::OsRng;
         let mut rid = [0u8; 32];
         let mut u_i = [0u8; 32];
         rng.fill_bytes(rid.as_mut_slice());

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -161,7 +161,8 @@ impl KeygenParticipant {
         // todo: maybe there should be a function for generating a PiSchInput
         let input = PiSchInput::new(&g, &q, &X);
         let sch_precom = PiSchProof::precommit(rng, &input)?;
-        let decom = KeygenDecommit::new(&message.id(), &self.id, &keyshare_public, &sch_precom);
+        let decom =
+            KeygenDecommit::new(rng, &message.id(), &self.id, &keyshare_public, &sch_precom);
         let com = decom.commit()?;
         let com_bytes = &serialize!(&com)?;
 
@@ -528,10 +529,7 @@ fn new_keyshare<R: RngCore + CryptoRng>(rng: &mut R) -> Result<(KeySharePrivate,
 mod tests {
     use super::*;
     use crate::Identifier;
-    use rand::{
-        rngs::{OsRng, StdRng},
-        CryptoRng, Rng, RngCore, SeedableRng,
-    };
+    use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
 
     impl KeygenParticipant {
@@ -647,12 +645,7 @@ mod tests {
     }
     #[test]
     fn test_run_keygen_protocol() -> Result<()> {
-        let mut osrng = OsRng;
-        let seed = osrng.next_u64();
-        // uncomment this line to test a specific seed
-        // let seed: u64 = 11129769151581080362;
-        let mut rng = StdRng::seed_from_u64(seed);
-        println!("Initializing run with seed {}", seed);
+        let mut rng = crate::utils::get_test_rng();
         let mut quorum = KeygenParticipant::new_quorum(3, &mut rng)?;
         let mut inboxes = HashMap::new();
         let mut main_storages: Vec<Storage> = vec![];

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -930,7 +930,7 @@ impl PresignKeyShareAndInfo {
 
         // Sample rho <- Z_N^* and set K = enc(k; rho)
         let (K, rho) = loop {
-            let (K, rho) = self.aux_info_public.pk.encrypt(&k)?;
+            let (K, rho) = self.aux_info_public.pk.encrypt(rng, &k)?;
             if !BigNumber::is_zero(&rho) {
                 break (K, rho);
             }
@@ -938,7 +938,7 @@ impl PresignKeyShareAndInfo {
 
         // Sample nu <- Z_N^* and set G = enc(gamma; nu)
         let (G, nu) = loop {
-            let (G, nu) = self.aux_info_public.pk.encrypt(&gamma)?;
+            let (G, nu) = self.aux_info_public.pk.encrypt(rng, &gamma)?;
 
             if !BigNumber::is_zero(&nu) {
                 break (G, nu);
@@ -997,8 +997,8 @@ impl PresignKeyShareAndInfo {
         let beta = random_bn_in_range(rng, ELL);
         let beta_hat = random_bn_in_range(rng, ELL);
 
-        let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(&beta)?;
-        let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(&beta_hat)?;
+        let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(rng, &beta)?;
+        let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(rng, &beta_hat)?;
 
         let D = receiver_aux_info
             .pk
@@ -1026,8 +1026,8 @@ impl PresignKeyShareAndInfo {
             )
             .ok_or(PaillierError::InvalidOperation)?;
 
-        let (F, r) = self.aux_info_public.pk.encrypt(&beta)?;
-        let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(&beta_hat)?;
+        let (F, r) = self.aux_info_public.pk.encrypt(rng, &beta)?;
+        let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(rng, &beta_hat)?;
 
         let g = CurvePoint::GENERATOR;
         let Gamma = CurvePoint(g.0 * bn_to_scalar(&sender_r1_priv.gamma)?);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -353,11 +353,7 @@ impl std::fmt::Display for Identifier {
 mod tests {
     use super::*;
     use k256::ecdsa::signature::DigestVerifier;
-    use rand::{
-        prelude::IteratorRandom,
-        rngs::{OsRng, StdRng},
-        SeedableRng,
-    };
+    use rand::seq::IteratorRandom;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
 
@@ -436,12 +432,7 @@ mod tests {
     #[cfg_attr(feature = "flame_it", flame)]
     #[test]
     fn test_run_protocol() -> Result<()> {
-        let mut osrng = OsRng;
-        let seed = osrng.next_u64();
-        // uncomment this line to test a specific seed
-        // let seed: u64 = 1707185616306954430;
-        let mut rng = StdRng::seed_from_u64(seed);
-        println!("Initializing run with seed {}", seed);
+        let mut rng = crate::utils::get_test_rng();
         let mut quorum = Participant::new_quorum(3, &mut rng)?;
         let mut inboxes = HashMap::new();
         for participant in &quorum {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -200,7 +200,6 @@ pub(crate) fn k256_order() -> BigNumber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::rngs::OsRng;
 
     #[test]
     fn test_random_bn_in_range() {
@@ -209,7 +208,7 @@ mod tests {
         let mut max_len = 0;
         let num_bytes = 100;
 
-        let mut rng = OsRng;
+        let mut rng = get_test_rng();
         for _ in 0..1000 {
             let bn = random_bn_in_range(&mut rng, num_bytes * 8);
             let len = bn.to_bytes().len();
@@ -309,4 +308,23 @@ pub(crate) fn process_ready_message(
     let is_ready = storage.contains_batch(&fetch).is_ok();
 
     Ok((messages, is_ready))
+}
+
+////////////////////////////
+// Test Utility Functions //
+////////////////////////////
+#[cfg(test)]
+use rand::{
+    rngs::{OsRng, StdRng},
+    SeedableRng,
+};
+/// Returns an rng to be used for testing. This will print the rng seed
+/// to stderr so that if a test fails, the failing seed can be recovered
+/// and used for debugging.
+#[cfg(test)]
+pub(crate) fn get_test_rng() -> StdRng {
+    let mut seeder = OsRng;
+    let seed = seeder.gen();
+    eprintln!("seed: {:?}", seed);
+    StdRng::from_seed(seed)
 }

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -429,32 +429,32 @@ mod tests {
     use crate::paillier::prime_gen;
 
     use super::*;
-    use rand::rngs::OsRng;
 
-    fn random_no_small_factors_proof() -> Result<(PiFacInput, PiFacProof)> {
-        let mut rng = OsRng;
-
-        let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
+    fn random_no_small_factors_proof<R: RngCore + CryptoRng>(
+        rng: &mut R,
+    ) -> Result<(PiFacInput, PiFacProof)> {
+        let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(rng).unwrap();
         let N0 = &p0 * &q0;
-        let setup_params = ZkSetupParameters::gen(&mut rng)?;
+        let setup_params = ZkSetupParameters::gen(rng)?;
 
         let input = PiFacInput::new(&setup_params, &N0);
-        let proof = PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&p0, &q0))?;
+        let proof = PiFacProof::prove(rng, &input, &PiFacSecret::new(&p0, &q0))?;
 
         Ok((input, proof))
     }
 
     #[test]
     fn test_no_small_factors_proof() -> Result<()> {
-        let (input, proof) = random_no_small_factors_proof()?;
+        let mut rng = crate::utils::get_test_rng();
+        let (input, proof) = random_no_small_factors_proof(&mut rng)?;
         proof.verify(&input)?;
         Ok(())
     }
 
     #[test]
     fn test_no_small_factors_proof_negative_cases() -> Result<()> {
-        let mut rng = OsRng;
-        let (input, proof) = random_no_small_factors_proof()?;
+        let mut rng = crate::utils::get_test_rng();
+        let (input, proof) = random_no_small_factors_proof(&mut rng)?;
 
         let incorrect_N = PiFacInput::new(
             &input.setup_params,
@@ -504,7 +504,7 @@ mod tests {
     // Make sure the bytes representations for BigNum and BigInt
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
-        let mut rng = OsRng;
+        let mut rng = crate::utils::get_test_rng();
         let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
 
         let num = &p0 * &q0;

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -154,27 +154,27 @@ mod tests {
     use crate::paillier::prime_gen;
 
     use super::*;
-    use rand::rngs::OsRng;
 
-    fn random_ring_pedersen_proof() -> Result<(PiPrmInput, PiPrmProof)> {
-        let mut rng = OsRng;
-        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
+    fn random_ring_pedersen_proof<R: RngCore + CryptoRng>(
+        rng: &mut R,
+    ) -> Result<(PiPrmInput, PiPrmProof)> {
+        let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(rng).unwrap();
         let N = &p * &q;
         let phi_n = (p - 1) * (q - 1);
-        let tau = BigNumber::from_rng(&N, &mut rng);
-        let lambda = BigNumber::from_rng(&phi_n, &mut rng);
+        let tau = BigNumber::from_rng(&N, rng);
+        let lambda = BigNumber::from_rng(&phi_n, rng);
         let t = modpow(&tau, &BigNumber::from(2), &N);
         let s = modpow(&t, &lambda, &N);
 
-        let mut rng = OsRng;
         let input = PiPrmInput::new(&N, &s, &t);
-        let proof = PiPrmProof::prove(&mut rng, &input, &PiPrmSecret::new(&lambda, &phi_n))?;
+        let proof = PiPrmProof::prove(rng, &input, &PiPrmSecret::new(&lambda, &phi_n))?;
         Ok((input, proof))
     }
 
     #[test]
     fn test_ring_pedersen_proof() -> Result<()> {
-        let (input, proof) = random_ring_pedersen_proof()?;
+        let mut rng = crate::utils::get_test_rng();
+        let (input, proof) = random_ring_pedersen_proof(&mut rng)?;
         proof.verify(&input)?;
 
         Ok(())
@@ -182,7 +182,8 @@ mod tests {
 
     #[test]
     fn test_ring_pedersen_proof_roundtrip() -> Result<()> {
-        let (_, proof) = random_ring_pedersen_proof()?;
+        let mut rng = crate::utils::get_test_rng();
+        let (_, proof) = random_ring_pedersen_proof(&mut rng)?;
         let buf = bincode::serialize(&proof).unwrap();
         let orig: PiPrmProof = bincode::deserialize(&buf).unwrap();
         assert_eq!(buf, bincode::serialize(&orig).unwrap());


### PR DESCRIPTION
This PR addresses #29 by modifying existing library functions so that every function which involves sampling values nondeterministically is parameterized with an rng to do this sampling. This also addresses #28 as the library itself should not call any of its own rngs, thus making tests deterministic once an rng is initialized.

More specifically, this PR adds a test-only function called `get_test_rng()` to utils.rs which samples a random seed, prints the seed to stderr, and returns an rng seeded with this seed. This function is called only once per test and is only called in functions with the `#[test]` decorator. 

To check that I covered all of the cases, I made sure OsRng and StdRng are not used anywhere in the library except for the  `get_test_rng()` function, and I also made sure every function with the substring "rand" has an rng argument (except for transcript-related functions, which deterministically sample randomness from transcripts).