### PR TITLE
Replace `N0: BigNumber` with `pk: PaillierEncryptionKey` in ZKPs.

### DIFF
--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -940,7 +940,7 @@ impl PresignKeyShareAndInfo {
                 rng,
                 &crate::zkp::pienc::PiEncInput::new(
                     &aux_info_public.params,
-                    self.aux_info_public.pk.n(),
+                    &self.aux_info_public.pk,
                     &K.clone(),
                 ),
                 &crate::zkp::pienc::PiEncSecret::new(&k, &rho),
@@ -1059,7 +1059,7 @@ impl PresignKeyShareAndInfo {
             &PiLogInput::new(
                 &receiver_aux_info.params,
                 &k256_order(),
-                self.aux_info_public.pk.n(),
+                &self.aux_info_public.pk,
                 &sender_r1_priv.G,
                 &Gamma,
                 &g,
@@ -1130,7 +1130,7 @@ impl PresignKeyShareAndInfo {
                 &PiLogInput::new(
                     &round_three_input.auxinfo_public.params,
                     &order,
-                    self.aux_info_public.pk.n(),
+                    &self.aux_info_public.pk,
                     &sender_r1_priv.K,
                     &Delta,
                     &Gamma,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1029,8 +1029,8 @@ impl PresignKeyShareAndInfo {
             &PiAffgInput::new(
                 &receiver_aux_info.params,
                 &g,
-                receiver_aux_info.pk.n(),
-                self.aux_info_public.pk.n(),
+                &receiver_aux_info.pk,
+                &self.aux_info_public.pk,
                 &receiver_r1_pub_broadcast.K,
                 &D,
                 &F,
@@ -1044,8 +1044,8 @@ impl PresignKeyShareAndInfo {
             &PiAffgInput::new(
                 &receiver_aux_info.params,
                 &g,
-                receiver_aux_info.pk.n(),
-                self.aux_info_public.pk.n(),
+                &receiver_aux_info.pk,
+                &self.aux_info_public.pk,
                 &receiver_r1_pub_broadcast.K,
                 &D_hat,
                 &F_hat,

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -10,7 +10,7 @@ use crate::{
     auxinfo::info::AuxInfoPublic,
     errors::Result,
     messages::{Message, MessageType, PresignMessageType},
-    paillier::{PaillierCiphertext, PaillierNonce},
+    paillier::{PaillierCiphertext, PaillierEncryptionKey, PaillierNonce},
     zkp::{pienc::PiEncProof, setup::ZkSetupParameters, Proof},
 };
 use libpaillier::unknown_order::BigNumber;
@@ -43,12 +43,12 @@ impl Public {
     fn verify(
         &self,
         receiver_setup_params: &ZkSetupParameters,
-        sender_modulus: &BigNumber,
+        sender_pk: &PaillierEncryptionKey,
         broadcasted_params: &PublicBroadcast,
     ) -> Result<()> {
         let input = crate::zkp::pienc::PiEncInput::new(
             receiver_setup_params,
-            sender_modulus,
+            sender_pk,
             &broadcasted_params.K,
         );
 
@@ -68,7 +68,7 @@ impl Public {
 
         match round_one_public.verify(
             &receiver_keygen_public.params,
-            sender_keygen_public.pk.n(),
+            &sender_keygen_public.pk,
             broadcasted_params,
         ) {
             Ok(()) => Ok(round_one_public),

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -53,7 +53,7 @@ impl Public {
         let psi_double_prime_input = PiLogInput::new(
             &receiver_keygen_public.params,
             &k256_order(),
-            sender_keygen_public.pk.n(),
+            &sender_keygen_public.pk,
             &sender_r1_public_broadcast.K,
             &self.Delta,
             &self.Gamma,

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -57,8 +57,8 @@ impl Public {
         let psi_input = PiAffgInput::new(
             &receiver_auxinfo_public.params,
             &g,
-            receiver_auxinfo_public.pk.n(),
-            sender_auxinfo_public.pk.n(),
+            &receiver_auxinfo_public.pk,
+            &sender_auxinfo_public.pk,
             &receiver_r1_private.K,
             &self.D,
             &self.F,
@@ -70,8 +70,8 @@ impl Public {
         let psi_hat_input = PiAffgInput::new(
             &receiver_auxinfo_public.params,
             &g,
-            receiver_auxinfo_public.pk.n(),
-            sender_auxinfo_public.pk.n(),
+            &receiver_auxinfo_public.pk,
+            &sender_auxinfo_public.pk,
             &receiver_r1_private.K,
             &self.D_hat,
             &self.F_hat,

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -83,7 +83,7 @@ impl Public {
         let psi_prime_input = PiLogInput::new(
             &receiver_auxinfo_public.params,
             &k256_order(),
-            sender_auxinfo_public.pk.n(),
+            &sender_auxinfo_public.pk,
             &sender_r1_public_broadcast.G,
             &self.Gamma,
             &g,

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -14,12 +14,12 @@
 use super::Proof;
 use crate::{
     errors::*,
-    paillier::PaillierCiphertext,
     paillier::PaillierNonce,
+    paillier::{PaillierCiphertext, PaillierEncryptionKey},
     parameters::{ELL, ELL_PRIME, EPSILON},
     utils::{
         self, k256_order, modpow, plusminus_bn_random_from_transcript, random_bn_in_range,
-        random_bn_in_z_star, random_bn_plusminus,
+        random_bn_plusminus,
     },
     zkp::setup::ZkSetupParameters,
 };
@@ -37,7 +37,7 @@ pub(crate) struct PiAffgProof {
     T: BigNumber,
     A: BigNumber,
     B_x: CurvePoint,
-    B_y: BigNumber,
+    B_y: PaillierCiphertext,
     E: BigNumber,
     F: BigNumber,
     e: BigNumber,
@@ -53,8 +53,8 @@ pub(crate) struct PiAffgProof {
 pub(crate) struct PiAffgInput {
     setup_params: ZkSetupParameters,
     g: CurvePoint,
-    N0: BigNumber,
-    N1: BigNumber,
+    pk0: PaillierEncryptionKey,
+    pk1: PaillierEncryptionKey,
     C: PaillierCiphertext,
     D: PaillierCiphertext,
     Y: PaillierCiphertext,
@@ -66,8 +66,8 @@ impl PiAffgInput {
     pub(crate) fn new(
         setup_params: &ZkSetupParameters,
         g: &CurvePoint,
-        N0: &BigNumber,
-        N1: &BigNumber,
+        pk0: &PaillierEncryptionKey,
+        pk1: &PaillierEncryptionKey,
         C: &PaillierCiphertext,
         D: &PaillierCiphertext,
         Y: &PaillierCiphertext,
@@ -76,8 +76,8 @@ impl PiAffgInput {
         Self {
             setup_params: setup_params.clone(),
             g: *g,
-            N0: N0.clone(),
-            N1: N1.clone(),
+            pk0: pk0.clone(),
+            pk1: pk1.clone(),
             C: C.clone(),
             D: D.clone(),
             Y: Y.clone(),
@@ -130,9 +130,6 @@ impl Proof for PiAffgProof {
         // Sample beta from 2^{ELL_PRIME + EPSILON}.
         let beta = random_bn_in_range(rng, ELL_PRIME + EPSILON);
 
-        let r = random_bn_in_z_star(rng, &input.N0)?;
-        let r_y = random_bn_in_z_star(rng, &input.N1)?;
-
         // range_ell_eps = 2^{ELL + EPSILON} * N_hat
         let range_ell_eps = (BigNumber::one() << (ELL + EPSILON)) * &input.setup_params.N;
         let gamma = random_bn_plusminus(rng, &range_ell_eps);
@@ -143,24 +140,13 @@ impl Proof for PiAffgProof {
         let m = random_bn_plusminus(rng, &range_ell);
         let mu = random_bn_plusminus(rng, &range_ell);
 
-        let N0_squared = &input.N0 * &input.N0;
-        let N1_squared = &input.N1 * &input.N1;
+        let N0_squared = input.pk0.n() * input.pk0.n();
 
-        let A = {
-            let a = modpow(&input.C.0, &alpha, &N0_squared);
-            let b = {
-                let c = modpow(&(BigNumber::one() + &input.N0), &beta, &N0_squared);
-                let d = modpow(&r, &input.N0, &N0_squared);
-                c.modmul(&d, &N0_squared)
-            };
-            a.modmul(&b, &N0_squared)
-        };
+        let a = modpow(&input.C.0, &alpha, &N0_squared);
+        let (b, r) = input.pk0.encrypt(rng, &beta)?;
+        let A = a.modmul(&b.0, &N0_squared);
         let B_x = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
-        let B_y = {
-            let a = modpow(&(BigNumber::one() + &input.N1), &beta, &N1_squared);
-            let b = modpow(&r_y, &input.N1, &N1_squared);
-            a.modmul(&b, &N1_squared)
-        };
+        let (B_y, r_y) = input.pk1.encrypt(rng, &beta)?;
         let E = {
             let a = modpow(&input.setup_params.s, &alpha, &input.setup_params.N);
             let b = modpow(&input.setup_params.t, &gamma, &input.setup_params.N);
@@ -205,8 +191,14 @@ impl Proof for PiAffgProof {
         let z2 = &beta + &e * &secret.y;
         let z3 = gamma + &e * m;
         let z4 = delta + &e * mu;
-        let w = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
-        let w_y = r_y.modmul(&modpow(secret.rho_y.inner(), &e, &input.N1), &input.N1);
+        let w = r.inner().modmul(
+            &modpow(secret.rho.inner(), &e, input.pk0.n()),
+            input.pk0.n(),
+        );
+        let w_y = r_y.inner().modmul(
+            &modpow(secret.rho_y.inner(), &e, input.pk1.n()),
+            input.pk1.n(),
+        );
 
         let proof = Self {
             alpha,
@@ -257,15 +249,15 @@ impl Proof for PiAffgProof {
             return verify_err!("Fiat-Shamir consistency check failed");
         }
 
-        let N0_squared = &input.N0 * &input.N0;
-        let N1_squared = &input.N1 * &input.N1;
+        let N0_squared = input.pk0.n() * input.pk0.n();
+        let N1_squared = input.pk1.n() * input.pk1.n();
 
         // Do equality checks
 
         let eq_check_1 = {
             let a = modpow(&input.C.0, &self.z1, &N0_squared);
-            let b = modpow(&(BigNumber::one() + &input.N0), &self.z2, &N0_squared);
-            let c = modpow(&self.w, &input.N0, &N0_squared);
+            let b = modpow(&(BigNumber::one() + input.pk0.n()), &self.z2, &N0_squared);
+            let c = modpow(&self.w, input.pk0.n(), &N0_squared);
             let lhs = a.modmul(&b, &N0_squared).modmul(&c, &N0_squared);
             let rhs = self
                 .A
@@ -286,11 +278,12 @@ impl Proof for PiAffgProof {
         }
 
         let eq_check_3 = {
-            let a = modpow(&(BigNumber::one() + &input.N1), &self.z2, &N1_squared);
-            let b = modpow(&self.w_y, &input.N1, &N1_squared);
+            let a = modpow(&(BigNumber::one() + input.pk1.n()), &self.z2, &N1_squared);
+            let b = modpow(&self.w_y, input.pk1.n(), &N1_squared);
             let lhs = a.modmul(&b, &N1_squared);
             let rhs = self
                 .B_y
+                .0
                 .modmul(&modpow(&input.Y.0, &self.e, &N1_squared), &N1_squared);
             lhs == rhs
         };
@@ -355,8 +348,7 @@ mod tests {
         let N0 = &p0 * &q0;
         let pk0 = decryption_key_0.encryption_key();
 
-        let (decryption_key_1, p1, q1) = PaillierDecryptionKey::new(rng)?;
-        let N1 = &p1 * &q1;
+        let (decryption_key_1, _, _) = PaillierDecryptionKey::new(rng)?;
         let pk1 = decryption_key_1.encryption_key();
 
         let g = k256::ProjectivePoint::GENERATOR;
@@ -376,7 +368,7 @@ mod tests {
 
         let setup_params = ZkSetupParameters::gen(rng)?;
 
-        let input = PiAffgInput::new(&setup_params, &CurvePoint(g), &N0, &N1, &C, &D, &Y, &X);
+        let input = PiAffgInput::new(&setup_params, &CurvePoint(g), &pk0, &pk1, &C, &D, &Y, &X);
         let proof = PiAffgProof::prove(rng, &input, &PiAffgSecret::new(x, y, &rho, &rho_y))?;
 
         proof.verify(&input)

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -53,7 +53,9 @@ pub(crate) struct PiAffgProof {
 pub(crate) struct PiAffgInput {
     setup_params: ZkSetupParameters,
     g: CurvePoint,
+    // This corresponds to `N_0` in the paper.
     pk0: PaillierEncryptionKey,
+    // This corresponds to `N_1` in the paper.
     pk1: PaillierEncryptionKey,
     C: PaillierCiphertext,
     D: PaillierCiphertext,

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -53,9 +53,9 @@ pub(crate) struct PiAffgProof {
 pub(crate) struct PiAffgInput {
     setup_params: ZkSetupParameters,
     g: CurvePoint,
-    // This corresponds to `N_0` in the paper.
+    /// This corresponds to `N_0` in the paper.
     pk0: PaillierEncryptionKey,
-    // This corresponds to `N_1` in the paper.
+    /// This corresponds to `N_1` in the paper.
     pk1: PaillierEncryptionKey,
     C: PaillierCiphertext,
     D: PaillierCiphertext,

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -39,6 +39,7 @@ pub(crate) struct PiEncProof {
 #[derive(Serialize)]
 pub(crate) struct PiEncInput {
     setup_params: ZkSetupParameters,
+    // This corresponds to `N_0` in the paper.
     pk: PaillierEncryptionKey,
     K: PaillierCiphertext,
 }

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -39,7 +39,7 @@ pub(crate) struct PiEncProof {
 #[derive(Serialize)]
 pub(crate) struct PiEncInput {
     setup_params: ZkSetupParameters,
-    // This corresponds to `N_0` in the paper.
+    /// This corresponds to `N_0` in the paper.
     pk: PaillierEncryptionKey,
     K: PaillierCiphertext,
 }

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -14,12 +14,9 @@
 use super::Proof;
 use crate::{
     errors::*,
-    paillier::{PaillierCiphertext, PaillierNonce},
+    paillier::{PaillierCiphertext, PaillierEncryptionKey, PaillierNonce},
     parameters::{ELL, EPSILON},
-    utils::{
-        k256_order, modpow, plusminus_bn_random_from_transcript, random_bn_in_range,
-        random_bn_in_z_star,
-    },
+    utils::{k256_order, modpow, plusminus_bn_random_from_transcript, random_bn_in_range},
     zkp::setup::ZkSetupParameters,
 };
 use libpaillier::unknown_order::BigNumber;
@@ -42,19 +39,19 @@ pub(crate) struct PiEncProof {
 #[derive(Serialize)]
 pub(crate) struct PiEncInput {
     setup_params: ZkSetupParameters,
-    N0: BigNumber,
+    pk: PaillierEncryptionKey,
     K: PaillierCiphertext,
 }
 
 impl PiEncInput {
     pub(crate) fn new(
         setup_params: &ZkSetupParameters,
-        N0: &BigNumber,
+        pk: &PaillierEncryptionKey,
         K: &PaillierCiphertext,
     ) -> Self {
         Self {
             setup_params: setup_params.clone(),
-            N0: N0.clone(),
+            pk: pk.clone(),
             K: K.clone(),
         }
     }
@@ -92,21 +89,16 @@ impl Proof for PiEncProof {
         let alpha = random_bn_in_range(rng, ELL + EPSILON);
 
         let mu = random_bn_in_range(rng, ELL) * &input.setup_params.N;
-        let r = random_bn_in_z_star(rng, &input.N0)?;
         let gamma = random_bn_in_range(rng, ELL + EPSILON) * &input.setup_params.N;
 
-        let N0_squared = &input.N0 * &input.N0;
+        let N0 = input.pk.n();
 
         let S = {
             let a = modpow(&input.setup_params.s, &secret.k, &input.setup_params.N);
             let b = modpow(&input.setup_params.t, &mu, &input.setup_params.N);
             a.modmul(&b, &input.setup_params.N)
         };
-        let A = {
-            let a = modpow(&(&BigNumber::one() + &input.N0), &alpha, &N0_squared);
-            let b = modpow(&r, &input.N0, &N0_squared);
-            PaillierCiphertext(a.modmul(&b, &N0_squared))
-        };
+        let (A, r) = input.pk.encrypt(rng, &alpha)?;
         let C = {
             let a = modpow(&input.setup_params.s, &alpha, &input.setup_params.N);
             let b = modpow(&input.setup_params.t, &gamma, &input.setup_params.N);
@@ -129,7 +121,7 @@ impl Proof for PiEncProof {
         );
 
         let z1 = &alpha + &e * &secret.k;
-        let z2 = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
+        let z2 = r.inner().modmul(&modpow(secret.rho.inner(), &e, N0), N0);
         let z3 = gamma + &e * mu;
 
         let proof = Self {
@@ -166,13 +158,14 @@ impl Proof for PiEncProof {
             return verify_err!("Fiat-Shamir didn't verify");
         }
 
-        let N0_squared = &input.N0 * &input.N0;
+        let N0 = input.pk.n();
+        let N0_squared = input.pk.n() * input.pk.n();
 
         // Do equality checks
 
         let eq_check_1 = {
-            let a = modpow(&(&BigNumber::one() + &input.N0), &self.z1, &N0_squared);
-            let b = modpow(&self.z2, &input.N0, &N0_squared);
+            let a = modpow(&(&BigNumber::one() + N0), &self.z1, &N0_squared);
+            let b = modpow(&self.z2, N0, &N0_squared);
             let lhs = a.modmul(&b, &N0_squared);
             let rhs = self
                 .A
@@ -217,16 +210,15 @@ mod tests {
         rng: &mut R,
         k: &BigNumber,
     ) -> Result<()> {
-        let (decryption_key, p, q) = PaillierDecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = PaillierDecryptionKey::new(rng)?;
         let pk = decryption_key.encryption_key();
-        let N = &p * &q;
 
         let (K, rho) = pk.encrypt(rng, k)?;
         let setup_params = ZkSetupParameters::gen(rng)?;
 
         let input = PiEncInput {
             setup_params,
-            N0: N,
+            pk,
             K,
         };
 

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -42,6 +42,7 @@ pub(crate) struct PiLogProof {
 pub(crate) struct PiLogInput {
     setup_params: ZkSetupParameters,
     q: BigNumber,
+    // This corresponds to `N_0` in the paper.
     pk: PaillierEncryptionKey,
     C: PaillierCiphertext,
     X: CurvePoint,

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -11,12 +11,11 @@
 use super::Proof;
 use crate::{
     errors::*,
-    paillier::PaillierCiphertext,
     paillier::PaillierNonce,
+    paillier::{PaillierCiphertext, PaillierEncryptionKey},
     parameters::{ELL, EPSILON},
     utils::{
-        self, modpow, plusminus_bn_random_from_transcript, random_bn_in_range, random_bn_in_z_star,
-        random_bn_plusminus,
+        self, modpow, plusminus_bn_random_from_transcript, random_bn_in_range, random_bn_plusminus,
     },
     zkp::setup::ZkSetupParameters,
 };
@@ -43,7 +42,7 @@ pub(crate) struct PiLogProof {
 pub(crate) struct PiLogInput {
     setup_params: ZkSetupParameters,
     q: BigNumber,
-    N0: BigNumber,
+    pk: PaillierEncryptionKey,
     C: PaillierCiphertext,
     X: CurvePoint,
     g: CurvePoint,
@@ -53,7 +52,7 @@ impl PiLogInput {
     pub(crate) fn new(
         setup_params: &ZkSetupParameters,
         q: &BigNumber,
-        N0: &BigNumber,
+        pk: &PaillierEncryptionKey,
         C: &PaillierCiphertext,
         X: &CurvePoint,
         g: &CurvePoint,
@@ -61,7 +60,7 @@ impl PiLogInput {
         Self {
             setup_params: setup_params.clone(),
             q: q.clone(),
-            N0: N0.clone(),
+            pk: pk.clone(),
             C: C.clone(),
             X: *X,
             g: *g,
@@ -99,8 +98,6 @@ impl Proof for PiLogProof {
         // Sample alpha from 2^{ELL + EPSILON}
         let alpha = random_bn_in_range(rng, ELL + EPSILON);
 
-        let r = random_bn_in_z_star(rng, &input.N0)?;
-
         // range = 2^{ELL} * N_hat
         let range_ell = (BigNumber::one() << ELL) * &input.setup_params.N;
         let mu = random_bn_plusminus(rng, &range_ell);
@@ -109,18 +106,12 @@ impl Proof for PiLogProof {
         let range_ell_epsilon = (BigNumber::one() << (ELL + EPSILON)) * &input.setup_params.N;
         let gamma = random_bn_plusminus(rng, &range_ell_epsilon);
 
-        let N0_squared = &input.N0 * &input.N0;
-
         let S = {
             let a = modpow(&input.setup_params.s, &secret.x, &input.setup_params.N);
             let b = modpow(&input.setup_params.t, &mu, &input.setup_params.N);
             a.modmul(&b, &input.setup_params.N)
         };
-        let A = {
-            let a = modpow(&(BigNumber::one() + &input.N0), &alpha, &N0_squared);
-            let b = modpow(&r, &input.N0, &N0_squared);
-            PaillierCiphertext(a.modmul(&b, &N0_squared))
-        };
+        let (A, r) = input.pk.encrypt(rng, &alpha)?;
         let Y = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
         let D = {
             let a = modpow(&input.setup_params.s, &alpha, &input.setup_params.N);
@@ -139,7 +130,9 @@ impl Proof for PiLogProof {
         let e = plusminus_bn_random_from_transcript(&mut transcript, &input.q);
 
         let z1 = &alpha + &e * &secret.x;
-        let z2 = r.modmul(&modpow(secret.rho.inner(), &e, &input.N0), &input.N0);
+        let z2 = r
+            .inner()
+            .modmul(&modpow(secret.rho.inner(), &e, input.pk.n()), input.pk.n());
         let z3 = gamma + &e * mu;
 
         let proof = Self {
@@ -180,13 +173,14 @@ impl Proof for PiLogProof {
             return verify_err!("Fiat-Shamir consistency check failed");
         }
 
-        let N0_squared = &input.N0 * &input.N0;
+        let N0 = input.pk.n();
+        let N0_squared = input.pk.n() * input.pk.n();
 
         // Do equality checks
 
         let eq_check_1 = {
-            let a = modpow(&(BigNumber::one() + &input.N0), &self.z1, &N0_squared);
-            let b = modpow(&self.z2, &input.N0, &N0_squared);
+            let a = modpow(&(BigNumber::one() + N0), &self.z1, &N0_squared);
+            let b = modpow(&self.z2, N0, &N0_squared);
             let lhs = a.modmul(&b, &N0_squared);
             let rhs = self
                 .A
@@ -238,9 +232,8 @@ mod tests {
     use crate::{paillier::PaillierDecryptionKey, utils::random_bn_in_range_min};
 
     fn random_paillier_log_proof<R: RngCore + CryptoRng>(rng: &mut R, x: &BigNumber) -> Result<()> {
-        let (decryption_key, p0, q0) = PaillierDecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = PaillierDecryptionKey::new(rng)?;
         let pk = decryption_key.encryption_key();
-        let N0 = &p0 * &q0;
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
 
@@ -249,7 +242,7 @@ mod tests {
 
         let setup_params = ZkSetupParameters::gen(rng)?;
 
-        let input = PiLogInput::new(&setup_params, &crate::utils::k256_order(), &N0, &C, &X, &g);
+        let input = PiLogInput::new(&setup_params, &crate::utils::k256_order(), &pk, &C, &X, &g);
 
         let proof = PiLogProof::prove(rng, &input, &PiLogSecret::new(x, &rho))?;
 

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -42,7 +42,7 @@ pub(crate) struct PiLogProof {
 pub(crate) struct PiLogInput {
     setup_params: ZkSetupParameters,
     q: BigNumber,
-    // This corresponds to `N_0` in the paper.
+    /// This corresponds to `N_0` in the paper.
     pk: PaillierEncryptionKey,
     C: PaillierCiphertext,
     X: CurvePoint,


### PR DESCRIPTION
This MR replaces the use of the explicit modulus with the Paillier encryption key in `pilog`, `pienc`, and `piaffg`, and does associated cleanup in those files.

Note that, occasionally, we still need to extract the modulus and work with it. This should be unnecessary once #64 and #118 are addressed.

Closes #120.