### PR TITLE
Use `PaillierCiphertext` in ZKPs

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -39,7 +39,7 @@ impl From<PaillierError> for InternalError {
 pub(crate) struct PaillierCiphertext(pub(crate) BigNumber);
 
 impl PaillierCiphertext {
-    /// Converts a [PaillierCiphertext] into its big-endian byte representation.
+    /// Converts a [`PaillierCiphertext`] into its big-endian byte representation.
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -38,6 +38,13 @@ impl From<PaillierError> for InternalError {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierCiphertext(pub(crate) BigNumber);
 
+impl PaillierCiphertext {
+    /// Converts a [PaillierCiphertext] into its big-endian byte representation.
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierEncryptionKey(pub(crate) libpaillier::EncryptionKey);
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1011,6 +1011,7 @@ impl PresignKeyShareAndInfo {
                     .ok_or(PaillierError::InvalidOperation)?,
                 &beta_ciphertext.0,
             )
+            .map(|D| PaillierCiphertext(D))
             .ok_or(PaillierError::InvalidOperation)?;
 
         let D_hat = receiver_aux_info
@@ -1024,6 +1025,7 @@ impl PresignKeyShareAndInfo {
                     .ok_or(PaillierError::InvalidOperation)?,
                 &beta_hat_ciphertext.0,
             )
+            .map(|D_hat| PaillierCiphertext(D_hat))
             .ok_or(PaillierError::InvalidOperation)?;
 
         let (F, r) = self.aux_info_public.pk.encrypt(rng, &beta)?;
@@ -1041,9 +1043,9 @@ impl PresignKeyShareAndInfo {
                 &g,
                 receiver_aux_info.pk.n(),
                 self.aux_info_public.pk.n(),
-                &receiver_r1_pub_broadcast.K.0,
+                &receiver_r1_pub_broadcast.K,
                 &D,
-                &F.0,
+                &F,
                 &Gamma,
             ),
             &PiAffgSecret::new(&sender_r1_priv.gamma, &beta, &s, &r),
@@ -1056,9 +1058,9 @@ impl PresignKeyShareAndInfo {
                 &g,
                 receiver_aux_info.pk.n(),
                 self.aux_info_public.pk.n(),
-                &receiver_r1_pub_broadcast.K.0,
+                &receiver_r1_pub_broadcast.K,
                 &D_hat,
-                &F_hat.0,
+                &F_hat,
                 &self.keyshare_public.X,
             ),
             &PiAffgSecret::new(&self.keyshare_private.x, &beta_hat, &s_hat, &r_hat),
@@ -1070,7 +1072,7 @@ impl PresignKeyShareAndInfo {
                 &receiver_aux_info.params,
                 &k256_order(),
                 self.aux_info_public.pk.n(),
-                &sender_r1_priv.G.0,
+                &sender_r1_priv.G,
                 &Gamma,
                 &g,
             ),
@@ -1080,8 +1082,8 @@ impl PresignKeyShareAndInfo {
         Ok((
             RoundTwoPrivate { beta, beta_hat },
             RoundTwoPublic {
-                D: PaillierCiphertext(D),
-                D_hat: PaillierCiphertext(D_hat),
+                D,
+                D_hat,
                 F,
                 F_hat,
                 Gamma,
@@ -1141,7 +1143,7 @@ impl PresignKeyShareAndInfo {
                     &round_three_input.auxinfo_public.params,
                     &order,
                     self.aux_info_public.pk.n(),
-                    &sender_r1_priv.K.0,
+                    &sender_r1_priv.K,
                     &Delta,
                     &Gamma,
                 ),

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1011,7 +1011,7 @@ impl PresignKeyShareAndInfo {
                     .ok_or(PaillierError::InvalidOperation)?,
                 &beta_ciphertext.0,
             )
-            .map(|D| PaillierCiphertext(D))
+            .map(PaillierCiphertext)
             .ok_or(PaillierError::InvalidOperation)?;
 
         let D_hat = receiver_aux_info
@@ -1025,7 +1025,7 @@ impl PresignKeyShareAndInfo {
                     .ok_or(PaillierError::InvalidOperation)?,
                 &beta_hat_ciphertext.0,
             )
-            .map(|D_hat| PaillierCiphertext(D_hat))
+            .map(PaillierCiphertext)
             .ok_or(PaillierError::InvalidOperation)?;
 
         let (F, r) = self.aux_info_public.pk.encrypt(rng, &beta)?;

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -54,7 +54,7 @@ impl Public {
             &receiver_keygen_public.params,
             &k256_order(),
             sender_keygen_public.pk.n(),
-            &sender_r1_public_broadcast.K.0,
+            &sender_r1_public_broadcast.K,
             &self.Delta,
             &self.Gamma,
         );

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -59,9 +59,9 @@ impl Public {
             &g,
             receiver_auxinfo_public.pk.n(),
             sender_auxinfo_public.pk.n(),
-            &receiver_r1_private.K.0,
-            &self.D.0,
-            &self.F.0,
+            &receiver_r1_private.K,
+            &self.D,
+            &self.F,
             &self.Gamma,
         );
         self.psi.verify(&psi_input)?;
@@ -72,9 +72,9 @@ impl Public {
             &g,
             receiver_auxinfo_public.pk.n(),
             sender_auxinfo_public.pk.n(),
-            &receiver_r1_private.K.0,
-            &self.D_hat.0,
-            &self.F_hat.0,
+            &receiver_r1_private.K,
+            &self.D_hat,
+            &self.F_hat,
             &sender_keyshare_public.X,
         );
         self.psi_hat.verify(&psi_hat_input)?;
@@ -84,7 +84,7 @@ impl Public {
             &receiver_auxinfo_public.params,
             &k256_order(),
             sender_auxinfo_public.pk.n(),
-            &sender_r1_public_broadcast.G.0,
+            &sender_r1_public_broadcast.G,
             &self.Gamma,
             &g,
         );

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct PiEncProof {
     alpha: BigNumber,
     S: BigNumber,
-    A: BigNumber,
+    A: PaillierCiphertext,
     C: BigNumber,
     e: BigNumber,
     z1: BigNumber,
@@ -105,7 +105,7 @@ impl Proof for PiEncProof {
         let A = {
             let a = modpow(&(&BigNumber::one() + &input.N0), &alpha, &N0_squared);
             let b = modpow(&r, &input.N0, &N0_squared);
-            a.modmul(&b, &N0_squared)
+            PaillierCiphertext(a.modmul(&b, &N0_squared))
         };
         let C = {
             let a = modpow(&input.setup_params.s, &alpha, &input.setup_params.N);
@@ -176,6 +176,7 @@ impl Proof for PiEncProof {
             let lhs = a.modmul(&b, &N0_squared);
             let rhs = self
                 .A
+                .0
                 .modmul(&modpow(&input.K.0, &e, &N0_squared), &N0_squared);
             lhs == rhs
         };


### PR DESCRIPTION
This commit replaces the use of `BigNumber` with `PaillierCiphertext` where needed in the ZKPs. It also adds a `to_bytes` method to `PaillierCiphertext` to avoid needing to explicitly call the `BigNumber::to_bytes` method. Further hiding of the underlying `BigNumber` value will be made once Issue #64 is addressed.

Closes #63.