### PR TITLE
Add `PaillierEncryptionKey::multiply_and_add`

### DIFF
--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -132,11 +132,15 @@ impl PaillierEncryptionKey {
         //
         // Note: We do not use `libpaillier::EncryptionKey::mul`
         // because it does a check that `0 < a < N`. However, the `a` passed in is usually
-        // in the range `-N/2 < a < N/2` so could fail that check. Instead, we just do the
-        // operations directly.
-        Ok(PaillierCiphertext(
-            modpow(&c1.0, a, self.0.nn()).modmul(&c2.0, self.0.nn()),
-        ))
+        // in the range `-N/2 <= a <= N/2` so could fail that check. Instead, we do the
+        // operations directly and manually do the range check.
+        if &self.half_n() < a || a < &-self.half_n() {
+            Err(PaillierError::InvalidOperation)?
+        } else {
+            Ok(PaillierCiphertext(
+                modpow(&c1.0, a, self.0.nn()).modmul(&c2.0, self.0.nn()),
+            ))
+        }
     }
 }
 

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -120,7 +120,7 @@ impl PaillierEncryptionKey {
         MaskedNonce(mask.0.modmul(&modpow(&nonce.0, e, self.n()), self.n()))
     }
 
-    /// Computes $`a \cdot C_1 + C_2`$, returning the resulting ciphertext.
+    /// Computes `a * c1 + c2` homomorphically over [`PaillierCiphertext`]s `c1` and `c2.
     pub(crate) fn multiply_and_add(
         &self,
         a: &BigNumber,

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -126,8 +126,18 @@ impl PaillierEncryptionKey {
         a: &BigNumber,
         c1: &PaillierCiphertext,
         c2: &PaillierCiphertext,
-    ) -> PaillierCiphertext {
-        PaillierCiphertext(a * &c1.0 + &c2.0)
+    ) -> Result<PaillierCiphertext> {
+        Ok(PaillierCiphertext(
+            self.0
+                .add(
+                    &self
+                        .0
+                        .mul(&c1.0, a)
+                        .ok_or(PaillierError::InvalidOperation)?,
+                    &c2.0,
+                )
+                .ok_or(PaillierError::InvalidOperation)?,
+        ))
     }
 }
 

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -120,7 +120,7 @@ impl PaillierEncryptionKey {
         MaskedNonce(mask.0.modmul(&modpow(&nonce.0, e, self.n()), self.n()))
     }
 
-    /// Computes `a * c1 + c2` homomorphically over [`PaillierCiphertext`]s `c1` and `c2.
+    /// Computes `a ⊙ c1 ⊕ c2` homomorphically over [`PaillierCiphertext`]s `c1` and `c2.
     pub(crate) fn multiply_and_add(
         &self,
         a: &BigNumber,

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -119,6 +119,16 @@ impl PaillierEncryptionKey {
     ) -> MaskedNonce {
         MaskedNonce(mask.0.modmul(&modpow(&nonce.0, e, self.n()), self.n()))
     }
+
+    /// Computes $`a \cdot C_1 + C_2`$, returning the resulting ciphertext.
+    pub(crate) fn multiply_and_add(
+        &self,
+        a: &BigNumber,
+        c1: &PaillierCiphertext,
+        c2: &PaillierCiphertext,
+    ) -> PaillierCiphertext {
+        PaillierCiphertext(a * &c1.0 + &c2.0)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -63,7 +63,7 @@ impl PaillierCiphertext {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct PaillierEncryptionKey(pub(crate) libpaillier::EncryptionKey);
+pub(crate) struct PaillierEncryptionKey(libpaillier::EncryptionKey);
 
 impl PaillierEncryptionKey {
     pub(crate) fn n(&self) -> &BigNumber {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -990,12 +990,12 @@ impl PresignKeyShareAndInfo {
             &sender_r1_priv.gamma,
             &receiver_r1_pub_broadcast.K,
             &beta_ciphertext,
-        );
+        )?;
         let D_hat = receiver_aux_info.pk.multiply_and_add(
             &self.keyshare_private.x,
             &receiver_r1_pub_broadcast.K,
             &beta_hat_ciphertext,
-        );
+        )?;
         let (F, r) = self.aux_info_public.pk.encrypt(rng, &beta)?;
         let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(rng, &beta_hat)?;
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -8,14 +8,12 @@
 
 use crate::broadcast::participant::BroadcastTag;
 use crate::errors::InternalError::InternalInvariantFailed;
-use crate::paillier::PaillierError;
 use crate::{
     auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant},
     errors::Result,
     keygen::keyshare::{KeySharePrivate, KeySharePublic},
     messages::{Message, MessageType, PresignMessageType},
-    paillier::PaillierCiphertext,
     parameters::ELL,
     participant::{Broadcast, ProtocolParticipant},
     presign::{
@@ -988,34 +986,16 @@ impl PresignKeyShareAndInfo {
         let (beta_ciphertext, s) = receiver_aux_info.pk.encrypt(rng, &beta)?;
         let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk.encrypt(rng, &beta_hat)?;
 
-        let D = receiver_aux_info
-            .pk
-            .0
-            .add(
-                &receiver_aux_info
-                    .pk
-                    .0
-                    .mul(&receiver_r1_pub_broadcast.K.0, &sender_r1_priv.gamma)
-                    .ok_or(PaillierError::InvalidOperation)?,
-                &beta_ciphertext.0,
-            )
-            .map(PaillierCiphertext)
-            .ok_or(PaillierError::InvalidOperation)?;
-
-        let D_hat = receiver_aux_info
-            .pk
-            .0
-            .add(
-                &receiver_aux_info
-                    .pk
-                    .0
-                    .mul(&receiver_r1_pub_broadcast.K.0, &self.keyshare_private.x)
-                    .ok_or(PaillierError::InvalidOperation)?,
-                &beta_hat_ciphertext.0,
-            )
-            .map(PaillierCiphertext)
-            .ok_or(PaillierError::InvalidOperation)?;
-
+        let D = receiver_aux_info.pk.multiply_and_add(
+            &sender_r1_priv.gamma,
+            &receiver_r1_pub_broadcast.K,
+            &beta_ciphertext,
+        );
+        let D_hat = receiver_aux_info.pk.multiply_and_add(
+            &self.keyshare_private.x,
+            &receiver_r1_pub_broadcast.K,
+            &beta_hat_ciphertext,
+        );
         let (F, r) = self.aux_info_public.pk.encrypt(rng, &beta)?;
         let (F_hat, r_hat) = self.aux_info_public.pk.encrypt(rng, &beta_hat)?;
 

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -168,11 +168,8 @@ impl Proof for PiEncProof {
         let eq_check_1 = {
             let a = modpow(&(&BigNumber::one() + N0), &self.z1, &N0_squared);
             let b = modpow(&self.z2.0, N0, &N0_squared);
-            let lhs = a.modmul(&b, &N0_squared);
-            let rhs = self
-                .A
-                .0
-                .modmul(&modpow(&input.K.0, &e, &N0_squared), &N0_squared);
+            let lhs = PaillierCiphertext(a.modmul(&b, &N0_squared));
+            let rhs = input.pk.multiply_and_add(&e, &input.K, &self.A)?;
             lhs == rhs
         };
         if !eq_check_1 {

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -179,11 +179,8 @@ impl Proof for PiLogProof {
         let eq_check_1 = {
             let a = modpow(&(BigNumber::one() + N0), &self.z1, &N0_squared);
             let b = modpow(&self.z2.0, N0, &N0_squared);
-            let lhs = a.modmul(&b, &N0_squared);
-            let rhs = self
-                .A
-                .0
-                .modmul(&modpow(&input.C.0, &self.e, &N0_squared), &N0_squared);
+            let lhs = PaillierCiphertext(a.modmul(&b, &N0_squared));
+            let rhs = input.pk.multiply_and_add(&self.e, &input.C, &self.A)?;
             lhs == rhs
         };
         if !eq_check_1 {


### PR DESCRIPTION
The PR adds an `PaillierEncryptionKey::multiply_and_add` method that allows us to hide the internals of `PaillierEncryptionKey`. Once we've addressed #107 we should be able to remove `PaillierEncryptionKey::n` and thus hide all the internals of the module.

Closes #64.