### PR TITLE
Add `encrypt_with_nonce` method to `PaillierEncryptionKey`

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -96,13 +96,22 @@ impl PaillierEncryptionKey {
             })?
         }
         let nonce = random_bn_in_z_star(rng, self.n())?;
+        let c = self.encrypt_with_nonce(x, &nonce)?;
+        Ok((c, PaillierNonce(nonce)))
+    }
 
+    /// Encrypt plaintext `x` using the provided `nonce`, producing the resulting Paillier ciphertext.
+    pub(crate) fn encrypt_with_nonce(
+        &self,
+        x: &BigNumber,
+        nonce: &BigNumber,
+    ) -> Result<PaillierCiphertext> {
         let one = BigNumber::one();
         let base = one + self.n();
         let a = base.modpow(x, self.0.nn());
         let b = nonce.modpow(self.n(), self.0.nn());
         let c = a.modmul(&b, self.0.nn());
-        Ok((PaillierCiphertext(c), PaillierNonce(nonce)))
+        Ok(PaillierCiphertext(c))
     }
 
     /// Masks a [`PaillierNonce`] `nonce` with another [`PaillierNonce`] `mask` and exponent `e`

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -160,15 +160,10 @@ impl Proof for PiEncProof {
             return verify_err!("Fiat-Shamir didn't verify");
         }
 
-        let N0 = input.pk.n();
-        let N0_squared = input.pk.n() * input.pk.n();
-
         // Do equality checks
 
         let eq_check_1 = {
-            let a = modpow(&(&BigNumber::one() + N0), &self.z1, &N0_squared);
-            let b = modpow(&self.z2.0, N0, &N0_squared);
-            let lhs = PaillierCiphertext(a.modmul(&b, &N0_squared));
+            let lhs = input.pk.encrypt_with_nonce(&self.z1, &self.z2)?;
             let rhs = input.pk.multiply_and_add(&e, &input.K, &self.A)?;
             lhs == rhs
         };

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -171,15 +171,10 @@ impl Proof for PiLogProof {
             return verify_err!("Fiat-Shamir consistency check failed");
         }
 
-        let N0 = input.pk.n();
-        let N0_squared = input.pk.n() * input.pk.n();
-
         // Do equality checks
 
         let eq_check_1 = {
-            let a = modpow(&(BigNumber::one() + N0), &self.z1, &N0_squared);
-            let b = modpow(&self.z2.0, N0, &N0_squared);
-            let lhs = PaillierCiphertext(a.modmul(&b, &N0_squared));
+            let lhs = input.pk.encrypt_with_nonce(&self.z1, &self.z2)?;
             let rhs = input.pk.multiply_and_add(&self.e, &input.C, &self.A)?;
             lhs == rhs
         };


### PR DESCRIPTION
This PR adds an `encrypt_with_nonce` method to `PaillierEncryptionKey`, allowing one to either generate a new (ciphertext, nonce) tuple using `encrypt`, or generate a ciphertext that results from a given (plaintext, nonce) tuple using `encrypt_with_nonce`.

Currently, `encrypt_with_nonce` is only used internally. The plan is to use it in the ZKPs that currently do the encryption "by hand" (e.g., [here](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/zkp/pilog.rs#L117)). However, that will require a bigger change to pass the `PaillierEncryptionKey` to the ZKPs rather than the particular modulus `N` (e.g., we'll need to replace `N0: BigNumber` [here](https://github.com/boltlabs-inc/tss-ecdsa/blob/main/src/zkp/pilog.rs#L44) with `pk: PallierEncryptionKey`), so I'll leave that change to another issue (if this approach looks good).

Closes #99.