### PR TITLE
Add `PaillierNonce` wrapper to API

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -35,6 +35,10 @@ impl From<PaillierError> for InternalError {
     }
 }
 
+/// A nonce generated as part of [PaillierEncryptionKey::encrypt].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct PaillierNonce(pub(crate) BigNumber);
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierCiphertext(pub(crate) BigNumber);
 
@@ -57,7 +61,7 @@ impl PaillierEncryptionKey {
         &self,
         rng: &mut R,
         x: &BigNumber,
-    ) -> Result<(PaillierCiphertext, BigNumber)> {
+    ) -> Result<(PaillierCiphertext, PaillierNonce)> {
         let nonce = random_bn_in_z_star(rng, self.0.n())?;
 
         let one = BigNumber::one();
@@ -65,7 +69,7 @@ impl PaillierEncryptionKey {
         let a = base.modpow(x, self.0.nn());
         let b = nonce.modpow(self.n(), self.0.nn());
         let c = a.modmul(&b, self.0.nn());
-        Ok((PaillierCiphertext(c), nonce))
+        Ok((PaillierCiphertext(c), PaillierNonce(nonce)))
     }
 }
 

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -37,7 +37,14 @@ impl From<PaillierError> for InternalError {
 
 /// A nonce generated as part of [`PaillierEncryptionKey::encrypt()`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct PaillierNonce(pub(crate) BigNumber);
+pub(crate) struct PaillierNonce(BigNumber);
+
+impl PaillierNonce {
+    /// Extracts the nonce as a [`BigNumber`].
+    pub(crate) fn inner(&self) -> &BigNumber {
+        &self.0
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierCiphertext(pub(crate) BigNumber);

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -36,6 +36,8 @@ impl From<PaillierError> for InternalError {
 }
 
 /// A nonce generated as part of [`PaillierEncryptionKey::encrypt()`].
+/// A nonce is drawn from the multiplicative group of integers modulo `n`, where `n`
+/// is the modulus from the associated [`PaillierEncryptionKey`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierNonce(BigNumber);
 

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -35,7 +35,7 @@ impl From<PaillierError> for InternalError {
     }
 }
 
-/// A nonce generated as part of [PaillierEncryptionKey::encrypt].
+/// A nonce generated as part of [`PaillierEncryptionKey::encrypt()`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PaillierNonce(pub(crate) BigNumber);
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -929,21 +929,9 @@ impl PresignKeyShareAndInfo {
         let gamma = random_positive_bn(rng, &order);
 
         // Sample rho <- Z_N^* and set K = enc(k; rho)
-        let (K, rho) = loop {
-            let (K, rho) = self.aux_info_public.pk.encrypt(rng, &k)?;
-            if !BigNumber::is_zero(&rho) {
-                break (K, rho);
-            }
-        };
-
+        let (K, rho) = self.aux_info_public.pk.encrypt(rng, &k)?;
         // Sample nu <- Z_N^* and set G = enc(gamma; nu)
-        let (G, nu) = loop {
-            let (G, nu) = self.aux_info_public.pk.encrypt(rng, &gamma)?;
-
-            if !BigNumber::is_zero(&nu) {
-                break (G, nu);
-            }
-        };
+        let (G, nu) = self.aux_info_public.pk.encrypt(rng, &gamma)?;
 
         let mut r1_publics = HashMap::new();
         for (id, aux_info_public) in public_keys {

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -10,7 +10,7 @@ use crate::{
     auxinfo::info::AuxInfoPublic,
     errors::Result,
     messages::{Message, MessageType, PresignMessageType},
-    paillier::PaillierCiphertext,
+    paillier::{PaillierCiphertext, PaillierNonce},
     zkp::{pienc::PiEncProof, setup::ZkSetupParameters, Proof},
 };
 use libpaillier::unknown_order::BigNumber;
@@ -19,9 +19,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Private {
     pub k: BigNumber,
-    pub rho: BigNumber,
+    pub rho: PaillierNonce,
     pub gamma: BigNumber,
-    pub nu: BigNumber,
+    pub nu: PaillierNonce,
     pub G: PaillierCiphertext, // Technically can be public but is only one per party
     pub K: PaillierCiphertext, // Technically can be public but is only one per party
 }

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -15,6 +15,7 @@ use super::Proof;
 use crate::{
     errors::*,
     paillier::PaillierCiphertext,
+    paillier::PaillierNonce,
     parameters::{ELL, ELL_PRIME, EPSILON},
     utils::{
         self, k256_order, modpow, plusminus_bn_random_from_transcript, random_bn_in_range,
@@ -88,12 +89,17 @@ impl PiAffgInput {
 pub(crate) struct PiAffgSecret {
     x: BigNumber,
     y: BigNumber,
-    rho: BigNumber,
-    rho_y: BigNumber,
+    rho: PaillierNonce,
+    rho_y: PaillierNonce,
 }
 
 impl PiAffgSecret {
-    pub(crate) fn new(x: &BigNumber, y: &BigNumber, rho: &BigNumber, rho_y: &BigNumber) -> Self {
+    pub(crate) fn new(
+        x: &BigNumber,
+        y: &BigNumber,
+        rho: &PaillierNonce,
+        rho_y: &PaillierNonce,
+    ) -> Self {
         Self {
             x: x.clone(),
             y: y.clone(),
@@ -199,8 +205,8 @@ impl Proof for PiAffgProof {
         let z2 = &beta + &e * &secret.y;
         let z3 = gamma + &e * m;
         let z4 = delta + &e * mu;
-        let w = r.modmul(&modpow(&secret.rho, &e, &input.N0), &input.N0);
-        let w_y = r_y.modmul(&modpow(&secret.rho_y, &e, &input.N1), &input.N1);
+        let w = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
+        let w_y = r_y.modmul(&modpow(&secret.rho_y.0, &e, &input.N1), &input.N1);
 
         let proof = Self {
             alpha,

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -205,8 +205,8 @@ impl Proof for PiAffgProof {
         let z2 = &beta + &e * &secret.y;
         let z3 = gamma + &e * m;
         let z4 = delta + &e * mu;
-        let w = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
-        let w_y = r_y.modmul(&modpow(&secret.rho_y.0, &e, &input.N1), &input.N1);
+        let w = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
+        let w_y = r_y.modmul(&modpow(secret.rho_y.inner(), &e, &input.N1), &input.N1);
 
         let proof = Self {
             alpha,

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -14,7 +14,7 @@
 use super::Proof;
 use crate::{
     errors::*,
-    paillier::PaillierCiphertext,
+    paillier::{PaillierCiphertext, PaillierNonce},
     parameters::{ELL, EPSILON},
     utils::{
         k256_order, modpow, plusminus_bn_random_from_transcript, random_bn_in_range,
@@ -62,11 +62,11 @@ impl PiEncInput {
 
 pub(crate) struct PiEncSecret {
     k: BigNumber,
-    rho: BigNumber,
+    rho: PaillierNonce,
 }
 
 impl PiEncSecret {
-    pub(crate) fn new(k: &BigNumber, rho: &BigNumber) -> Self {
+    pub(crate) fn new(k: &BigNumber, rho: &PaillierNonce) -> Self {
         Self {
             k: k.clone(),
             rho: rho.clone(),
@@ -129,7 +129,7 @@ impl Proof for PiEncProof {
         );
 
         let z1 = &alpha + &e * &secret.k;
-        let z2 = r.modmul(&modpow(&secret.rho, &e, &input.N0), &input.N0);
+        let z2 = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
         let z3 = gamma + &e * mu;
 
         let proof = Self {

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -129,7 +129,7 @@ impl Proof for PiEncProof {
         );
 
         let z1 = &alpha + &e * &secret.k;
-        let z2 = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
+        let z2 = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
         let z3 = gamma + &e * mu;
 
         let proof = Self {

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -139,7 +139,7 @@ impl Proof for PiLogProof {
         let e = plusminus_bn_random_from_transcript(&mut transcript, &input.q);
 
         let z1 = &alpha + &e * &secret.x;
-        let z2 = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
+        let z2 = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
         let z3 = gamma + &e * mu;
 
         let proof = Self {

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -12,6 +12,7 @@ use super::Proof;
 use crate::{
     errors::*,
     paillier::PaillierCiphertext,
+    paillier::PaillierNonce,
     parameters::{ELL, EPSILON},
     utils::{
         self, modpow, plusminus_bn_random_from_transcript, random_bn_in_range, random_bn_in_z_star,
@@ -70,11 +71,11 @@ impl PiLogInput {
 
 pub(crate) struct PiLogSecret {
     x: BigNumber,
-    rho: BigNumber,
+    rho: PaillierNonce,
 }
 
 impl PiLogSecret {
-    pub(crate) fn new(x: &BigNumber, rho: &BigNumber) -> Self {
+    pub(crate) fn new(x: &BigNumber, rho: &PaillierNonce) -> Self {
         Self {
             x: x.clone(),
             rho: rho.clone(),
@@ -138,7 +139,7 @@ impl Proof for PiLogProof {
         let e = plusminus_bn_random_from_transcript(&mut transcript, &input.q);
 
         let z1 = &alpha + &e * &secret.x;
-        let z2 = r.modmul(&modpow(&secret.rho, &e, &input.N0), &input.N0);
+        let z2 = r.modmul(&modpow(&secret.rho.0, &e, &input.N0), &input.N0);
         let z3 = gamma + &e * mu;
 
         let proof = Self {


### PR DESCRIPTION
This PR adds a `PaillierNonce` type which wraps a `BigNumber`, and utilizes this new type where needed in the various ZKPs. The PR also removes an unnecessary check that the generated nonce is non-zero (the check is unnecessary as we already to such a check during nonce generation).

Like with the previous PRs around adding these wrapper types, we do need to add a bunch of `.0`s to make things work. Going forward these will be removed when we start hiding the visibility of the underlying `BigNumber` type.

Closes #62. Once #40 is complete we can swap out the underlying `BigNumber` with `ZStarN`.