### PR TITLE
CI Updates for Faster Execution.

### DIFF
--- a/.github/workflows/ignored_tests.yml
+++ b/.github/workflows/ignored_tests.yml
@@ -18,8 +18,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          # Set Rust version here!
+          toolchain: 1.67.0
           override: true
 
+      # Caching for Rust files. Must be called after installing Rust toolchain.
+      # See https://github.com/Swatinem/rust-cache for more information.
+      - name: Set Up Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run ignored tests (only!)
-        run: cargo test -- --ignored
+        run: cargo test --release -- --ignored

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,29 @@ jobs:
     name: ci
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
+        id: install-rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          # Set Rust version here!
+          toolchain: 1.67.0
           override: true
           components: rustfmt, clippy
+
+      # Caching for Rust files. Must be called after installing Rust toolchain.
+      # See https://github.com/Swatinem/rust-cache for more information.
+      - name: Set Up Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install cargo-make
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: --debug cargo-make
+
       - name: Run full CI (fmt, clippy, build, test, doctest, docs)
         run: cargo make ci
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/.DS_Store
 /target
 Cargo.lock
 **/*.rs.bk
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ generic-array = "0.14"
 hex = "0.4"
 k256 = { version = "0.10", features = ["arithmetic", "digest", "sha256", "ecdsa", "serde"] }
 lazy_static = "1"
-libpaillier = { version = "0.5", default-features = false, features = ["rust"] }
+libpaillier = { version = "0.5", default-features = false, features = ["gmp"] }
 merlin = "3"
 num-bigint = "0.4"
 rand = "0.8"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,10 @@
+[tasks.check]
+command = "cargo"
+args = ["check", "--tests", "--benches", "--all-targets"]
+
 # -- CI Tasks --
 [tasks.ci]
-dependencies = ["ci-format", "ci-clippy", "ci-build", "ci-test", "ci-doc-test", "ci-docs"]
+dependencies = ["ci-format", "ci-clippy", "ci-build", "ci-docs", "ci-doc-test", "ci-test"]
 
 [tasks.ci-format]
 command = "cargo"
@@ -12,17 +16,17 @@ args = ["clippy", "--all-targets", "--workspace", "--", "-Dwarnings"]
 
 [tasks.ci-build]
 command = "cargo"
-args = ["build", "--all-targets", "--workspace"]
-
-[tasks.ci-test]
-command = "cargo"
-args = ["test", "--lib", "--bins", "--workspace"]
-
-[tasks.ci-doc-test]
-command = "cargo"
-args = ["test", "--doc", "--workspace"]
+args = ["build", "--release",  "--all-targets", "--workspace"]
 
 [tasks.ci-docs]
 env = { "RUSTDOCFLAGS" = "-Dwarnings" }
 command = "cargo"
-args = ["doc", "--no-deps", "--document-private-items", "--workspace"]
+args = ["doc", "--release", "--no-deps", "--document-private-items", "--workspace"]
+
+[tasks.ci-doc-test]
+command = "cargo"
+args = ["test", "--release", "--doc", "--workspace"]
+
+[tasks.ci-test]
+command = "cargo"
+args = ["test", "--release", "--lib", "--bins", "--workspace"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Specifically, we are targeting the three-round presigning protocol (with quadrat
 
 This codebase is generally intended to be network-agnostic. Programs take messages as input and potentially output some outgoing messages in response. The relaying of these messages is assumed to happen externally. However, a proof-of-concept example of such networking code can be found in examples/network.
 
+## Project Dependencies
+This project relies on the `libpaillier` Rust crate using the GMP backend. GMP should be available during build-time.  
+
 ##  What's Implemented
 
 ### Key Generation (Figure 5 of CGGMP20)


### PR DESCRIPTION
This PR makes the following changes:
- Pins Rust compiler version to avoid Clippy failures on new Rust version releases.
- Switches libpaillier backend to use openssl.
- Compiles project in release version for faster test execution time. Use new `cargo make` or `cargo make check` for checking code without release mode.
- Uses rust-cache GitHub Action for caching Rust dependencies during compilation.

This should cut down on build time from ~30 minutes to ~10 minutes when building from scratch. Smaller changes should be even quicker if no recompilation is necessary. Here are runtime compiling from scratch and running `cargo make ci` locally (by no means rigorous, repeatable results!):
```
Original Times `cargo make ci` execution time using Rust backend for unknown_order crate:
- cargo clean +  --release.
Executed in  144.39 secs    fish           external
   usr time   24.71 mins    0.00 micros   24.71 mins
   sys time    1.57 mins  534.00 micros    1.57 mins

- cargo clean + debug mode
- Executed in  543.93 secs    fish           external
   usr time   41.82 mins  524.00 micros   41.82 mins
   sys time    0.89 mins  287.00 micros    0.89 mins

Using OpenSSL Backend.
- cargo clean + compile with release.
Executed in  135.71 secs    fish           external
   usr time   25.66 mins  418.00 micros   25.66 mins
   sys time    1.41 mins  265.00 micros    1.41 mins
```
Btw, I didn't have to install + cache the opennssl dependencies on the GitHub Actions CI. It seems they are already kinda installed. These commands were run in CI via our actions yaml file.
```
Run apt list | grep libcrypto

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

android-libcrypto-utils-dev/jammy 1:10.0.0+r36-9 all
android-libcrypto-utils/jammy 1:10.0.0+r36-9 amd64
libcrypto++-dev/jammy 8.6.0-2ubuntu1 amd64
libcrypto++-doc/jammy 8.6.0-2ubuntu1 all
libcrypto++-utils/jammy 8.6.0-2ubuntu1 amd64
libcrypto++8/jammy 8.6.0-2ubuntu1 amd64
libcrypto-equality-clojure/jammy 1.0.0-2 all
libcrypto-random-clojure/jammy 1.2.1-1 all
libcryptokit-ocaml-dev/jammy 1.16.1-1build3 amd64
libcryptokit-ocaml/jammy 1.16.1-1build3 amd64
libcryptominisat5-5.8/jammy 5.8.0+dfsg1-2 amd64
libcryptominisat5-dev/jammy 5.8.0+dfsg1-2 amd64

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

libssl-dev/jammy-updates,jammy-security,now 3.0.2-0ubuntu1.7 amd64 [installed]
libssl-doc/jammy-updates,jammy-security 3.0.2-0ubuntu1.7 all
libssl-ocaml-dev/jammy 0.5.10-1build2 amd64
libssl-ocaml/jammy 0.5.10-1build2 amd64
libssl-utils-clojure/jammy 3.3.0-1 all
libssl1.1/now 1.1.1f-1ubuntu2.16 amd64 [installed,local]
libssl3/jammy-updates,jammy-security,now 3.0.2-0ubuntu1.7 amd64 [installed,automatic]
```
Which is a little odd, but it does seem to just work? :grimacing: 