### PR TITLE
Consolidate Errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,24 +25,6 @@ pub enum InternalError {
     CouldNotGenerateProof,
     #[error("Failed to verify proof: `{0}`")]
     FailedToVerifyProof(String),
-    #[error("Could not find square roots modulo n")]
-    NoSquareRoots,
-    #[error("Elements are not coprime")]
-    NotCoprime,
-    #[error("Elements of the multiplicative group ZK*_N cannot be larger than the RSA modulus")]
-    LargerThanModulus,
-    #[error("Elements of the multiplicative group ZK*_N cannot be negative")]
-    NegativeElement,
-    #[error("Elements of the multiplicative group  ZK*_N cannot be zero")]
-    IsZero,
-    #[error("One or more of the integer inputs to the Chinese remainder theorem were outside the expected range")]
-    InvalidIntegers,
-    #[error(
-        "Could not find uniqueness for fourth roots combination in Paillier-Blum modulus proof"
-    )]
-    NonUniqueFourthRootsCombination,
-    #[error("Could not invert a BigNumber")]
-    CouldNotInvertBigNumber,
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
@@ -63,8 +45,6 @@ pub enum InternalError {
     NoChainedShares,
     #[error("Storage does not contain the requested item")]
     StorageItemNotFound,
-    #[error("Function call contained invalid arguments: `{0}`")]
-    InvalidArgument(String),
     #[error("The provided Broadcast Tag was not the expected tag for this context")]
     IncorrectBroadcastMessageTag,
     #[error("Encountered a Message sent directly, when it should have been broadcasted")]
@@ -94,13 +74,5 @@ macro_rules! verify_err {
         Err(crate::errors::InternalError::FailedToVerifyProof(
             String::from($x),
         ))
-    }};
-}
-
-macro_rules! arg_err {
-    ($x:expr) => {{
-        Err(crate::errors::InternalError::InvalidArgument(String::from(
-            $x,
-        )))
     }};
 }

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     errors::{
-        InternalError::{CouldNotConvertToScalar, CouldNotInvertScalar},
+        InternalError::{CouldNotConvertToScalar, CouldNotInvertScalar, InternalInvariantFailed},
         Result,
     },
     utils::bn_to_scalar,
@@ -47,8 +47,7 @@ impl TryFrom<RecordPair> for PresignRecord {
 
         let g = CurvePoint::GENERATOR;
         if CurvePoint(g.0 * delta) != Delta {
-            // Error, failed to validate
-            panic!("Error, failed to validate");
+            return Err(InternalInvariantFailed);
         }
 
         let delta_inv = Option::<Scalar>::from(delta.invert()).ok_or(CouldNotInvertScalar)?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -290,10 +290,11 @@ impl SignatureShare {
     /// Can be used to combine [SignatureShare]s
     pub fn chain(&self, share: Self) -> Result<Self> {
         let r = match (self.r, share.r) {
-            (_, None) => arg_err!("Input share was not initialized"),
+            // Reason: Input share was not initialized
+            (_, None) => Err(InternalError::InternalInvariantFailed),
             (Some(prev_r), Some(new_r)) => {
                 if prev_r != new_r {
-                    return arg_err!("share.r does not match self.r");
+                    return Err(InternalError::SignatureInstantiationError);
                 }
                 Ok(prev_r)
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -138,7 +138,7 @@ pub(crate) fn random_plusminus_by_size_with_minimum<R: RngCore + CryptoRng>(
     min: usize,
 ) -> crate::errors::Result<BigNumber> {
     if min >= max {
-        return arg_err!("min needs to be less than max");
+        return Err(InternalError::InternalInvariantFailed);
     }
     // Sample from [0, 2^max - 2^min], then add 2^min to bump into correct range.
     let min_bound_bn = (BigNumber::one() << max) - (BigNumber::one() << min);

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -25,15 +25,17 @@ impl ZStarNBuilder {
     /// sampling the element in the multiplicative group modulo n.
     pub fn validate(&self, unverified: ZStarNUnverified) -> Result<ZStarN, InternalError> {
         if unverified.value().is_zero() {
-            return Err(InternalError::IsZero);
+            return verify_err!("Elements of the multiplicative group  ZK*_N cannot be zero");
         } else if unverified.value() > self.modulus() {
-            return Err(InternalError::LargerThanModulus);
+            return verify_err!(
+                "Elements of the multiplicative group ZK*_N cannot be larger than the RSA modulus"
+            );
         } else if unverified.value() < &BigNumber::zero() {
-            return Err(InternalError::NegativeElement);
+            return verify_err!("Elements of the multiplicative group ZK*_N cannot be negative");
         }
         let result = unverified.value().gcd(self.modulus());
         if result != BigNumber::one() {
-            return Err(InternalError::NotCoprime);
+            return verify_err!("Elements are not coprime");
         }
         Ok(ZStarN {
             value: unverified.value().to_owned(),


### PR DESCRIPTION
This PR attempts to consolidate some error types, particularly around proof generation, addressing issue #158 .

For this PR I kept the `verify_err!` macro in place so that a later PR can switch it to a logging one.

For parts of the code made less descriptive by switching the error type, I left a comment indicating the reason for the failure. Once logging is done, this is the text which should be logged

Potential Issue: This makes some tests less specific, as they are currently set up to look for specific errors to be thrown. How much do we care about this? (Personally, I think this is fine). If we care, is there an easy way to achieve this same effect through the automated checking of log files? 

Suggestion: The PR text mentions consolidating these into an error like `CouldNotGenerateProof`. Would it make sense to consolidate `CouldNotGenerateProof` itself into `InternalInvariantFailed`, or is there some situation where distinguishing these is useful? To my knowledge, there isn't a way for malicious external inputs to cause an honest prover to fail to generate their proof, which would imply that this error coming up is only due to some programming bug, but it's worth checking this.

I'd like to get rid of this `CouldNotConvertToScalar` error in `bn_to_scalar` (and some other small errors too), but it doesn't map cleanly onto `InternalInvariantFailure` or `FailedToVerifyProof`, as it can be triggered both by a code bug or a malicious input. For utility functions like this, would it make sense to have a generic `FailedToDoX` error which could be mapped by the calling function?