### PR TITLE
Add tests for Paillier encryption and decryption

### DIFF
--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1108,9 +1108,8 @@ impl PresignKeyShareAndInfo {
             let r2_pub_j = round_three_input.r2_public.clone();
             let r2_priv_j = round_three_input.r2_private.clone();
 
-            let alpha = BigNumber::from_slice(self.aux_info_private.sk.decrypt(&r2_pub_j.D)?);
-            let alpha_hat =
-                BigNumber::from_slice(self.aux_info_private.sk.decrypt(&r2_pub_j.D_hat)?);
+            let alpha = self.aux_info_private.sk.decrypt(&r2_pub_j.D)?;
+            let alpha_hat = self.aux_info_private.sk.decrypt(&r2_pub_j.D_hat)?;
 
             delta = delta.modadd(&alpha.modsub(&r2_priv_j.beta, &order), &order);
             chi = chi.modadd(&alpha_hat.modsub(&r2_priv_j.beta_hat, &order), &order);


### PR DESCRIPTION
Closes #100. Closes #101.

This adds some fairly standard tests for Paillier encryption + decryption.

It also addresses something I'm not sure is a practical issue: the paper says
> We represent integers modulo N in the interval {−N/2, . . . , N/2} (rather than the canonical representation); this convention is crucial to the security analysis.

I'm not sure if this is also crucial to the _practical_ security of the library, but we encrypt a lot of things drawn from a range like `+/- 2^ell`. I wanted some kind of bounds check on encrypted messages, so I check that they're in the `[-N/2, N/2]` range. Then, to make decryption correct in the most reasonable way, I convert the output from the default canonical representation `[0, N)` to the range used in the protocol.

