### PR TITLE
Add logging support for our library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,18 +31,23 @@ rand = "0.8"
 serde = "1"
 sha2 = "0.9"
 thiserror = "1"
+tracing = "0.1.37"
 
 [dev-dependencies]
 anyhow = "1"
 clap = { version = "3", features = ["derive"] }
 criterion = "0.3"
 dialoguer = "0.10"
+env_logger = "0.10.0"
 glass_pumpkin = "1"
 indicatif = "0.16"
 openssl = "0.10"
 reqwest = { version = "0.11", features = ["json"] }
 rocket = { version = "0.5.0-rc", default-features = false, features = ["json"] }
 rug = { version = "1.16", default-features = false, features = ["integer", "rand"] }
+test-log = { version = "0.2.11", features = ["trace"]}
+tracing = {version = "0.1", default-features = false}
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["full"] }
 
 [[bench]]

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -360,6 +360,7 @@ pub(crate) mod prime_gen {
 mod test {
     use libpaillier::unknown_order::BigNumber;
     use rand::{CryptoRng, Rng, RngCore};
+    use test_log::test;
 
     use crate::{
         paillier::Ciphertext,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,6 +242,7 @@ pub(crate) fn k256_order() -> BigNumber {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     #[test]
     fn test_random_bn_in_range() {

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -286,7 +286,7 @@ impl Proof for PiAffgProof {
 mod tests {
     use super::*;
     use crate::{paillier::DecryptionKey, utils::random_plusminus_by_size_with_minimum};
-
+    use test_log::test;
     fn random_paillier_affg_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
         x: &BigNumber,

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -264,6 +264,7 @@ mod tests {
         paillier::DecryptionKey,
         utils::{random_plusminus, random_plusminus_by_size_with_minimum, random_positive_bn},
     };
+    use test_log::test;
 
     fn build_random_proof<R: RngCore + CryptoRng>(
         rng: &mut R,

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -324,6 +324,7 @@ mod tests {
         paillier::DecryptionKey, ring_pedersen::VerifiedRingPedersen,
         utils::random_plusminus_by_size_with_minimum,
     };
+    use test_log::test;
 
     fn random_paillier_log_proof<R: RngCore + CryptoRng>(rng: &mut R, x: &BigNumber) -> Result<()> {
         let (decryption_key, _, _) = DecryptionKey::new(rng)?;

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -374,6 +374,7 @@ mod tests {
         paillier::{prime_gen, DecryptionKey},
         parameters::SOUNDNESS_PARAMETER,
     };
+    use test_log::test;
 
     #[test]
     fn test_jacobi() {

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -165,6 +165,7 @@ mod tests {
     use super::*;
     use crate::paillier::DecryptionKey;
     use rand::Rng;
+    use test_log::test;
 
     fn random_ring_pedersen_proof<R: RngCore + CryptoRng>(
         rng: &mut R,

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -190,6 +190,7 @@ impl PiSchProof {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_log::test;
 
     fn random_schnorr_proof<R: RngCore + CryptoRng>(
         rng: &mut R,


### PR DESCRIPTION
Closes #31

- Add logging events and spans to main functions.
- Set logging for unit tests and example application.
- Add documentation on how logging works and how to add new logging events and spans.