### PR TITLE
Remove remaining asserts from library code

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -49,6 +49,8 @@ pub enum InternalError {
     CouldNotInvertScalar,
     #[error("Reached the maximum allowed number of retries")]
     RetryFailed,
+    #[error("This Participant was given a message intended for somebody else")]
+    WrongMessageRecipient,
 }
 
 macro_rules! serialize {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -367,8 +367,6 @@ impl PresignParticipant {
             auxinfo_identifier,
         )?;
 
-        assert_eq!(message.to(), self.id);
-
         // Find the keyshare corresponding to the "from" participant
         let keyshare_from = other_public_keyshares.get(&message.from()).ok_or_else(|| {
             bail_context!("Could not find corresponding public keyshare for participant in round 2")
@@ -472,12 +470,14 @@ impl PresignParticipant {
         // Since we are in round 2, it should certainly be the case that all
         // public auxinfo for other participants have been stored, since
         // this was a requirement to proceed for round 1.
-        assert!(has_collected_all_of_others(
+        if !has_collected_all_of_others(
             &self.other_participant_ids,
             main_storage,
             StorableType::AuxInfoPublic,
-            auxinfo_identifier
-        )?);
+            auxinfo_identifier,
+        )? {
+            return Err(InternalInvariantFailed);
+        }
 
         // Check if storage has all of the other participants' round 2 values (both
         // private and public), and start generating the messages for round 3 if so

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     auxinfo::participant::AuxInfoParticipant,
-    errors::Result,
+    errors::{InternalError, Result},
     keygen::{keyshare::KeySharePublic, participant::KeygenParticipant},
     messages::{AuxinfoMessageType, KeygenMessageType, MessageType},
     presign::{participant::PresignParticipant, record::PresignRecord},
@@ -99,6 +99,9 @@ impl Participant {
         message: &Message,
         rng: &mut R,
     ) -> Result<Vec<Message>> {
+        if message.to() != self.id {
+            return Err(InternalError::WrongMessageRecipient);
+        }
         match message.message_type() {
             MessageType::Auxinfo(_) => {
                 self.auxinfo_participant


### PR DESCRIPTION
This PR addresses #57 by removing the remaining asserts from the main library (there weren't many left). There was an assert check that message.to() == self.id in one of the subprotocols, so I moved it to the top level process_single_message() function. 