### PR TITLE
Update soundness parameter to 80

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -59,7 +59,4 @@ pub(crate) const PRIME_BITS: usize = 1024;
 
 /// Number of repetitions required for statistical security in proofs that allow an adversary to
 /// guess a challenge value correctly with probability 1/2.
-///
-/// Historical documentation note without a verified source:
-/// > Needs to be a multiple of 8 for Pi_prm
-pub(crate) const SOUNDNESS_PARAMETER: usize = 8;
+pub(crate) const SOUNDNESS_PARAMETER: usize = 80;


### PR DESCRIPTION
Fixes #73

This PR updates the soundness parameter from 8 to 80. 

This caused a small issue with `PiPrm`, which previously held its arrays of values in fixed-length arrays. I found that serde's derivable `Deserialize` can [only handle tuples up to length 32](https://docs.rs/serde/latest/serde/trait.Deserialize.html#impl-Deserialize%3C%27de%3E-for-%5BT%3B%200%5D). To accommodate this, I switched the representation to a `Vec` with appropriate length checks. Since this required some inline changes, I also took the time to fix non-idomatic code that generates those values (switching from loops over mutable `Vec`s to iterators). These tasks were originally assigned to #51; I've checked off the boxes in there that I did here. The functional code stays the same -- it's just the loop structure that is different.

`PiMod` already used `Vec`s to hold its proof items. Related issue: #72.

Benchmark results are in the Bolt-private document "Soundness parameter benchmark"; the highlight is that this causes aux-info to take about twice as long (from ~2.4 seconds to ~4.5 seconds).

Review requests: nothing particularly special, would appreciate an eye over the iterators to make sure I didn't change any functional code.