### PR TITLE
Remove bail! errors from codebase

### DIFF
--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -22,7 +22,7 @@ fn deliver_all(
 
 fn is_keygen_done(quorum: &[Participant], keygen_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant.is_keygen_done(keygen_identifier).is_err() {
+        if participant.check_keygen_done(keygen_identifier).is_err() {
             return false;
         }
     }
@@ -31,7 +31,7 @@ fn is_keygen_done(quorum: &[Participant], keygen_identifier: Identifier) -> bool
 
 fn is_auxinfo_done(quorum: &[Participant], auxinfo_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant.is_auxinfo_done(auxinfo_identifier).is_err() {
+        if participant.check_auxinfo_done(auxinfo_identifier).is_err() {
             return false;
         }
     }
@@ -40,7 +40,10 @@ fn is_auxinfo_done(quorum: &[Participant], auxinfo_identifier: Identifier) -> bo
 
 fn is_presigning_done(quorum: &[Participant], presign_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant.is_presigning_done(presign_identifier).is_err() {
+        if participant
+            .check_presigning_done(presign_identifier)
+            .is_err()
+        {
             return false;
         }
     }

--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -22,7 +22,7 @@ fn deliver_all(
 
 fn is_keygen_done(quorum: &[Participant], keygen_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant.check_keygen_done(keygen_identifier).is_err() {
+        if !participant.is_keygen_done(keygen_identifier).unwrap() {
             return false;
         }
     }
@@ -31,7 +31,7 @@ fn is_keygen_done(quorum: &[Participant], keygen_identifier: Identifier) -> bool
 
 fn is_auxinfo_done(quorum: &[Participant], auxinfo_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant.check_auxinfo_done(auxinfo_identifier).is_err() {
+        if !participant.is_auxinfo_done(auxinfo_identifier).unwrap() {
             return false;
         }
     }
@@ -40,10 +40,7 @@ fn is_auxinfo_done(quorum: &[Participant], auxinfo_identifier: Identifier) -> bo
 
 fn is_presigning_done(quorum: &[Participant], presign_identifier: Identifier) -> bool {
     for participant in quorum {
-        if participant
-            .check_presigning_done(presign_identifier)
-            .is_err()
-        {
+        if !participant.is_presigning_done(presign_identifier).unwrap() {
             return false;
         }
     }

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -108,7 +108,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let auxinfo_notifications = state.auxinfo_notifications.read().await;
     if auxinfo_notifications.contains_key(&message.id())
-        && participant.is_auxinfo_done(message.id()).is_ok()
+        && participant.check_auxinfo_done(message.id()).is_ok()
     {
         let notify = auxinfo_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();
@@ -117,7 +117,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let keygen_notifications = state.keygen_notifications.read().await;
     if keygen_notifications.contains_key(&message.id())
-        && participant.is_keygen_done(message.id()).is_ok()
+        && participant.check_keygen_done(message.id()).is_ok()
     {
         let notify = keygen_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();
@@ -126,7 +126,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let presign_notifications = state.presign_notifications.read().await;
     if presign_notifications.contains_key(&message.id())
-        && participant.is_presigning_done(message.id()).is_ok()
+        && participant.check_presigning_done(message.id()).is_ok()
     {
         let notify = presign_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -108,7 +108,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let auxinfo_notifications = state.auxinfo_notifications.read().await;
     if auxinfo_notifications.contains_key(&message.id())
-        && participant.check_auxinfo_done(message.id()).is_ok()
+        && participant.is_auxinfo_done(message.id()).unwrap()
     {
         let notify = auxinfo_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();
@@ -117,7 +117,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let keygen_notifications = state.keygen_notifications.read().await;
     if keygen_notifications.contains_key(&message.id())
-        && participant.check_keygen_done(message.id()).is_ok()
+        && participant.is_keygen_done(message.id()).unwrap()
     {
         let notify = keygen_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();
@@ -126,7 +126,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
 
     let presign_notifications = state.presign_notifications.read().await;
     if presign_notifications.contains_key(&message.id())
-        && participant.check_presigning_done(message.id()).is_ok()
+        && participant.is_presigning_done(message.id()).unwrap()
     {
         let notify = presign_notifications.get(&message.id()).unwrap().clone();
         notify.notify_one();

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     auxinfo::info::AuxInfoPublic,
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{AuxinfoMessageType, Message, MessageType},
     protocol::{Identifier, ParticipantIdentifier},
 };
@@ -23,7 +23,7 @@ pub(crate) struct AuxInfoCommit {
 impl AuxInfoCommit {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
         let auxinfo_commit: AuxInfoCommit = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_commit)
@@ -61,7 +61,7 @@ impl AuxInfoDecommit {
 
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R2Decommit) {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
         let auxinfo_decommit: AuxInfoDecommit = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_decommit)
@@ -93,9 +93,11 @@ impl AuxInfoDecommit {
         let mut hash = [0u8; 32];
         transcript.challenge_bytes(b"hashing r1", &mut hash);
         let rebuilt_com = AuxInfoCommit { hash };
-        match rebuilt_com == *com {
-            true => Ok(()),
-            false => verify_err!("decommitment does not match original commitment"),
+
+        if rebuilt_com == *com {
+            Ok(())
+        } else {
+            verify_err!("decommitment does not match original commitment")
         }
     }
 }

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::{
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{AuxinfoMessageType, MessageType},
     ring_pedersen::VerifiedRingPedersen,
     zkp::{
@@ -30,7 +30,7 @@ pub(crate) struct AuxInfoProof {
 impl AuxInfoProof {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R3Proof) {
-            return Err(crate::errors::InternalError::IncorrectBroadcastMessageTag);
+            return Err(InternalError::IncorrectBroadcastMessageTag);
         }
         let auxinfo_proof: AuxInfoProof = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_proof)

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -30,9 +30,7 @@ pub(crate) struct AuxInfoProof {
 impl AuxInfoProof {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R3Proof) {
-            return bail!(
-                "Wrong message type, expected MessageType::Auxinfo(AuxinfoMessageType::R3Proof)"
-            );
+            return Err(crate::errors::InternalError::IncorrectBroadcastMessageTag);
         }
         let auxinfo_proof: AuxInfoProof = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_proof)

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -8,7 +8,7 @@
 
 use super::participant::BroadcastTag;
 use crate::{
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{BroadcastMessageType, Message, MessageType},
     ParticipantIdentifier,
 };
@@ -27,7 +27,7 @@ impl BroadcastData {
         if message.message_type() != MessageType::Broadcast(BroadcastMessageType::Disperse)
             && message.message_type() != MessageType::Broadcast(BroadcastMessageType::Redisperse)
         {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
         let broadcast_data: BroadcastData = deserialize!(&message.unverified_bytes)?;
         Ok(broadcast_data)

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -27,7 +27,7 @@ impl BroadcastData {
         if message.message_type() != MessageType::Broadcast(BroadcastMessageType::Disperse)
             && message.message_type() != MessageType::Broadcast(BroadcastMessageType::Redisperse)
         {
-            return bail!("Wrong message type, expected MessageType::Broadcast(BroadcastMessageType::Disperse) or ...Redisperse");
+            return Err(crate::errors::InternalError::MisroutedMessage);
         }
         let broadcast_data: BroadcastData = deserialize!(&message.unverified_bytes)?;
         Ok(broadcast_data)

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     broadcast::data::BroadcastData,
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{BroadcastMessageType, Message, MessageType},
     participant::ProtocolParticipant,
     protocol::ParticipantIdentifier,
@@ -91,7 +91,7 @@ impl BroadcastParticipant {
                 let (output_option, messages) = self.handle_round_two_msg(rng, message)?;
                 Ok((output_option, messages))
             }
-            _ => Err(crate::errors::InternalError::MisroutedMessage),
+            _ => Err(InternalError::MisroutedMessage),
         }
     }
 
@@ -208,7 +208,7 @@ impl BroadcastParticipant {
                 return Ok(Some(out));
             }
         }
-        Err(crate::errors::InternalError::BroadcastFailure(
+        Err(InternalError::BroadcastFailure(
             "No message got enough votes".to_string(),
         ))
     }

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -91,9 +91,7 @@ impl BroadcastParticipant {
                 let (output_option, messages) = self.handle_round_two_msg(rng, message)?;
                 Ok((output_option, messages))
             }
-            _ => {
-                bail!("Attempting to process a non-broadcast message with a broadcast participant")
-            }
+            _ => Err(crate::errors::InternalError::MisroutedMessage),
         }
     }
 
@@ -210,7 +208,9 @@ impl BroadcastParticipant {
                 return Ok(Some(out));
             }
         }
-        bail!("error: no message received enough votes")
+        Err(crate::errors::InternalError::BroadcastFailure(
+            "No message got enough votes".to_string(),
+        ))
     }
 
     fn gen_round_two_msgs<R: RngCore + CryptoRng>(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -61,8 +61,8 @@ pub enum InternalError {
     SignatureInstantiationError,
     #[error("Tried to produce a signature without including shares")]
     NoChainedShares,
-    #[error("Storage does not contain entry: `{0}`")]
-    StorageItemNotFound(String),
+    #[error("Storage does not contain the requested item")]
+    StorageItemNotFound,
     #[error("Function call contained invalid arguments: `{0}`")]
     InvalidArgument(String),
     #[error("The provided Broadcast Tag was not the expected tag for this context")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,8 +43,6 @@ pub enum InternalError {
     NonUniqueFourthRootsCombination,
     #[error("Could not invert a BigNumber")]
     CouldNotInvertBigNumber,
-    #[error("`{0}`")]
-    BailError(String),
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
@@ -105,24 +103,4 @@ macro_rules! arg_err {
             $x,
         )))
     }};
-}
-
-#[allow(unused)]
-macro_rules! bail {
-    ($msg:literal $(,)?) => {
-        Err(bail_context!($msg))
-    };
-    ($fmt:expr, $($arg:tt)*) => {
-        Err(bail_context!($fmt, $($arg)*))
-    };
-}
-
-#[allow(unused)]
-macro_rules! bail_context {
-    ($msg:literal $(,)?) => {
-        crate::errors::InternalError::BailError(String::from($msg))
-    };
-    ($fmt:expr, $($arg:tt)*) => {
-        crate::errors::InternalError::BailError(format!($fmt, $($arg)*))
-    };
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,7 @@ pub enum InternalError {
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
-    PaillierError(#[from] PaillierError),
+    PaillierError(#[from] paillier::Error),
     #[error("Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)")]
     CouldNotConvertToScalar,
     #[error("Could not invert a Scalar")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,7 @@ pub enum InternalError {
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
-    PaillierError(paillier::Error),
+    PaillierError(#[from] PaillierError),
     #[error("Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)")]
     CouldNotConvertToScalar,
     #[error("Could not invert a Scalar")]
@@ -57,6 +57,24 @@ pub enum InternalError {
     RetryFailed,
     #[error("This Participant was given a message intended for somebody else")]
     WrongMessageRecipient,
+    #[error("Encountered a MessageType which was not expected in this context")]
+    MisroutedMessage,
+    #[error("Could not construct signature from provided scalars")]
+    SignatureInstantiationError,
+    #[error("Tried to produce a signature without including shares")]
+    NoChainedShares,
+    #[error("Storage does not contain entry: `{0}`")]
+    StorageItemNotFound(String),
+    #[error("Function call contained invalid arguments: `{0}`")]
+    InvalidArgument(String),
+    #[error("The provided Broadcast Tag was not the expected tag for this context")]
+    IncorrectBroadcastMessageTag,
+    #[error("Encountered a Message sent directly, when it should have been broadcasted")]
+    MessageMustBeBroadcasted,
+    #[error("Broadcast has irrecoverably failed: `{0}`")]
+    BroadcastFailure(String),
+    #[error("Tried to start a new protocol instance with an Identifier used in an existing instance")]
+    IdentifierInUse,
 }
 
 macro_rules! serialize {
@@ -79,6 +97,15 @@ macro_rules! verify_err {
     }};
 }
 
+macro_rules! arg_err {
+    ($x:expr) => {{
+        Err(crate::errors::InternalError::InvalidArgument(String::from(
+            $x,
+        )))
+    }};
+}
+
+#[allow(unused)]
 macro_rules! bail {
     ($msg:literal $(,)?) => {
         Err(bail_context!($msg))
@@ -88,6 +115,7 @@ macro_rules! bail {
     };
 }
 
+#[allow(unused)]
 macro_rules! bail_context {
     ($msg:literal $(,)?) => {
         crate::errors::InternalError::BailError(String::from($msg))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,7 +73,9 @@ pub enum InternalError {
     MessageMustBeBroadcasted,
     #[error("Broadcast has irrecoverably failed: `{0}`")]
     BroadcastFailure(String),
-    #[error("Tried to start a new protocol instance with an Identifier used in an existing instance")]
+    #[error(
+        "Tried to start a new protocol instance with an Identifier used in an existing instance"
+    )]
     IdentifierInUse,
 }
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -212,14 +212,11 @@ impl KeygenParticipant {
         )?;
 
         // check if we've received all the commits.
-        let r1_done = self
-            .storage
-            .contains_for_all_ids(
-                StorableType::KeygenCommit,
-                message.id(),
-                &self.other_participant_ids.clone(),
-            )
-            .is_ok();
+        let r1_done = self.storage.contains_for_all_ids(
+            StorableType::KeygenCommit,
+            message.id(),
+            &self.other_participant_ids.clone(),
+        )?;
         let mut messages = vec![];
 
         if r1_done {
@@ -248,7 +245,7 @@ impl KeygenParticipant {
     ) -> Result<Vec<Message>> {
         // check that we've generated our keyshare before trying to retrieve it
         let fetch = vec![(StorableType::PublicKeyshare, message.id(), self.id)];
-        let public_keyshare_generated = self.storage.contains_batch(&fetch).is_ok();
+        let public_keyshare_generated = self.storage.contains_batch(&fetch)?;
         let mut messages = vec![];
         if !public_keyshare_generated {
             let more_messages =
@@ -286,14 +283,11 @@ impl KeygenParticipant {
     ) -> Result<Vec<Message>> {
         // We must receive all commitments in round 1 before we start processing
         // decommits in round 2.
-        let r1_done = self
-            .storage
-            .contains_for_all_ids(
-                StorableType::KeygenCommit,
-                message.id(),
-                &[self.other_participant_ids.clone(), vec![self.id]].concat(),
-            )
-            .is_ok();
+        let r1_done = self.storage.contains_for_all_ids(
+            StorableType::KeygenCommit,
+            message.id(),
+            &[self.other_participant_ids.clone(), vec![self.id]].concat(),
+        )?;
         if !r1_done {
             // store any early round2 messages
             self.stash_message(message)?;
@@ -313,14 +307,11 @@ impl KeygenParticipant {
         )?;
 
         // check if we've received all the decommits
-        let r2_done = self
-            .storage
-            .contains_for_all_ids(
-                StorableType::KeygenDecommit,
-                message.id(),
-                &self.other_participant_ids.clone(),
-            )
-            .is_ok();
+        let r2_done = self.storage.contains_for_all_ids(
+            StorableType::KeygenDecommit,
+            message.id(),
+            &self.other_participant_ids.clone(),
+        )?;
         let mut messages = vec![];
 
         if r2_done {
@@ -470,14 +461,11 @@ impl KeygenParticipant {
         )?;
 
         //check if we've stored all the public keyshares
-        let keyshare_done = self
-            .storage
-            .contains_for_all_ids(
-                StorableType::PublicKeyshare,
-                message.id(),
-                &[self.other_participant_ids.clone(), vec![self.id]].concat(),
-            )
-            .is_ok();
+        let keyshare_done = self.storage.contains_for_all_ids(
+            StorableType::PublicKeyshare,
+            message.id(),
+            &[self.other_participant_ids.clone(), vec![self.id]].concat(),
+        )?;
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
@@ -564,7 +552,7 @@ mod tests {
                 &[],
             )
         }
-        pub fn check_keygen_done(&self, keygen_identifier: Identifier) -> Result<()> {
+        pub fn is_keygen_done(&self, keygen_identifier: Identifier) -> Result<bool> {
             let mut fetch = vec![];
             for participant in self.other_participant_ids.clone() {
                 fetch.push((StorableType::PublicKeyshare, keygen_identifier, participant));
@@ -591,14 +579,13 @@ mod tests {
         Ok(())
     }
 
-    fn check_keygen_done(
-        quorum: &[KeygenParticipant],
-        keygen_identifier: Identifier,
-    ) -> Result<()> {
+    fn is_keygen_done(quorum: &[KeygenParticipant], keygen_identifier: Identifier) -> Result<bool> {
         for participant in quorum {
-            participant.check_keygen_done(keygen_identifier)?;
+            if !participant.is_keygen_done(keygen_identifier)? {
+                return Ok(false);
+            }
         }
-        Ok(())
+        Ok(true)
     }
 
     fn process_messages<R: RngCore + CryptoRng>(
@@ -660,7 +647,7 @@ mod tests {
             let inbox = inboxes.get_mut(&participant.id).unwrap();
             inbox.push(participant.initialize_keygen_message(keyshare_identifier));
         }
-        while check_keygen_done(&quorum, keyshare_identifier).is_err() {
+        while !is_keygen_done(&quorum, keyshare_identifier)? {
             process_messages(&mut quorum, &mut inboxes, &mut rng, &mut main_storages)?;
         }
 

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -35,14 +35,7 @@ pub enum Error {
     NoPregeneratedPrimes(usize),
 }
 
-/// TODO: Remove this once `InternalError` is instantiated with thiserror.
-impl From<Error> for InternalError {
-    fn from(err: Error) -> Self {
-        InternalError::PaillierError(err)
-    }
-}
-
-/// A nonce generated as part of [`EncryptionKey::encrypt()`].
+/// A nonce generated as part of [`PaillierEncryptionKey::encrypt()`].
 /// A nonce is drawn from the multiplicative group of integers modulo `n`, where `n`
 /// is the modulus from the associated [`EncryptionKey`].
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -35,7 +35,7 @@ pub enum Error {
     NoPregeneratedPrimes(usize),
 }
 
-/// A nonce generated as part of [`PaillierEncryptionKey::encrypt()`].
+/// A nonce generated as part of [`EncryptionKey::encrypt()`].
 /// A nonce is drawn from the multiplicative group of integers modulo `n`, where `n`
 /// is the modulus from the associated [`EncryptionKey`].
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -839,15 +839,24 @@ impl PresignParticipant {
         &self,
         identifier: Identifier,
     ) -> Result<Vec<crate::round_three::Public>> {
-        let mut ret_vec = vec![];
-        for other_participant_id in self.other_participant_ids.clone() {
-            let val = self.storage.retrieve(
-                StorableType::PresignRoundThreePublic,
-                identifier,
-                other_participant_id,
-            )?;
-            ret_vec.push(deserialize!(&val)?);
-        }
+        check_collected_all_of_others(
+            &self.other_participant_ids,
+            &self.storage,
+            StorableType::PresignRoundThreePublic,
+            identifier,
+        )?;
+        let ret_vec = self
+            .other_participant_ids
+            .iter()
+            .map(|other_participant_id| {
+                let r3pub = deserialize!(&self.storage.retrieve(
+                    StorableType::PresignRoundThreePublic,
+                    identifier,
+                    *other_participant_id,
+                )?)?;
+                Ok(r3pub)
+            })
+            .collect::<Result<Vec<crate::round_three::Public>>>()?;
         Ok(ret_vec)
     }
 }

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -160,7 +160,7 @@ impl PresignParticipant {
         identifier: Identifier,
     ) -> Result<Message> {
         if self.presign_map.contains_key(&identifier) {
-            return Err(crate::errors::InternalError::IdentifierInUse)
+            return Err(crate::errors::InternalError::IdentifierInUse);
         }
         // Set the presign map internally
         let _ = self
@@ -364,9 +364,9 @@ impl PresignParticipant {
         )?;
 
         // Find the keyshare corresponding to the "from" participant
-        let keyshare_from = other_public_keyshares.get(&message.from()).ok_or_else(|| {
-            InternalInvariantFailed
-        })?;
+        let keyshare_from = other_public_keyshares
+            .get(&message.from())
+            .ok_or(InternalInvariantFailed)?;
 
         // Get this participant's round 1 private value
         let r1_priv: RoundOnePrivate = deserialize!(&self.storage.retrieve(
@@ -647,7 +647,7 @@ impl PresignParticipant {
         // Check consistency across all Gamma values
         for r3_pub in r3_pubs.iter() {
             if r3_pub.Gamma != r3_private.Gamma {
-                return Err(InternalInvariantFailed)
+                return Err(InternalInvariantFailed);
             }
         }
 
@@ -664,9 +664,10 @@ impl PresignParticipant {
         &self,
         presign_identifier: &Identifier,
     ) -> Result<(Identifier, Identifier)> {
-        let (id1, id2) = self.presign_map.get(presign_identifier).ok_or_else(
-            || InternalInvariantFailed
-        )?;
+        let (id1, id2) = self
+            .presign_map
+            .get(presign_identifier)
+            .ok_or(InternalInvariantFailed)?;
 
         Ok((*id1, *id2))
     }

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -59,7 +59,7 @@ impl Public {
         broadcasted_params: &PublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundOne) {
-            return bail!("Wrong message type, expected MessageType::RoundOne");
+            return Err(crate::errors::InternalError::MisroutedMessage);
         }
         let round_one_public: Self = deserialize!(&message.unverified_bytes)?;
 
@@ -69,7 +69,7 @@ impl Public {
             broadcasted_params.K.clone(),
         ) {
             Ok(()) => Ok(round_one_public),
-            Err(e) => bail!("Failed to verify round one public: {}", e),
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     auxinfo::info::AuxInfoPublic,
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
     paillier::{Ciphertext, EncryptionKey, Nonce},
     ring_pedersen::VerifiedRingPedersen,
@@ -59,17 +59,15 @@ impl Public {
         broadcasted_params: &PublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundOne) {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
         let round_one_public: Self = deserialize!(&message.unverified_bytes)?;
 
-        match round_one_public.verify(
+        round_one_public.verify(
             &receiver_keygen_public.params,
             sender_keygen_public.pk.clone(),
             broadcasted_params.K.clone(),
-        ) {
-            Ok(()) => Ok(round_one_public),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(round_one_public)
     }
 }

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     auxinfo::info::AuxInfoPublic,
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
     presign::{
         round_one::PublicBroadcast as RoundOnePublicBroadcast,
@@ -70,19 +70,17 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundThree) {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
 
         let round_three_public: Self = deserialize!(&message.unverified_bytes)?;
 
-        match round_three_public.verify(
+        round_three_public.verify(
             receiver_auxinfo_public,
             sender_auxinfo_public,
             sender_r1_public_broadcast,
-        ) {
-            Ok(()) => Ok(round_three_public),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(round_three_public)
     }
 }
 

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -70,7 +70,7 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundThree) {
-            return bail!("Wrong message type, expected MessageType::RoundThree");
+            return Err(crate::errors::InternalError::MisroutedMessage);
         }
 
         let round_three_public: Self = deserialize!(&message.unverified_bytes)?;
@@ -81,7 +81,7 @@ impl Public {
             sender_r1_public_broadcast,
         ) {
             Ok(()) => Ok(round_three_public),
-            Err(e) => bail!("Failed to verify round three public: {}", e),
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     auxinfo::info::AuxInfoPublic,
-    errors::Result,
+    errors::{InternalError, Result},
     keygen::keyshare::KeySharePublic,
     messages::{Message, MessageType, PresignMessageType},
     paillier::Ciphertext,
@@ -102,19 +102,17 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundTwo) {
-            return Err(crate::errors::InternalError::MisroutedMessage);
+            return Err(InternalError::MisroutedMessage);
         }
         let round_two_public: Self = deserialize!(&message.unverified_bytes)?;
 
-        match round_two_public.verify(
+        round_two_public.verify(
             receiver_auxinfo_public,
             sender_auxinfo_public,
             sender_keyshare_public,
             receiver_r1_private,
             sender_r1_public_broadcast,
-        ) {
-            Ok(()) => Ok(round_two_public),
-            Err(e) => Err(e),
-        }
+        )?;
+        Ok(round_two_public)
     }
 }

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -102,7 +102,7 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundTwo) {
-            return bail!("Wrong message type, expected MessageType::RoundTwo");
+            return Err(crate::errors::InternalError::MisroutedMessage);
         }
         let round_two_public: Self = deserialize!(&message.unverified_bytes)?;
 
@@ -114,7 +114,7 @@ impl Public {
             sender_r1_public_broadcast,
         ) {
             Ok(()) => Ok(round_two_public),
-            Err(e) => bail!("Failed to verify round two public: {}", e),
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -153,7 +153,7 @@ impl Storage {
         let ret = self
             .0
             .get(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{:?}", storable_index)))?
+            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{storable_index:?}")))?
             .clone();
 
         Ok(ret)
@@ -163,7 +163,7 @@ impl Storage {
         let key = serialize!(&storable_index)?;
         self.0
             .remove(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{:?}", storable_index)))
+            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{storable_index:?}")))
     }
 
     fn contains_index_batch<I: Storable>(&self, storable_indices: &[I]) -> Result<()> {
@@ -172,8 +172,7 @@ impl Storage {
             let ret = self.0.contains_key(&key);
             if !ret {
                 return Err(InternalError::StorageItemNotFound(format!(
-                    "{:?}",
-                    storable_index
+                    "{storable_index:?}"
                 )));
             }
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -113,7 +113,7 @@ impl Storage {
     pub(crate) fn contains_batch(
         &self,
         type_and_id: &[(StorableType, Identifier, ParticipantIdentifier)],
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let storable_indices: Vec<StorableIndex> = type_and_id
             .iter()
             .map(|(t, identifier, participant)| StorableIndex {
@@ -132,7 +132,7 @@ impl Storage {
         s_type: StorableType,
         sid: Identifier,
         participants: &[ParticipantIdentifier],
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let fetch: Vec<(StorableType, Identifier, ParticipantIdentifier)> = participants
             .iter()
             .map(|participant| (s_type, sid, *participant))
@@ -153,7 +153,7 @@ impl Storage {
         let ret = self
             .0
             .get(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{storable_index:?}")))?
+            .ok_or_else(|| InternalError::StorageItemNotFound)?
             .clone();
 
         Ok(ret)
@@ -163,19 +163,17 @@ impl Storage {
         let key = serialize!(&storable_index)?;
         self.0
             .remove(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound(format!("{storable_index:?}")))
+            .ok_or_else(|| InternalError::StorageItemNotFound)
     }
 
-    fn contains_index_batch<I: Storable>(&self, storable_indices: &[I]) -> Result<()> {
+    fn contains_index_batch<I: Storable>(&self, storable_indices: &[I]) -> Result<bool> {
         for storable_index in storable_indices {
             let key = serialize!(&storable_index)?;
             let ret = self.0.contains_key(&key);
             if !ret {
-                return Err(InternalError::StorageItemNotFound(format!(
-                    "{storable_index:?}"
-                )));
+                return Ok(false);
             }
         }
-        Ok(())
+        Ok(true)
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -133,10 +133,10 @@ impl Storage {
         sid: Identifier,
         participants: &[ParticipantIdentifier],
     ) -> Result<()> {
-        let mut fetch = vec![];
-        for participant in participants {
-            fetch.push((s_type, sid, *participant));
-        }
+        let fetch: Vec<(StorableType, Identifier, ParticipantIdentifier)> = participants
+            .iter()
+            .map(|participant| (s_type, sid, *participant))
+            .collect();
         self.contains_batch(&fetch)
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -255,12 +255,12 @@ pub(crate) fn has_collected_all_of_others(
     storage: &Storage,
     storable_type: StorableType,
     identifier: Identifier,
-) -> Result<bool> {
+) -> Result<()> {
     let indices: Vec<(StorableType, Identifier, ParticipantIdentifier)> = other_ids
         .iter()
         .map(|participant_id| (storable_type, identifier, *participant_id))
         .collect();
-    Ok(storage.contains_batch(&indices).is_ok())
+    storage.contains_batch(&indices)
 }
 
 /// Aggregate the other participants' public keyshares from storage. But don't
@@ -273,9 +273,7 @@ pub(crate) fn get_other_participants_public_auxinfo(
     storage: &Storage,
     identifier: Identifier,
 ) -> Result<HashMap<ParticipantIdentifier, AuxInfoPublic>> {
-    if !has_collected_all_of_others(other_ids, storage, StorableType::AuxInfoPublic, identifier)? {
-        return bail!("Not ready to get other participants public auxinfo just yet!");
-    }
+    has_collected_all_of_others(other_ids, storage, StorableType::AuxInfoPublic, identifier)?;
 
     let mut hm = HashMap::new();
     for &other_participant_id in other_ids {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -248,9 +248,8 @@ mod tests {
 // Protocol Utility Functions //
 ////////////////////////////////
 
-/// Returns true if in storage, there is one storable_type for each other
-/// participant in the quorum.
-pub(crate) fn has_collected_all_of_others(
+/// Errors unless there is one storable_type for each other participant in the quorum.
+pub(crate) fn check_collected_all_of_others(
     other_ids: &[ParticipantIdentifier],
     storage: &Storage,
     storable_type: StorableType,
@@ -273,7 +272,7 @@ pub(crate) fn get_other_participants_public_auxinfo(
     storage: &Storage,
     identifier: Identifier,
 ) -> Result<HashMap<ParticipantIdentifier, AuxInfoPublic>> {
-    has_collected_all_of_others(other_ids, storage, StorableType::AuxInfoPublic, identifier)?;
+    check_collected_all_of_others(other_ids, storage, StorableType::AuxInfoPublic, identifier)?;
 
     let mut hm = HashMap::new();
     for &other_participant_id in other_ids {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,7 +115,7 @@ pub(crate) fn random_plusminus_by_size_with_minimum<R: RngCore + CryptoRng>(
     min: usize,
 ) -> crate::errors::Result<BigNumber> {
     if min >= max {
-        return bail!("min_bound needs to be less than n");
+        return arg_err!("min needs to be less than max");
     }
     // Sample from [0, 2^max - 2^min], then add 2^min to bump into correct range.
     let min_bound_bn = (BigNumber::one() << max) - (BigNumber::one() << min);

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -181,9 +181,7 @@ impl PiSchProof {
     }
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Keygen(KeygenMessageType::R3Proof) {
-            return bail!(
-                "Wrong message type, expected MessageType::Keygen(KeygenMessageType::R3Proof)"
-            );
+            return Err(InternalError::MisroutedMessage);
         }
         let keygen_decommit: PiSchProof = deserialize!(&message.unverified_bytes)?;
         Ok(keygen_decommit)


### PR DESCRIPTION
This PR removes all of the instances of bail! and bail_context! from the codebase. I introduced some new errors for cases which where previously handled by bails, but I'm starting to think that there are too many error variants to be useful. I like how FailedToVerifyProof consolidates different ways of a proof failing, and we could probably do something similar for some of these other variants.

I also think there's like three kinds of errors which would require different control flows to handle: 
"Expected": Things like looking for a contents from a message that hasn't been received yet. Eventually this will probably resolve and so not much more needs to be done besides trying again later
"Malicious": Things like a proof failing that should only happen if a Participant doesn't follow the protocol. Identifying and dealing with malicious behaviour will probably have its own control flow
"Bug": Things like InternalInvariantFailed which would only happen if there's a bug in the code.