### PR TITLE
Use `PaillierCiphertext` in `encrypt` and `decrypt`

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -50,7 +50,7 @@ impl PaillierEncryptionKey {
         &self,
         rng: &mut R,
         x: &BigNumber,
-    ) -> Result<(BigNumber, BigNumber)> {
+    ) -> Result<(PaillierCiphertext, BigNumber)> {
         let nonce = random_bn_in_z_star(rng, self.0.n())?;
 
         let one = BigNumber::one();
@@ -58,7 +58,7 @@ impl PaillierEncryptionKey {
         let a = base.modpow(x, self.0.nn());
         let b = nonce.modpow(self.n(), self.0.nn());
         let c = a.modmul(&b, self.0.nn());
-        Ok((c, nonce))
+        Ok((PaillierCiphertext(c), nonce))
     }
 }
 
@@ -66,8 +66,11 @@ impl PaillierEncryptionKey {
 pub(crate) struct PaillierDecryptionKey(libpaillier::DecryptionKey);
 
 impl PaillierDecryptionKey {
-    pub(crate) fn decrypt(&self, c: &BigNumber) -> Result<Vec<u8>> {
-        Ok(self.0.decrypt(c).ok_or(PaillierError::DecryptionFailed)?)
+    pub(crate) fn decrypt(&self, c: &PaillierCiphertext) -> Result<Vec<u8>> {
+        Ok(self
+            .0
+            .decrypt(&c.0)
+            .ok_or(PaillierError::DecryptionFailed)?)
     }
 
     /// Generate a new [`PaillierDecryptionKey`] and its factors.

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -363,13 +363,13 @@ mod tests {
         // Compute D = C^x * (1 + N0)^y rho^N0 (mod N0^2)
         let (D, rho) = {
             let (D_intermediate, rho) = pk0.encrypt(rng, y)?;
-            let D = modpow(&C, x, &N0_squared).modmul(&D_intermediate, &N0_squared);
+            let D = modpow(&C, x, &N0_squared).modmul(&D_intermediate.0, &N0_squared);
             (D, rho)
         };
 
         let setup_params = ZkSetupParameters::gen(rng)?;
 
-        let input = PiAffgInput::new(&setup_params, &CurvePoint(g), &N0, &N1, &C, &D, &Y, &X);
+        let input = PiAffgInput::new(&setup_params, &CurvePoint(g), &N0, &N1, &C, &D, &Y.0, &X);
         let proof = PiAffgProof::prove(rng, &input, &PiAffgSecret::new(x, y, &rho, &rho_y))?;
 
         proof.verify(&input)

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -226,7 +226,7 @@ mod tests {
         let input = PiEncInput {
             setup_params,
             N0: N,
-            K: PaillierCiphertext(K),
+            K,
         };
 
         let proof = PiEncProof::prove(rng, &input, &PiEncSecret { k: k.clone(), rho })?;

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -246,7 +246,14 @@ mod tests {
 
         let setup_params = ZkSetupParameters::gen(rng)?;
 
-        let input = PiLogInput::new(&setup_params, &crate::utils::k256_order(), &N0, &C, &X, &g);
+        let input = PiLogInput::new(
+            &setup_params,
+            &crate::utils::k256_order(),
+            &N0,
+            &C.0,
+            &X,
+            &g,
+        );
 
         let proof = PiLogProof::prove(rng, &input, &PiLogSecret::new(x, &rho))?;
 


### PR DESCRIPTION
This PR swaps out the use of `BigNumber` in `PaillierEncryptionKey::encrypt` and `PaillierDecryptionKey::decrypt` with `PaillierCiphertext`. Right now `PaillierCiphertext` is a thin wrapper around `BigNumber`, but future work will aim to hide that behind a cleaner interface.

This is work towards addressing Issue #59.