### PR TITLE
Add `Transcript` to `Proof` trait

### DIFF
--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -13,6 +13,7 @@ use crate::{
     zkp::{
         pifac::{PiFacInput, PiFacProof, PiFacSecret},
         pimod::{PiModInput, PiModProof, PiModSecret},
+        Proof,
     },
     Identifier, Message,
 };
@@ -48,21 +49,21 @@ impl AuxInfoProof {
         let mut pimod_transcript = Transcript::new(b"PaillierBlumModulusProof");
         pimod_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pimod_transcript.append_message(b"rho", &rho);
-        let pimod = PiModProof::prove_with_transcript(
-            rng,
+        let pimod = PiModProof::prove(
             &PiModInput::new(N),
             &PiModSecret::new(p, q),
             &mut pimod_transcript,
+            rng,
         )?;
 
         let mut pifac_transcript = Transcript::new(b"PiFacProof");
         pifac_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pifac_transcript.append_message(b"rho", &rho);
-        let pifac = PiFacProof::prove_with_transcript(
-            rng,
+        let pifac = PiFacProof::prove(
             &PiFacInput::new(setup_params, N),
             &PiFacSecret::new(p, q),
             &mut pifac_transcript,
+            rng,
         )?;
 
         Ok(Self { pimod, pifac })
@@ -79,13 +80,13 @@ impl AuxInfoProof {
         pimod_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pimod_transcript.append_message(b"rho", &rho);
         self.pimod
-            .verify_with_transcript(&PiModInput::new(N), &mut pimod_transcript)?;
+            .verify(&PiModInput::new(N), &mut pimod_transcript)?;
 
         let mut pifac_transcript = Transcript::new(b"PiFacProof");
         pifac_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pifac_transcript.append_message(b"rho", &rho);
         self.pifac
-            .verify_with_transcript(&PiFacInput::new(params, N), &mut pifac_transcript)?;
+            .verify(&PiFacInput::new(params, N), &mut pifac_transcript)?;
         Ok(())
     }
 }

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -15,6 +15,7 @@ use crate::{
     zkp::{pienc::PiEncProof, Proof},
 };
 use libpaillier::unknown_order::BigNumber;
+use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -47,9 +48,9 @@ impl Public {
         sender_pk: EncryptionKey,
         K: Ciphertext,
     ) -> Result<()> {
+        let mut transcript = Transcript::new(b"PiEncProof");
         let input = crate::zkp::pienc::PiEncInput::new(receiver_setup_params.clone(), sender_pk, K);
-
-        self.proof.verify(&input)
+        self.proof.verify(&input, &mut transcript)
     }
 
     pub(crate) fn from_message(

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -23,6 +23,7 @@ use crate::{
 };
 use k256::Scalar;
 use libpaillier::unknown_order::BigNumber;
+use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -50,6 +51,7 @@ impl Public {
         sender_keygen_public: &AuxInfoPublic,
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<()> {
+        let mut transcript = Transcript::new(b"PiLogProof");
         let psi_double_prime_input = PiLogInput::new(
             &receiver_keygen_public.params,
             &k256_order(),
@@ -58,7 +60,8 @@ impl Public {
             &self.Delta,
             &self.Gamma,
         );
-        self.psi_double_prime.verify(&psi_double_prime_input)?;
+        self.psi_double_prime
+            .verify(&psi_double_prime_input, &mut transcript)?;
 
         Ok(())
     }

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -22,6 +22,7 @@ use crate::{
     CurvePoint,
 };
 use libpaillier::unknown_order::BigNumber;
+use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -64,7 +65,8 @@ impl Public {
             &self.F,
             &self.Gamma,
         );
-        self.psi.verify(&psi_input)?;
+        let mut transcript = Transcript::new(b"PiAffgProof");
+        self.psi.verify(&psi_input, &mut transcript)?;
 
         // Verify the psi_hat proof
         let psi_hat_input = PiAffgInput::new(
@@ -77,7 +79,8 @@ impl Public {
             &self.F_hat,
             &sender_keyshare_public.X,
         );
-        self.psi_hat.verify(&psi_hat_input)?;
+        let mut transcript = Transcript::new(b"PiAffgProof");
+        self.psi_hat.verify(&psi_hat_input, &mut transcript)?;
 
         // Verify the psi_prime proof
         let psi_prime_input = PiLogInput::new(
@@ -88,7 +91,8 @@ impl Public {
             &self.Gamma,
             &g,
         );
-        self.psi_prime.verify(&psi_prime_input)?;
+        let mut transcript = Transcript::new(b"PiLogProof");
+        self.psi_prime.verify(&psi_prime_input, &mut transcript)?;
 
         Ok(())
     }

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -1,9 +1,16 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
+// Modifications Copyright (c) 2023 Bolt Labs, Inc.
 //
 // This source code is licensed under both the MIT license found in the
 // LICENSE-MIT file in the root directory of this source tree and the Apache
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
+
+//! Implements a trait for zero-knowledge proofs.
+//!
+//! In more detail, this module provides a trait [`Proof`] for constructing a (non-interactive)
+//! zero knowledge proof. The trait provides two methods, [`Proof::prove`] and [`Proof::verify`].
+//! The former builds a proof and the latter verifies the proof was constructed correctly.
 
 pub(crate) mod piaffg;
 pub(crate) mod pienc;
@@ -14,17 +21,26 @@ pub(crate) mod piprm;
 pub(crate) mod pisch;
 
 use crate::errors::Result;
+use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{de::DeserializeOwned, Serialize};
+
+/// A trait for constructing zero knowledge proofs.
+///
+/// The associated type [`Proof::CommonInput`] denotes the data known the both the prover
+/// and verifier, and the associated type [`Proof::ProverSecret`] denotes the data known
+/// only to the prover.
 pub(crate) trait Proof: Sized + Serialize + DeserializeOwned {
     type CommonInput;
     type ProverSecret;
-
+    /// Constructs a zero knowledge proof over [`Proof::ProverSecret`] and [`Proof::CommonInput`]
+    /// using the provided [`Transcript`].
     fn prove<R: RngCore + CryptoRng>(
-        rng: &mut R,
         input: &Self::CommonInput,
         secret: &Self::ProverSecret,
+        transcript: &mut Transcript,
+        rng: &mut R,
     ) -> Result<Self>;
-
-    fn verify(&self, input: &Self::CommonInput) -> Result<()>;
+    /// Verifies a zero knowledge proof using the provided [`Proof::CommonInput`] and [`Transcript`].
+    fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()>;
 }

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -8,9 +8,10 @@
 
 //! Implements a trait for zero-knowledge proofs.
 //!
-//! In more detail, this module provides a trait [`Proof`] for constructing a (non-interactive)
-//! zero knowledge proof. The trait provides two methods, [`Proof::prove`] and [`Proof::verify`].
-//! The former builds a proof and the latter verifies the proof was constructed correctly.
+//! In more detail, this module provides a trait [`Proof`] for constructing a
+//! (non-interactive) zero knowledge proof. The trait provides two methods,
+//! [`Proof::prove`] and [`Proof::verify`]. The former builds a proof and the
+//! latter verifies the proof was constructed correctly.
 
 pub(crate) mod piaffg;
 pub(crate) mod pienc;
@@ -27,20 +28,21 @@ use serde::{de::DeserializeOwned, Serialize};
 
 /// A trait for constructing zero knowledge proofs.
 ///
-/// The associated type [`Proof::CommonInput`] denotes the data known the both the prover
-/// and verifier, and the associated type [`Proof::ProverSecret`] denotes the data known
-/// only to the prover.
+/// The associated type [`Proof::CommonInput`] denotes the data known the both
+/// the prover and verifier, and the associated type [`Proof::ProverSecret`]
+/// denotes the data known only to the prover.
 pub(crate) trait Proof: Sized + Serialize + DeserializeOwned {
     type CommonInput;
     type ProverSecret;
-    /// Constructs a zero knowledge proof over [`Proof::ProverSecret`] and [`Proof::CommonInput`]
-    /// using the provided [`Transcript`].
+    /// Constructs a zero knowledge proof over [`Proof::ProverSecret`] and
+    /// [`Proof::CommonInput`] using the provided [`Transcript`].
     fn prove<R: RngCore + CryptoRng>(
         input: &Self::CommonInput,
         secret: &Self::ProverSecret,
         transcript: &mut Transcript,
         rng: &mut R,
     ) -> Result<Self>;
-    /// Verifies a zero knowledge proof using the provided [`Proof::CommonInput`] and [`Transcript`].
+    /// Verifies a zero knowledge proof using the provided
+    /// [`Proof::CommonInput`] and [`Transcript`].
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()>;
 }

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -171,7 +171,8 @@ impl Proof for PiEncProof {
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
-        // Check Fiat-Shamir challenge consistency: update the transcript with commitments...
+        // Check Fiat-Shamir challenge consistency: update the transcript with
+        // commitments...
         Self::fill_out_transcript(
             transcript,
             input,

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -113,9 +113,10 @@ impl Proof for PiEncProof {
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
     fn prove<R: RngCore + CryptoRng>(
-        rng: &mut R,
         input: &Self::CommonInput,
         secret: &Self::ProverSecret,
+        transcript: &mut Transcript,
+        rng: &mut R,
     ) -> Result<Self> {
         // Sample a mask for the plaintext (aka `alpha`)
         let plaintext_mask = random_plusminus_by_size(rng, ELL + EPSILON);
@@ -136,9 +137,8 @@ impl Proof for PiEncProof {
                 .commit(&plaintext_mask, ELL + EPSILON, rng);
 
         // Fill out the transcript with our fresh commitments...
-        let mut transcript = Transcript::new(b"PiEncProof");
         Self::fill_out_transcript(
-            &mut transcript,
+            transcript,
             input,
             &plaintext_commit,
             &ciphertext_mask,
@@ -146,7 +146,7 @@ impl Proof for PiEncProof {
         )?;
 
         // ...and generate a challenge from it (aka `e`)
-        let challenge = plusminus_bn_random_from_transcript(&mut transcript, &k256_order());
+        let challenge = plusminus_bn_random_from_transcript(transcript, &k256_order());
 
         // Form proof responses. Each combines one secret value with its mask and the
         // challenge (aka `z1`, `z2`, `z3` respectively)
@@ -170,12 +170,10 @@ impl Proof for PiEncProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
-    fn verify(&self, input: &Self::CommonInput) -> Result<()> {
-        // Check Fiat-Shamir challenge consistency: update the transcript with
-        // commitments...
-        let mut transcript = Transcript::new(b"PiEncProof");
+    fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
+        // Check Fiat-Shamir challenge consistency: update the transcript with commitments...
         Self::fill_out_transcript(
-            &mut transcript,
+            transcript,
             input,
             &self.plaintext_commit,
             &self.ciphertext_mask,
@@ -183,7 +181,7 @@ impl Proof for PiEncProof {
         )?;
 
         // ...generate a challenge, and make sure it matches the one the prover sent.
-        let e = plusminus_bn_random_from_transcript(&mut transcript, &k256_order());
+        let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
         if e != self.challenge {
             return verify_err!("Fiat-Shamir didn't verify");
         }
@@ -282,7 +280,13 @@ mod tests {
             ciphertext,
         };
 
-        let proof = PiEncProof::prove(rng, &input, &PiEncSecret { plaintext, nonce })?;
+        let mut transcript = Transcript::new(b"PiEncProof");
+        let proof = PiEncProof::prove(
+            &input,
+            &PiEncSecret { plaintext, nonce },
+            &mut transcript,
+            rng,
+        )?;
 
         Ok((proof, input))
     }
@@ -299,8 +303,10 @@ mod tests {
         let roundtrip_proof_bytes = bincode::serialize(&roundtrip_proof).unwrap();
 
         assert_eq!(proof_bytes, roundtrip_proof_bytes);
-        assert!(proof.verify(&input).is_ok());
-        assert!(roundtrip_proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(roundtrip_proof.verify(&input, &mut transcript).is_ok());
 
         Ok(())
     }
@@ -312,19 +318,22 @@ mod tests {
         // A plaintext in the range 2^ELL should always succeed
         let in_range = random_plusminus_by_size(&mut rng, ELL);
         let (proof, input) = build_random_proof(&mut rng, in_range)?;
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         // A plaintext in range for encryption but larger (absolute value) than 2^ELL
         // should fail
         let too_large =
             random_plusminus_by_size_with_minimum(&mut rng, ELL + EPSILON + 1, ELL + EPSILON)?;
         let (proof, input) = build_random_proof(&mut rng, too_large.clone())?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
 
         // Ditto with the opposite sign for the too-large plaintext
         let too_small = -too_large;
         let (proof, input) = build_random_proof(&mut rng, too_small)?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
 
         // PiEnc expects an input in the range ±2^ELL. The proof can guarantee this
         // range up to the slackness parameter -- that is, that the input is in
@@ -334,16 +343,20 @@ mod tests {
         // The lower edge case works (2^ELL))
         let lower_bound = BigNumber::one() << ELL;
         let (proof, input) = build_random_proof(&mut rng, lower_bound.clone())?;
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
         let (proof, input) = build_random_proof(&mut rng, -lower_bound)?;
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         // The higher edge case fails (2^ELL+EPSILON)
         let upper_bound = BigNumber::one() << (ELL + EPSILON);
         let (proof, input) = build_random_proof(&mut rng, upper_bound.clone())?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
         let (proof, input) = build_random_proof(&mut rng, -upper_bound)?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
 
         Ok(())
     }
@@ -367,7 +380,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.plaintext_commit = scheme.commit(&plaintext, ELL, rng).0;
             assert_ne!(&bad_proof.plaintext_commit, &proof.plaintext_commit);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad ciphertext mask (encryption of wrong value with wrong nonce)
@@ -375,7 +389,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.ciphertext_mask = input.encryption_key.encrypt(rng, &random_mask).unwrap().0;
             assert_ne!(bad_proof.ciphertext_mask, proof.ciphertext_mask);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad plaintext mask commitment (commitment to wrong value with wrong
@@ -384,7 +399,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.plaintext_mask_commit = bad_plaintext_mask;
             assert_ne!(bad_proof.plaintext_mask_commit, proof.plaintext_mask_commit);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad challenge fails
@@ -392,7 +408,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.challenge = random_plusminus(rng, &k256_order());
             assert_ne!(bad_proof.challenge, proof.challenge);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad plaintext response fails (this can be an arbitrary integer, using
@@ -401,7 +418,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.plaintext_response = random_positive_bn(rng, scheme.modulus());
             assert_ne!(bad_proof.plaintext_response, proof.plaintext_response);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad nonce response fails
@@ -409,7 +427,8 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.nonce_response = MaskedNonce::random(rng, input.encryption_key.modulus());
             assert_ne!(bad_proof.nonce_response, proof.nonce_response);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // Bad randomness response fails (ditto on arbitrary integer)
@@ -417,11 +436,13 @@ mod tests {
             let mut bad_proof = proof.clone();
             bad_proof.randomness_response = bad_randomness.as_masked().to_owned();
             assert_ne!(bad_proof.randomness_response, proof.randomness_response);
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiEncProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
 
         // The original proof itself verifies correctly, though!
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
     }
 
     #[test]
@@ -444,41 +465,50 @@ mod tests {
         };
 
         // Correctly formed proof verifies correctly
+        let mut transcript = Transcript::new(b"PiEncProof");
         let proof = PiEncProof::prove(
-            rng,
             &input,
             &PiEncSecret {
                 plaintext: plaintext.clone(),
                 nonce: nonce.clone(),
             },
+            &mut transcript,
+            rng,
         )?;
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         // Forming with the wrong plaintext fails
         let wrong_plaintext = random_plusminus_by_size(rng, ELL);
         assert_ne!(wrong_plaintext, plaintext);
+        let mut transcript = Transcript::new(b"PiEncProof");
         let proof = PiEncProof::prove(
-            rng,
             &input,
             &PiEncSecret {
                 plaintext: wrong_plaintext,
                 nonce: nonce.clone(),
             },
+            &mut transcript,
+            rng,
         )?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
 
         // Forming with the wrong nonce fails
         let (_, wrong_nonce) = encryption_key.encrypt(rng, &plaintext)?;
         assert_ne!(wrong_nonce, nonce);
+        let mut transcript = Transcript::new(b"PiEncProof");
         let proof = PiEncProof::prove(
-            rng,
             &input,
             &PiEncSecret {
                 plaintext,
                 nonce: wrong_nonce,
             },
+            &mut transcript,
+            rng,
         )?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
 
         Ok(())
     }
@@ -493,27 +523,37 @@ mod tests {
         let (proof, mut input) = build_random_proof(&mut rng, plaintext.clone())?;
 
         // Verification works on the original input
-        assert!(proof.verify(&input).is_ok());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         // Verification fails with the wrong setup params
         let (bad_decryption_key, _, _) = DecryptionKey::new(&mut rng)?;
         let bad_setup_params = VerifiedRingPedersen::extract(&bad_decryption_key, &mut rng)?;
         let setup_params = input.setup_params;
         input.setup_params = bad_setup_params;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
         input.setup_params = setup_params;
 
         // Verification fails with the wrong encryption key
         let bad_encryption_key = DecryptionKey::new(&mut rng)?.0.encryption_key();
         let encryption_key = input.encryption_key;
         input.encryption_key = bad_encryption_key;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
         input.encryption_key = encryption_key;
 
         // Verification fails with the wrong ciphertext
         let (bad_ciphertext, _) = input.encryption_key.encrypt(&mut rng, &plaintext)?;
+        let ciphertext = input.ciphertext;
         input.ciphertext = bad_ciphertext;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_err());
+        input.ciphertext = ciphertext;
+
+        // Proof still works (as in, it wasn't just failing due to bad transcripts)
+        let mut transcript = Transcript::new(b"PiEncProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         Ok(())
     }

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -71,9 +71,10 @@ impl Proof for PiFacProof {
 
     #[cfg_attr(feature = "flame_it", flame("PiFacProof"))]
     fn prove<R: RngCore + CryptoRng>(
-        rng: &mut R,
         input: &Self::CommonInput,
         secret: &Self::ProverSecret,
+        transcript: &mut Transcript,
+        rng: &mut R,
     ) -> Result<Self> {
         // Small names for scaling factors in our ranges
         let sqrt_N0 = &sqrt(&input.N0);
@@ -104,7 +105,6 @@ impl Proof for PiFacProof {
             rng,
         );
 
-        let mut transcript = Transcript::new(b"PiFacProof");
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(P, Q, A, B, T, sigma)",
@@ -120,7 +120,7 @@ impl Proof for PiFacProof {
         );
 
         // Verifier samples e in +- q (where q is the group order)
-        let e = plusminus_bn_random_from_transcript(&mut transcript, &k256_order());
+        let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
 
         let sigma_hat = nu.mask_neg(&sigma, &secret.p);
         let z1 = &alpha + &e * &secret.p;
@@ -145,8 +145,7 @@ impl Proof for PiFacProof {
         Ok(proof)
     }
 
-    fn verify(&self, input: &Self::CommonInput) -> Result<()> {
-        let mut transcript = Transcript::new(b"PiFacProof");
+    fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(P, Q, A, B, T, sigma)",
@@ -161,7 +160,7 @@ impl Proof for PiFacProof {
             .concat(),
         );
         // Verifier samples e in +- q (where q is the group order)
-        let e = plusminus_bn_random_from_transcript(&mut transcript, &k256_order());
+        let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
 
         let eq_check_1 = {
             let lhs = input.setup_params.scheme().reconstruct(&self.z1, &self.w1);
@@ -221,153 +220,6 @@ fn sqrt(num: &BigNumber) -> BigNumber {
     BigNumber::from_slice(sqrt.to_bytes_be().1)
 }
 
-impl PiFacProof {
-    pub(crate) fn prove_with_transcript<R: RngCore + CryptoRng>(
-        rng: &mut R,
-        input: &PiFacInput,
-        secret: &PiFacSecret,
-        transcript: &mut Transcript,
-    ) -> Result<Self> {
-        // Small names for scaling factors in our ranges
-        let sqrt_N0 = &sqrt(&input.N0);
-
-        let alpha = random_plusminus_scaled(rng, ELL + EPSILON, sqrt_N0);
-        let beta = random_plusminus_scaled(rng, ELL + EPSILON, sqrt_N0);
-
-        let sigma = input
-            .setup_params
-            .scheme()
-            .commitment_randomness(ELL, &input.N0, rng);
-
-        let (P, mu) = input.setup_params.scheme().commit(&secret.p, ELL, rng);
-        let (Q, nu) = input.setup_params.scheme().commit(&secret.q, ELL, rng);
-        let (A, x) = input
-            .setup_params
-            .scheme()
-            .commit(&alpha, ELL + EPSILON, rng);
-        let (B, y) = input
-            .setup_params
-            .scheme()
-            .commit(&beta, ELL + EPSILON, rng);
-        let (T, r) = input.setup_params.scheme().commit_with_commitment(
-            &Q,
-            &alpha,
-            ELL + EPSILON,
-            &input.N0,
-            rng,
-        );
-
-        transcript.append_message(b"CommonInput", &serialize!(&input)?);
-        transcript.append_message(
-            b"(P, Q, A, B, T, sigma)",
-            &[
-                P.to_bytes(),
-                Q.to_bytes(),
-                A.to_bytes(),
-                B.to_bytes(),
-                T.to_bytes(),
-                sigma.to_bytes(),
-            ]
-            .concat(),
-        );
-
-        // Verifier samples e in +- q (where q is the group order)
-        let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
-
-        let sigma_hat = nu.mask_neg(&sigma, &secret.p);
-        let z1 = &alpha + &e * &secret.p;
-        let z2 = &beta + &e * &secret.q;
-        let w1 = mu.mask(&x, &e);
-        let w2 = nu.mask(&y, &e);
-        let v = sigma_hat.remask(&r, &e);
-
-        let proof = Self {
-            P,
-            Q,
-            A,
-            B,
-            T,
-            sigma,
-            z1,
-            z2,
-            w1,
-            w2,
-            v,
-        };
-        Ok(proof)
-    }
-
-    pub(crate) fn verify_with_transcript(
-        &self,
-        input: &PiFacInput,
-        transcript: &mut Transcript,
-    ) -> Result<()> {
-        transcript.append_message(b"CommonInput", &serialize!(&input)?);
-        transcript.append_message(
-            b"(P, Q, A, B, T, sigma)",
-            &[
-                self.P.to_bytes(),
-                self.Q.to_bytes(),
-                self.A.to_bytes(),
-                self.B.to_bytes(),
-                self.T.to_bytes(),
-                self.sigma.to_bytes(),
-            ]
-            .concat(),
-        );
-        // Verifier samples e in +- q (where q is the group order)
-        let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
-
-        let eq_check_1 = {
-            let lhs = input.setup_params.scheme().reconstruct(&self.z1, &self.w1);
-            let rhs = input.setup_params.scheme().combine(&self.A, &self.P, &e);
-            lhs == rhs
-        };
-        if !eq_check_1 {
-            return verify_err!("eq_check_1 failed");
-        }
-
-        let eq_check_2 = {
-            let lhs = input.setup_params.scheme().reconstruct(&self.z2, &self.w2);
-            let rhs = input.setup_params.scheme().combine(&self.B, &self.Q, &e);
-            lhs == rhs
-        };
-        if !eq_check_2 {
-            return verify_err!("eq_check_2 failed");
-        }
-
-        let eq_check_3 = {
-            let R = input
-                .setup_params
-                .scheme()
-                .reconstruct(&input.N0, self.sigma.as_masked());
-            let lhs = input
-                .setup_params
-                .scheme()
-                .reconstruct_with_commitment(&self.Q, &self.z1, &self.v);
-            let rhs = input.setup_params.scheme().combine(&self.T, &R, &e);
-            lhs == rhs
-        };
-        if !eq_check_3 {
-            return verify_err!("eq_check_3 failed");
-        }
-
-        let sqrt_N0 = sqrt(&input.N0);
-        // 2^{ELL + EPSILON}
-        let two_ell_eps = BigNumber::one() << (ELL + EPSILON);
-        // 2^{ELL + EPSILON} * sqrt(N_0)
-        let z_bound = &sqrt_N0 * &two_ell_eps;
-        if self.z1 < -z_bound.clone() || self.z1 > z_bound {
-            return verify_err!("self.z1 > z_bound check failed");
-        }
-        if self.z2 < -z_bound.clone() || self.z2 > z_bound {
-            return verify_err!("self.z2 > z_bound check failed");
-        }
-
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::paillier::prime_gen;
@@ -381,8 +233,9 @@ mod tests {
         let N0 = &p0 * &q0;
         let setup_params = VerifiedRingPedersen::gen(rng)?;
 
+        let mut transcript = Transcript::new(b"PiFac Test");
         let input = PiFacInput::new(&setup_params, &N0);
-        let proof = PiFacProof::prove(rng, &input, &PiFacSecret::new(&p0, &q0))?;
+        let proof = PiFacProof::prove(&input, &PiFacSecret::new(&p0, &q0), &mut transcript, rng)?;
 
         Ok((input, proof))
     }
@@ -391,7 +244,8 @@ mod tests {
     fn test_no_small_factors_proof() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
         let (input, proof) = random_no_small_factors_proof(&mut rng)?;
-        proof.verify(&input)?;
+        let mut transcript = Transcript::new(b"PiFac Test");
+        proof.verify(&input, &mut transcript)?;
         Ok(())
     }
 
@@ -400,46 +254,75 @@ mod tests {
         let mut rng = crate::utils::get_test_rng();
         let (input, proof) = random_no_small_factors_proof(&mut rng)?;
 
-        let incorrect_N = PiFacInput::new(
-            &input.setup_params,
-            &prime_gen::try_get_prime_from_pool_insecure(&mut rng).unwrap(),
-        );
-        assert!(proof.verify(&incorrect_N).is_err());
+        {
+            let incorrect_N = PiFacInput::new(
+                &input.setup_params,
+                &prime_gen::try_get_prime_from_pool_insecure(&mut rng).unwrap(),
+            );
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(proof.verify(&incorrect_N, &mut transcript).is_err());
+        }
+        {
+            let incorrect_startup_params =
+                PiFacInput::new(&VerifiedRingPedersen::gen(&mut rng)?, &input.N0);
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(proof
+                .verify(&incorrect_startup_params, &mut transcript)
+                .is_err());
+        }
+        {
+            let mut transcript = Transcript::new(b"PiFac Test");
+            let (not_p0, not_q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
+            let incorrect_factors = PiFacProof::prove(
+                &input,
+                &PiFacSecret::new(&not_p0, &not_q0),
+                &mut transcript,
+                &mut rng,
+            )?;
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(incorrect_factors.verify(&input, &mut transcript).is_err());
 
-        let incorrect_startup_params =
-            PiFacInput::new(&VerifiedRingPedersen::gen(&mut rng)?, &input.N0);
-        assert!(proof.verify(&incorrect_startup_params).is_err());
+            let mut transcript = Transcript::new(b"PiFac Test");
+            let small_p = BigNumber::from(7u64);
+            let small_q = BigNumber::from(11u64);
+            let setup_params = VerifiedRingPedersen::gen(&mut rng)?;
+            let small_input = PiFacInput::new(&setup_params, &(&small_p * &small_q));
+            let small_proof = PiFacProof::prove(
+                &input,
+                &PiFacSecret::new(&small_p, &small_q),
+                &mut transcript,
+                &mut rng,
+            )?;
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(small_proof.verify(&small_input, &mut transcript).is_err());
 
-        let (not_p0, not_q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
-        let incorrect_factors =
-            PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&not_p0, &not_q0))?;
-        assert!(incorrect_factors.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiFac Test");
+            let regular_sized_q = prime_gen::try_get_prime_from_pool_insecure(&mut rng).unwrap();
+            let mixed_input = PiFacInput::new(&setup_params, &(&small_p * &regular_sized_q));
+            let mixed_proof = PiFacProof::prove(
+                &input,
+                &PiFacSecret::new(&small_p, &regular_sized_q),
+                &mut transcript,
+                &mut rng,
+            )?;
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(mixed_proof.verify(&mixed_input, &mut transcript).is_err());
 
-        let small_p = BigNumber::from(7u64);
-        let small_q = BigNumber::from(11u64);
-        let setup_params = VerifiedRingPedersen::gen(&mut rng)?;
-        let small_input = PiFacInput::new(&setup_params, &(&small_p * &small_q));
-        let small_proof =
-            PiFacProof::prove(&mut rng, &input, &PiFacSecret::new(&small_p, &small_q))?;
-        assert!(small_proof.verify(&small_input).is_err());
-
-        let regular_sized_q = prime_gen::try_get_prime_from_pool_insecure(&mut rng).unwrap();
-        let mixed_input = PiFacInput::new(&setup_params, &(&small_p * &regular_sized_q));
-        let mixed_proof = PiFacProof::prove(
-            &mut rng,
-            &input,
-            &PiFacSecret::new(&small_p, &regular_sized_q),
-        )?;
-        assert!(mixed_proof.verify(&mixed_input).is_err());
-
-        let small_fac_p = &not_p0 * &BigNumber::from(2u64);
-        let small_fac_input = PiFacInput::new(&setup_params, &(&small_fac_p * &regular_sized_q));
-        let small_fac_proof = PiFacProof::prove(
-            &mut rng,
-            &input,
-            &PiFacSecret::new(&small_fac_p, &regular_sized_q),
-        )?;
-        assert!(small_fac_proof.verify(&small_fac_input).is_err());
+            let mut transcript = Transcript::new(b"PiFac Test");
+            let small_fac_p = &not_p0 * &BigNumber::from(2u64);
+            let small_fac_input =
+                PiFacInput::new(&setup_params, &(&small_fac_p * &regular_sized_q));
+            let small_fac_proof = PiFacProof::prove(
+                &input,
+                &PiFacSecret::new(&small_fac_p, &regular_sized_q),
+                &mut transcript,
+                &mut rng,
+            )?;
+            let mut transcript = Transcript::new(b"PiFac Test");
+            assert!(small_fac_proof
+                .verify(&small_fac_input, &mut transcript)
+                .is_err());
+        }
 
         Ok(())
     }

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -64,8 +64,8 @@ impl PiPrmSecret {
     }
 }
 
-/// Generates challenge bytes from the proof transcript using the Fiat-Shamir transform.
-/// Used by the prover and the verifier.
+/// Generates challenge bytes from the proof transcript using the Fiat-Shamir
+/// transform. Used by the prover and the verifier.
 fn generate_challenge_bytes(
     input: &RingPedersen,
     commitments: &[BigNumber],

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -64,11 +64,13 @@ impl PiPrmSecret {
     }
 }
 
-/// Generates challenge bytes from the proof transcript using the Fiat-Shamir
-/// transform. Used by the prover and the verifier.
-fn generate_challenge_bytes(input: &RingPedersen, commitments: &[BigNumber]) -> Result<Vec<u8>> {
-    // Construct a transcript for the Fiat-Shamir transform.
-    let mut transcript = Transcript::new(b"PiPrmProof");
+/// Generates challenge bytes from the proof transcript using the Fiat-Shamir transform.
+/// Used by the prover and the verifier.
+fn generate_challenge_bytes(
+    input: &RingPedersen,
+    commitments: &[BigNumber],
+    transcript: &mut Transcript,
+) -> Result<Vec<u8>> {
     transcript.append_message(b"Common input", &serialize!(&input)?);
     transcript.append_message(b"Commitments", &serialize!(&commitments)?);
     // Extract challenge bytes from the transcript.
@@ -83,9 +85,10 @@ impl Proof for PiPrmProof {
 
     #[cfg_attr(feature = "flame_it", flame("PiPrmProof"))]
     fn prove<R: RngCore + CryptoRng>(
-        rng: &mut R,
         input: &Self::CommonInput,
         secret: &Self::ProverSecret,
+        transcript: &mut Transcript,
+        rng: &mut R,
     ) -> Result<Self> {
         // Sample secret exponents `a_i ← Z[ɸ(N)]`.
         let secret_exponents: Vec<_> =
@@ -97,7 +100,7 @@ impl Proof for PiPrmProof {
             .iter()
             .map(|a| modpow(input.t(), a, input.modulus()))
             .collect::<Vec<_>>();
-        let challenge_bytes = generate_challenge_bytes(input, &commitments)?;
+        let challenge_bytes = generate_challenge_bytes(input, &commitments, transcript)?;
         // Compute challenge responses `z_i = a_i + e_i λ mod ɸ(N)`.
         let responses = challenge_bytes
             .iter()
@@ -119,7 +122,7 @@ impl Proof for PiPrmProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiPrmProof"))]
-    fn verify(&self, input: &Self::CommonInput) -> Result<()> {
+    fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // Check that all the lengths equal the soundness parameter.
         if self.commitments.len() != SOUNDNESS
             || self.challenge_bytes.len() != SOUNDNESS
@@ -127,7 +130,7 @@ impl Proof for PiPrmProof {
         {
             return verify_err!("length of values provided does not match soundness parameter");
         }
-        let challenges = generate_challenge_bytes(input, &self.commitments)?;
+        let challenges = generate_challenge_bytes(input, &self.commitments, transcript)?;
         // Check Fiat-Shamir consistency.
         if challenges != self.challenge_bytes.as_slice() {
             return verify_err!("Fiat-Shamir does not verify");
@@ -169,7 +172,8 @@ mod tests {
         let (sk, _, _) = DecryptionKey::new(rng)?;
         let (scheme, lambda, totient) = RingPedersen::extract(&sk, rng)?;
         let secrets = PiPrmSecret::new(lambda.clone(), totient.clone());
-        let proof = PiPrmProof::prove(rng, &scheme, &secrets)?;
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        let proof = PiPrmProof::prove(&scheme, &secrets, &mut transcript, rng)?;
         Ok((scheme, proof, lambda, totient))
     }
 
@@ -177,7 +181,8 @@ mod tests {
     fn piprm_proof_verifies() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
-        proof.verify(&input)
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        proof.verify(&input, &mut transcript)
     }
 
     #[test]
@@ -187,13 +192,17 @@ mod tests {
         let serialized = bincode::serialize(&proof).unwrap();
         let deserialized: PiPrmProof = bincode::deserialize(&serialized).unwrap();
         assert_eq!(serialized, bincode::serialize(&deserialized).unwrap());
-        deserialized.verify(&input)
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        deserialized.verify(&input, &mut transcript)
     }
 
     #[test]
     fn incorrect_lengths_fails() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
+        // Validate that the proof is okay.
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
         // Test that too short vectors fail.
         {
             let mut bad_proof = proof.clone();
@@ -202,7 +211,8 @@ mod tests {
                 .into_iter()
                 .take(SOUNDNESS - 1)
                 .collect();
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         {
             let mut bad_proof = proof.clone();
@@ -211,7 +221,8 @@ mod tests {
                 .into_iter()
                 .take(SOUNDNESS - 1)
                 .collect();
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         {
             let mut bad_proof = proof.clone();
@@ -220,7 +231,8 @@ mod tests {
                 .into_iter()
                 .take(SOUNDNESS - 1)
                 .collect();
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         // Test that too long vectors fail.
         {
@@ -228,19 +240,22 @@ mod tests {
             bad_proof
                 .commitments
                 .push(random_positive_bn(&mut rng, input.modulus()));
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         {
             let mut bad_proof = proof.clone();
             bad_proof.challenge_bytes.push(rng.gen::<u8>());
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         {
             let mut bad_proof = proof;
             bad_proof
                 .responses
                 .push(random_positive_bn(&mut rng, input.modulus()));
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         Ok(())
     }
@@ -248,31 +263,46 @@ mod tests {
     #[test]
     fn bad_secret_exponent_fails() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
-        let (input, _, _, totient) = random_ring_pedersen_proof(&mut rng)?;
+        let (input, proof, _, totient) = random_ring_pedersen_proof(&mut rng)?;
         let bad_lambda = random_positive_bn(&mut rng, &totient);
         let secrets = PiPrmSecret::new(bad_lambda, totient);
-        let proof = PiPrmProof::prove(&mut rng, &input, &secrets)?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        let bad_proof = PiPrmProof::prove(&input, &secrets, &mut transcript, &mut rng)?;
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(bad_proof.verify(&input, &mut transcript).is_err());
+        // Validate that the original proof is okay.
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
+
         Ok(())
     }
 
     #[test]
     fn bad_secret_totient_fails() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
-        let (input, _, lambda, _) = random_ring_pedersen_proof(&mut rng)?;
+        let (input, proof, lambda, _) = random_ring_pedersen_proof(&mut rng)?;
         let bad_totient = random_positive_bn(&mut rng, input.modulus());
         let secrets = PiPrmSecret::new(lambda, bad_totient);
-        let proof = PiPrmProof::prove(&mut rng, &input, &secrets)?;
-        assert!(proof.verify(&input).is_err());
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        let bad_proof = PiPrmProof::prove(&input, &secrets, &mut transcript, &mut rng)?;
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(bad_proof.verify(&input, &mut transcript).is_err());
+        // Validate that the original proof is okay.
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
         Ok(())
     }
 
     #[test]
     fn incorrect_ring_pedersen_fails() -> Result<()> {
         let mut rng = crate::utils::get_test_rng();
-        let (_, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
+        let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         let (bad_input, _, _, _) = random_ring_pedersen_proof(&mut rng)?;
-        assert!(proof.verify(&bad_input).is_err());
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&bad_input, &mut transcript).is_err());
+        // Validate that the original proof is okay.
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
         Ok(())
     }
 
@@ -283,7 +313,8 @@ mod tests {
         for i in 0..SOUNDNESS {
             let mut bad_proof = proof.clone();
             bad_proof.commitments[i] = random_positive_bn(&mut rng, input.modulus());
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         for i in 0..SOUNDNESS {
             let mut bad_proof = proof.clone();
@@ -291,13 +322,18 @@ mod tests {
             while bad_proof.challenge_bytes[i] == valid {
                 bad_proof.challenge_bytes[i] = rng.gen::<u8>();
             }
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
         for i in 0..SOUNDNESS {
             let mut bad_proof = proof.clone();
             bad_proof.responses[i] = random_positive_bn(&mut rng, input.modulus());
-            assert!(bad_proof.verify(&input).is_err());
+            let mut transcript = Transcript::new(b"PiPrmProof");
+            assert!(bad_proof.verify(&input, &mut transcript).is_err());
         }
+        // Validate that the original proof is okay.
+        let mut transcript = Transcript::new(b"PiPrmProof");
+        assert!(proof.verify(&input, &mut transcript).is_ok());
 
         Ok(())
     }


### PR DESCRIPTION
Closes #49.

This PR adds a `Transcript` argument to both the `Proof::prove` and `Proof::verify` functions to avoid having both `prove` and `prove_with_transcript` methods for some of the implemented zero knowledge proofs.

This commit also makes a couple of other minor changes:
* It adds documentation to the `Proof` trait.
* It moves the `rng` argument in `Proof::prove` to the end to be more consistent with some other uses of `rng` in the library.