### PR TITLE
Fix tiny bounds-sampling bugs and adjust sampling calls

### DIFF
--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -31,7 +31,7 @@ use crate::{
     storage::{StorableType, Storage},
     utils::{
         bn_to_scalar, get_other_participants_public_auxinfo, has_collected_all_of_others,
-        k256_order, process_ready_message, random_bn_in_range, random_positive_bn,
+        k256_order, process_ready_message, random_plusminus_by_size, random_positive_bn,
     },
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof, PiAffgSecret},
@@ -982,8 +982,8 @@ impl PresignKeyShareAndInfo {
         // Picking betas as elements of [+- 2^384] here is like sampling them from the
         // distribution [1, 2^256], which is akin to 2^{ell + epsilon} where ell
         // = epsilon = 384. Note that we need q/2^epsilon to be negligible.
-        let beta = random_bn_in_range(rng, ELL);
-        let beta_hat = random_bn_in_range(rng, ELL);
+        let beta = random_plusminus_by_size(rng, ELL);
+        let beta_hat = random_plusminus_by_size(rng, ELL);
 
         let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(rng, &beta)?;
         let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(rng, &beta_hat)?;


### PR DESCRIPTION
Closes #85 

This fixes a couple of little bugs around sampling. In one or two places, the ranges we sampled from weren't quite correct. A range used for testing only was not correct. And the general plus/minus range sampling was off by one.

I also made a couple of quality-of-life improvements, including adjusting the names of the sampling functions (open to alternate suggestions if you don't like these changes) and adding another convenience function for a common sampling format.

This review is kind of detail-oriented because there are so many little ranges. I would prefer a focus on making sure that the changes don't change anything in the code (beyond the bugs noted inline). Don't worry about comparing to the paper -- I did this as I went, but I think we can re-audit that as we do the code-quality checks on each ZKP.