### PR TITLE
remove commented-out dead PiMod code

### DIFF
--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -48,8 +48,6 @@ impl ZkSetupParameters {
         let t = tau.modpow(&BigNumber::from(2), N);
         let s = t.modpow(&lambda, N);
 
-        //let pimod = PiModProof::prove(rng, &PiModInput::new(N), &PiModSecret::new(p,
-        // q))?;
         let piprm = PiPrmProof::prove(
             rng,
             &PiPrmInput::new(N, &s, &t),
@@ -60,13 +58,11 @@ impl ZkSetupParameters {
             N: N.clone(),
             s,
             t,
-            //pimod,
             piprm,
         })
     }
 
     pub(crate) fn verify(&self) -> Result<()> {
-        //self.pimod.verify(&PiModInput::new(&self.N))?;
         self.piprm
             .verify(&PiPrmInput::new(&self.N, &self.s, &self.t))?;
         Ok(())


### PR DESCRIPTION
Closes #42

This issue was listed as a bug because I thought that the `PiMod` proof may have been removed entirely at some point (because it was commented out). Luckily, it was not removed, just moved to the correct point in the protocol (round 3, where it's supposed to live, vs round 1, where the `ZkSetupParameters` are made). I read through the protocol description and the code and everything seems to be in the correct place.