### PR TITLE
Rename pailler types without paillier

### DIFF
--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -8,22 +8,22 @@
 
 use crate::{
     errors::Result,
-    paillier::{PaillierDecryptionKey, PaillierEncryptionKey},
+    paillier::{DecryptionKey, EncryptionKey},
     zkp::setup::ZkSetupParameters,
 };
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 
-/// The private key corresponding to a given Participant's [AuxInfoPublic]
+/// The private key corresponding to a given Participant's [AuxInfoPublic].
 #[derive(Serialize, Deserialize)]
 pub(crate) struct AuxInfoPrivate {
-    pub(crate) sk: PaillierDecryptionKey,
+    pub(crate) sk: DecryptionKey,
 }
 
-/// The public Auxilary Information corresponding to a given Participant
+/// The public Auxilary Information corresponding to a given Participant.
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct AuxInfoPublic {
-    pub(crate) pk: PaillierEncryptionKey,
+    pub(crate) pk: EncryptionKey,
     pub(crate) params: ZkSetupParameters,
 }
 

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -15,7 +15,7 @@ use crate::{
     broadcast::participant::{BroadcastOutput, BroadcastParticipant},
     errors::Result,
     messages::{AuxinfoMessageType, Message, MessageType},
-    paillier::PaillierDecryptionKey,
+    paillier::DecryptionKey,
     participant::{Broadcast, ProtocolParticipant},
     protocol::ParticipantIdentifier,
     run_only_once,
@@ -507,7 +507,7 @@ impl AuxInfoParticipant {
 fn new_auxinfo<R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Result<(AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses)> {
-    let (decryption_key, p, q) = PaillierDecryptionKey::new(rng)?;
+    let (decryption_key, p, q) = DecryptionKey::new(rng)?;
     let encryption_key = decryption_key.encryption_key();
     let params = ZkSetupParameters::gen_from_primes(rng, &(&p * &q), &p, &q)?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@
 use core::fmt::Debug;
 use thiserror::Error;
 
-use crate::paillier::PaillierError;
+use crate::paillier;
 
 /// The default Result type used in this crate
 pub type Result<T> = std::result::Result<T, InternalError>;
@@ -42,7 +42,7 @@ pub enum InternalError {
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
-    PaillierError(PaillierError),
+    PaillierError(paillier::Error),
     #[error("Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)")]
     CouldNotConvertToScalar,
     #[error("Could not invert a Scalar")]

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -10,7 +10,7 @@ use crate::{
     auxinfo::info::AuxInfoPublic,
     errors::Result,
     messages::{Message, MessageType, PresignMessageType},
-    paillier::{PaillierCiphertext, PaillierEncryptionKey, PaillierNonce},
+    paillier::{Ciphertext, EncryptionKey, Nonce},
     zkp::{pienc::PiEncProof, setup::ZkSetupParameters, Proof},
 };
 use libpaillier::unknown_order::BigNumber;
@@ -19,11 +19,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Private {
     pub k: BigNumber,
-    pub rho: PaillierNonce,
+    pub rho: Nonce,
     pub gamma: BigNumber,
-    pub nu: PaillierNonce,
-    pub G: PaillierCiphertext, // Technically can be public but is only one per party
-    pub K: PaillierCiphertext, // Technically can be public but is only one per party
+    pub nu: Nonce,
+    pub G: Ciphertext, // Technically can be public but is only one per party
+    pub K: Ciphertext, // Technically can be public but is only one per party
 }
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Public {
@@ -32,8 +32,8 @@ pub(crate) struct Public {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct PublicBroadcast {
-    pub K: PaillierCiphertext,
-    pub G: PaillierCiphertext,
+    pub K: Ciphertext,
+    pub G: Ciphertext,
 }
 
 impl Public {
@@ -43,7 +43,7 @@ impl Public {
     fn verify(
         &self,
         receiver_setup_params: &ZkSetupParameters,
-        sender_pk: &PaillierEncryptionKey,
+        sender_pk: &EncryptionKey,
         broadcasted_params: &PublicBroadcast,
     ) -> Result<()> {
         let input = crate::zkp::pienc::PiEncInput::new(

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -11,7 +11,7 @@ use crate::{
     errors::Result,
     keygen::keyshare::KeySharePublic,
     messages::{Message, MessageType, PresignMessageType},
-    paillier::PaillierCiphertext,
+    paillier::Ciphertext,
     presign::round_one::{Private as RoundOnePrivate, PublicBroadcast as RoundOnePublicBroadcast},
     utils::k256_order,
     zkp::{
@@ -32,10 +32,10 @@ pub(crate) struct Private {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct Public {
-    pub D: PaillierCiphertext,
-    pub D_hat: PaillierCiphertext,
-    pub F: PaillierCiphertext,
-    pub F_hat: PaillierCiphertext,
+    pub D: Ciphertext,
+    pub D_hat: Ciphertext,
+    pub F: Ciphertext,
+    pub F_hat: Ciphertext,
     pub Gamma: CurvePoint,
     pub psi: PiAffgProof,
     pub psi_hat: PiAffgProof,

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -11,8 +11,8 @@
 use super::Proof;
 use crate::{
     errors::*,
-    paillier::{MaskedNonce, PaillierNonce},
-    paillier::{PaillierCiphertext, PaillierEncryptionKey},
+    paillier::{Ciphertext, EncryptionKey},
+    paillier::{MaskedNonce, Nonce},
     parameters::{ELL, EPSILON},
     utils::{
         self, modpow, plusminus_bn_random_from_transcript, random_plusminus_by_size,
@@ -30,7 +30,7 @@ use utils::CurvePoint;
 pub(crate) struct PiLogProof {
     alpha: BigNumber,
     S: BigNumber,
-    A: PaillierCiphertext,
+    A: Ciphertext,
     Y: CurvePoint,
     D: BigNumber,
     e: BigNumber,
@@ -44,8 +44,8 @@ pub(crate) struct PiLogInput {
     setup_params: ZkSetupParameters,
     q: BigNumber,
     /// This corresponds to `N_0` in the paper.
-    pk: PaillierEncryptionKey,
-    C: PaillierCiphertext,
+    pk: EncryptionKey,
+    C: Ciphertext,
     X: CurvePoint,
     g: CurvePoint,
 }
@@ -54,8 +54,8 @@ impl PiLogInput {
     pub(crate) fn new(
         setup_params: &ZkSetupParameters,
         q: &BigNumber,
-        pk: &PaillierEncryptionKey,
-        C: &PaillierCiphertext,
+        pk: &EncryptionKey,
+        C: &Ciphertext,
         X: &CurvePoint,
         g: &CurvePoint,
     ) -> Self {
@@ -72,11 +72,11 @@ impl PiLogInput {
 
 pub(crate) struct PiLogSecret {
     x: BigNumber,
-    rho: PaillierNonce,
+    rho: Nonce,
 }
 
 impl PiLogSecret {
-    pub(crate) fn new(x: &BigNumber, rho: &PaillierNonce) -> Self {
+    pub(crate) fn new(x: &BigNumber, rho: &Nonce) -> Self {
         Self {
             x: x.clone(),
             rho: rho.clone(),
@@ -172,7 +172,6 @@ impl Proof for PiLogProof {
         }
 
         // Do equality checks
-
         let eq_check_1 = {
             let lhs = input.pk.encrypt_with_nonce(&self.z1, &self.z2)?;
             let rhs = input.pk.multiply_and_add(&self.e, &input.C, &self.A)?;
@@ -219,10 +218,10 @@ impl Proof for PiLogProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{paillier::PaillierDecryptionKey, utils::random_plusminus_by_size_with_minimum};
+    use crate::{paillier::DecryptionKey, utils::random_plusminus_by_size_with_minimum};
 
     fn random_paillier_log_proof<R: RngCore + CryptoRng>(rng: &mut R, x: &BigNumber) -> Result<()> {
-        let (decryption_key, _, _) = PaillierDecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = DecryptionKey::new(rng)?;
         let pk = decryption_key.encryption_key();
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);

--- a/src/zkp/setup.rs
+++ b/src/zkp/setup.rs
@@ -29,9 +29,9 @@ pub(crate) struct ZkSetupParameters {
 impl ZkSetupParameters {
     #[cfg(test)]
     pub(crate) fn gen<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Self> {
-        use crate::paillier::PaillierDecryptionKey;
+        use crate::paillier::DecryptionKey;
 
-        let (_, p, q) = PaillierDecryptionKey::new(rng)?;
+        let (_, p, q) = DecryptionKey::new(rng)?;
         let N = &p * &q;
         Self::gen_from_primes(rng, &N, &p, &q)
     }


### PR DESCRIPTION
This renames all the Paillier types to not have the word `Paillier` in them. I decided not to put the path inline where we use it (e.g. `pailler::Type`) because we don't have any other ciphertext or nonce or encryption key types that it might get confused with.

Closes #119.