### PR TITLE
Log Proof Verification Errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ openssl = "0.10"
 reqwest = { version = "0.11", features = ["json"] }
 rocket = { version = "0.5.0-rc", default-features = false, features = ["json"] }
 rug = { version = "1.16", default-features = false, features = ["integer", "rand"] }
-test-log = { version = "0.2.11", features = ["trace"]}
 tracing = {version = "0.1", default-features = false}
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+#tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tokio = { version = "1", features = ["full"] }
 
 [[bench]]

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -17,7 +17,7 @@ use crate::{
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, error};
+use tracing::{error, instrument};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct AuxInfoCommit {

--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -17,7 +17,7 @@ use crate::{
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::error;
+use tracing::{instrument, error};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct AuxInfoCommit {
@@ -141,6 +141,7 @@ impl AuxInfoDecommit {
 
     /// Verify that this [`AuxInfoDecommit`] corresponds to the given
     /// [`AuxInfoCommit`].
+    #[instrument(skip_all, err(Debug))]
     pub(crate) fn verify(
         &self,
         sid: &Identifier,

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -17,7 +17,7 @@ use crate::{
 use k256::elliptic_curve::zeroize::ZeroizeOnDrop;
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, error};
+use tracing::{error, instrument};
 
 /// The private key corresponding to a given Participant's [`AuxInfoPublic`].
 ///

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -17,7 +17,7 @@ use crate::{
 use k256::elliptic_curve::zeroize::ZeroizeOnDrop;
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
-use tracing::error;
+use tracing::{instrument, error};
 
 /// The private key corresponding to a given Participant's [`AuxInfoPublic`].
 ///
@@ -90,6 +90,7 @@ impl AuxInfoPublic {
 
     /// Verifies that the public key's modulus matches the ZKSetupParameters
     /// modulus N, and that the parameters have appropriate s and t values.
+    #[instrument(skip_all, err(Debug))]
     pub(crate) fn verify(&self) -> Result<()> {
         if self.pk.modulus() != self.params.scheme().modulus() {
             error!("Mismatch between public key modulus and setup parameters modulus");

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -544,10 +544,9 @@ fn new_auxinfo<R: RngCore + CryptoRng>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Identifier;
+    use crate::{utils::testing::init_testing, Identifier};
     use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
-    use test_log::test;
 
     impl AuxInfoParticipant {
         pub fn new_quorum<R: RngCore + CryptoRng>(
@@ -665,6 +664,8 @@ mod tests {
     // This test is cheap. Try a bunch of message permutations to decrease error
     // likelihood
     fn test_run_auxinfo_protocol_many_times() -> Result<()> {
+        let _rng = init_testing();
+
         for _ in 0..20 {
             test_run_auxinfo_protocol()?;
         }
@@ -673,7 +674,7 @@ mod tests {
     #[test]
     fn test_run_auxinfo_protocol() -> Result<()> {
         let QUORUM_SIZE = 3;
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let mut quorum = AuxInfoParticipant::new_quorum(QUORUM_SIZE, &mut rng)?;
         let mut inboxes = HashMap::new();
         let mut main_storages: Vec<Storage> = vec![];

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,8 +25,8 @@ pub enum InternalError {
     ProtocolError,
     #[error("Could not successfully generate proof")]
     CouldNotGenerateProof,
-    #[error("Failed to verify proof: `{0}`")]
-    FailedToVerifyProof(String),
+    #[error("Failed to verify proof")]
+    FailedToVerifyProof,
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
@@ -68,13 +68,5 @@ macro_rules! serialize {
 macro_rules! deserialize {
     ($x:expr) => {{
         bincode::deserialize($x).or(Err(crate::errors::InternalError::Serialization))
-    }};
-}
-
-macro_rules! verify_err {
-    ($x:expr) => {{
-        Err(crate::errors::InternalError::FailedToVerifyProof(
-            String::from($x),
-        ))
     }};
 }

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -17,6 +17,7 @@ use crate::{
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct KeygenCommit {
@@ -102,7 +103,8 @@ impl KeygenDecommit {
         if rebuilt_com == *com {
             Ok(())
         } else {
-            verify_err!("decommitment does not match original commitment")
+            warn!("decommitment does not match original commitment");
+            Err(InternalError::FailedToVerifyProof)
         }
     }
 }

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -17,7 +17,7 @@ use crate::{
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct KeygenCommit {
@@ -85,6 +85,7 @@ impl KeygenDecommit {
         Ok(KeygenCommit { hash })
     }
 
+    #[instrument(skip_all, err(Debug))]
     pub(crate) fn verify(
         &self,
         sid: &Identifier,

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -559,10 +559,9 @@ fn new_keyshare<R: RngCore + CryptoRng>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Identifier;
+    use crate::{utils::testing::init_testing, Identifier};
     use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
-    use test_log::test;
     use tracing::debug;
 
     impl KeygenParticipant {
@@ -675,6 +674,8 @@ mod tests {
     // This test is cheap. Try a bunch of message permutations to decrease error
     // likelihood
     fn keygen_always_produces_valid_outputs() -> Result<()> {
+        let _rng = init_testing();
+
         for _ in 0..20 {
             keygen_produces_valid_outputs()?;
         }
@@ -683,7 +684,7 @@ mod tests {
     #[test]
     fn keygen_produces_valid_outputs() -> Result<()> {
         let QUORUM_SIZE = 3;
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let mut quorum = KeygenParticipant::new_quorum(QUORUM_SIZE, &mut rng)?;
         let mut inboxes = HashMap::new();
         let mut main_storages: Vec<Storage> = vec![];

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -369,12 +369,11 @@ pub(crate) mod prime_gen {
 mod test {
     use libpaillier::unknown_order::BigNumber;
     use rand::{CryptoRng, Rng, RngCore};
-    use test_log::test;
 
     use crate::{
         paillier::Ciphertext,
         parameters::PRIME_BITS,
-        utils::{get_test_rng, random_plusminus},
+        utils::{random_plusminus, testing::init_testing},
     };
 
     use super::{prime_gen, DecryptionKey, EncryptionKey};
@@ -382,7 +381,8 @@ mod test {
     #[test]
     #[ignore = "sometimes slow in debug mode"]
     fn get_random_safe_prime_512_produces_safe_primes() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
+
         let p = prime_gen::get_random_safe_prime(&mut rng);
         assert!(p.is_prime());
         let q: BigNumber = (p - 1) / 2;
@@ -391,8 +391,7 @@ mod test {
 
     #[test]
     fn paillier_keygen_produces_good_primes() {
-        let mut rng = get_test_rng();
-
+        let mut rng = init_testing();
         let (decryption_key, p, q) = DecryptionKey::new(&mut rng).unwrap();
 
         assert!(p.is_prime());
@@ -414,6 +413,7 @@ mod test {
     #[test]
     #[ignore = "slow"]
     fn paillier_keygen_always_produces_good_primes() {
+        let _rng = init_testing();
         for _ in 0..100 {
             paillier_keygen_produces_good_primes()
         }
@@ -429,7 +429,7 @@ mod test {
 
     #[test]
     fn paillier_encryption_works() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
@@ -453,7 +453,7 @@ mod test {
 
     #[test]
     fn pailler_decryption_requires_correct_key() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
@@ -469,9 +469,10 @@ mod test {
 
     #[test]
     fn pailler_encryption_requires_input_in_Zn() {
+        let mut rng = init_testing();
+
         // Specifically, the integers mod N must be in the interval around 0.
         // So, inputs in the range [-N/2, N/2] are acceptable, but not [0, N).
-        let mut rng = get_test_rng();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
@@ -500,7 +501,7 @@ mod test {
 
     #[test]
     fn paillier_encryption_generates_unique_nonces() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
@@ -521,7 +522,7 @@ mod test {
 
     #[test]
     fn paillier_ciphertext_bits_matter() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
@@ -559,7 +560,7 @@ mod test {
 
     #[test]
     fn half_ns_match() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -419,11 +419,11 @@ impl std::fmt::Display for Identifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::testing::init_testing;
     use k256::ecdsa::signature::DigestVerifier;
     use rand::seq::IteratorRandom;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
-    use test_log::test;
     use tracing::debug;
 
     /// Delivers all messages into their respective participant's inboxes   
@@ -501,7 +501,7 @@ mod tests {
     #[cfg_attr(feature = "flame_it", flame)]
     #[test]
     fn test_run_protocol() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let mut quorum = Participant::new_quorum(3, &mut rng)?;
         let mut inboxes = HashMap::new();
         for participant in &quorum {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,7 +23,7 @@ use k256::elliptic_curve::{Field, IsHigh};
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
-use tracing::{info, instrument, trace};
+use tracing::{error, info, instrument, trace};
 
 /////////////////////
 // Participant API //
@@ -325,8 +325,10 @@ impl SignatureShare {
     /// Can be used to combine [SignatureShare]s
     pub fn chain(&self, share: Self) -> Result<Self> {
         let r = match (self.r, share.r) {
-            // Reason: Input share was not initialized
-            (_, None) => Err(InternalError::InternalInvariantFailed),
+            (_, None) => {
+                error!("Input share was not initialized");
+                Err(InternalError::InternalInvariantFailed)
+            }
             (Some(prev_r), Some(new_r)) => {
                 if prev_r != new_r {
                     return Err(InternalError::SignatureInstantiationError);

--- a/src/ring_pedersen.rs
+++ b/src/ring_pedersen.rs
@@ -310,13 +310,13 @@ impl RingPedersen {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{get_test_rng, random_plusminus_by_size};
+    use crate::utils::{random_plusminus_by_size, testing::init_testing};
 
     use super::*;
 
     #[test]
     fn verified_ring_pedersen_generation_works() -> Result<()> {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let scheme = VerifiedRingPedersen::gen(&mut rng)?;
         assert!(scheme.verify().is_ok());
         Ok(())
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn mixing_verified_ring_pedersen_scheme_and_proof_fails() -> Result<()> {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         // Mixing a proof from one scheme with another should fail.
         let scheme0 = VerifiedRingPedersen::gen(&mut rng)?;
         let scheme1 = VerifiedRingPedersen::gen(&mut rng)?;
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn ring_pedersen_commitments_work() -> Result<()> {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let scheme = VerifiedRingPedersen::gen(&mut rng)?;
         let value = random_plusminus_by_size(&mut rng, 256);
         let (c, r) = scheme.scheme().commit(&value, 256, &mut rng);
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn mixing_ring_pedersen_commitments_fails() -> Result<()> {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let scheme = VerifiedRingPedersen::gen(&mut rng)?;
         let value0 = random_plusminus_by_size(&mut rng, 256);
         let value1 = random_plusminus_by_size(&mut rng, 256);

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -23,7 +23,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 use utils::CurvePoint;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,6 +188,7 @@ impl Proof for PiAffgProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiAffgProof"))]
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // First, do Fiat-Shamir consistency check
 

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -23,6 +23,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use utils::CurvePoint;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -209,7 +210,8 @@ impl Proof for PiAffgProof {
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
 
         if e != self.e {
-            return verify_err!("Fiat-Shamir consistency check failed");
+            warn!("Fiat-Shamir consistency check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Do equality checks
@@ -221,7 +223,8 @@ impl Proof for PiAffgProof {
             lhs == rhs
         };
         if !eq_check_1 {
-            return verify_err!("eq_check_1 failed");
+            warn!("eq_check_1 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_2 = {
@@ -230,7 +233,8 @@ impl Proof for PiAffgProof {
             lhs == rhs
         };
         if !eq_check_2 {
-            return verify_err!("eq_check_2 failed");
+            warn!("eq_check_2 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_3 = {
@@ -240,7 +244,8 @@ impl Proof for PiAffgProof {
             lhs == rhs
         };
         if !eq_check_3 {
-            return verify_err!("eq_check_3 failed");
+            warn!("eq_check_3 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_4 = {
@@ -252,7 +257,8 @@ impl Proof for PiAffgProof {
             lhs == rhs
         };
         if !eq_check_4 {
-            return verify_err!("eq_check_4 failed");
+            warn!("eq_check_4 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_5 = {
@@ -264,7 +270,8 @@ impl Proof for PiAffgProof {
             lhs == rhs
         };
         if !eq_check_5 {
-            return verify_err!("eq_check_5 failed");
+            warn!("eq_check_5 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Do range check
@@ -272,10 +279,12 @@ impl Proof for PiAffgProof {
         let ell_bound = BigNumber::one() << (ELL + EPSILON);
         let ell_prime_bound = BigNumber::one() << (ELL_PRIME + EPSILON);
         if self.z1 < -ell_bound.clone() || self.z1 > ell_bound {
-            return verify_err!("self.z1 > ell_bound check failed");
+            warn!("self.z1 > ell_bound check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
         if self.z2 < -ell_prime_bound.clone() || self.z2 > ell_prime_bound {
-            return verify_err!("self.z2 > ell_prime_bound check failed");
+            warn!("self.z2 > ell_prime_bound check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         Ok(())

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -23,7 +23,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 use utils::CurvePoint;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,7 +188,6 @@ impl Proof for PiAffgProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiAffgProof"))]
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // First, do Fiat-Shamir consistency check
 

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -294,8 +294,11 @@ impl Proof for PiAffgProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{paillier::DecryptionKey, utils::random_plusminus_by_size_with_minimum};
-    use test_log::test;
+    use crate::{
+        paillier::DecryptionKey,
+        utils::{random_plusminus_by_size_with_minimum, testing::init_testing},
+    };
+
     fn random_paillier_affg_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
         x: &BigNumber,
@@ -336,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_paillier_affg_proof() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         let x_small = random_plusminus_by_size(&mut rng, ELL);
         let y_small = random_plusminus_by_size(&mut rng, ELL_PRIME);

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -38,7 +38,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 /// Proof of knowledge of the plaintext value of a ciphertext, where the value
 /// is within a desired range.
@@ -171,6 +171,7 @@ impl Proof for PiEncProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // Check Fiat-Shamir challenge consistency: update the transcript with
         // commitments...

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -38,7 +38,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 
 /// Proof of knowledge of the plaintext value of a ciphertext, where the value
 /// is within a desired range.
@@ -171,7 +171,6 @@ impl Proof for PiEncProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // Check Fiat-Shamir challenge consistency: update the transcript with
         // commitments...

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -267,9 +267,11 @@ mod tests {
     use super::*;
     use crate::{
         paillier::DecryptionKey,
-        utils::{random_plusminus, random_plusminus_by_size_with_minimum, random_positive_bn},
+        utils::{
+            random_plusminus, random_plusminus_by_size_with_minimum, random_positive_bn,
+            testing::init_testing,
+        },
     };
-    use test_log::test;
 
     fn build_random_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
@@ -300,7 +302,7 @@ mod tests {
 
     #[test]
     fn proof_serializes_correctly() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         let plaintext = random_plusminus_by_size(&mut rng, ELL);
         let (proof, input) = build_random_proof(&mut rng, plaintext)?;
@@ -320,7 +322,7 @@ mod tests {
 
     #[test]
     fn plaintext_must_be_in_range() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         // A plaintext in the range 2^ELL should always succeed
         let in_range = random_plusminus_by_size(&mut rng, ELL);
@@ -370,7 +372,7 @@ mod tests {
 
     #[test]
     fn every_proof_field_matters() {
-        let rng = &mut crate::utils::get_test_rng();
+        let rng = &mut init_testing();
         let plaintext = random_plusminus_by_size(rng, ELL);
 
         let (proof, input) = build_random_proof(rng, plaintext.clone()).unwrap();
@@ -454,7 +456,7 @@ mod tests {
 
     #[test]
     fn proof_must_be_constructed_with_knowledge_of_secrets() -> Result<()> {
-        let rng = &mut crate::utils::get_test_rng();
+        let rng = &mut init_testing();
 
         // Form common inputs
         let (decryption_key, _, _) = DecryptionKey::new(rng)?;
@@ -523,7 +525,7 @@ mod tests {
     #[test]
     fn verification_requires_correct_common_input() -> Result<()> {
         // Replace each field of `CommonInput` with something else to verify
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         // Form inputs
         let plaintext = random_plusminus_by_size(&mut rng, ELL);

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -20,7 +20,7 @@ use merlin::Transcript;
 use num_bigint::{BigInt, Sign};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct PiFacProof {
@@ -146,7 +146,6 @@ impl Proof for PiFacProof {
         Ok(proof)
     }
 
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
         transcript.append_message(

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -228,7 +228,7 @@ fn sqrt(num: &BigNumber) -> BigNumber {
 
 #[cfg(test)]
 mod tests {
-    use crate::paillier::prime_gen;
+    use crate::{paillier::prime_gen, utils::testing::init_testing};
 
     use super::*;
 
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_no_small_factors_proof() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof) = random_no_small_factors_proof(&mut rng)?;
         let mut transcript = Transcript::new(b"PiFac Test");
         proof.verify(&input, &mut transcript)?;
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_no_small_factors_proof_negative_cases() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof) = random_no_small_factors_proof(&mut rng)?;
 
         {
@@ -337,7 +337,7 @@ mod tests {
     // Make sure the bytes representations for BigNum and BigInt
     // didn't change in a way that would mess up the sqrt funtion
     fn test_bignum_bigint_byte_representation() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (p0, q0) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
 
         let num = &p0 * &q0;

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -20,7 +20,7 @@ use merlin::Transcript;
 use num_bigint::{BigInt, Sign};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct PiFacProof {
@@ -146,6 +146,7 @@ impl Proof for PiFacProof {
         Ok(proof)
     }
 
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         transcript.append_message(b"CommonInput", &serialize!(&input)?);
         transcript.append_message(

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -20,6 +20,7 @@ use merlin::Transcript;
 use num_bigint::{BigInt, Sign};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct PiFacProof {
@@ -168,7 +169,8 @@ impl Proof for PiFacProof {
             lhs == rhs
         };
         if !eq_check_1 {
-            return verify_err!("eq_check_1 failed");
+            warn!("eq_check_1 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_2 = {
@@ -177,7 +179,8 @@ impl Proof for PiFacProof {
             lhs == rhs
         };
         if !eq_check_2 {
-            return verify_err!("eq_check_2 failed");
+            warn!("eq_check_2 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let eq_check_3 = {
@@ -193,7 +196,8 @@ impl Proof for PiFacProof {
             lhs == rhs
         };
         if !eq_check_3 {
-            return verify_err!("eq_check_3 failed");
+            warn!("eq_check_3 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         let sqrt_N0 = sqrt(&input.N0);
@@ -202,10 +206,12 @@ impl Proof for PiFacProof {
         // 2^{ELL + EPSILON} * sqrt(N_0)
         let z_bound = &sqrt_N0 * &two_ell_eps;
         if self.z1 < -z_bound.clone() || self.z1 > z_bound {
-            return verify_err!("self.z1 > z_bound check failed");
+            warn!("self.z1 > z_bound check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
         if self.z2 < -z_bound.clone() || self.z2 > z_bound {
-            return verify_err!("self.z2 > z_bound check failed");
+            warn!("self.z2 > z_bound check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         Ok(())

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -327,10 +327,10 @@ impl Proof for PiLogProof {
 mod tests {
     use super::*;
     use crate::{
-        paillier::DecryptionKey, ring_pedersen::VerifiedRingPedersen,
-        utils::random_plusminus_by_size_with_minimum,
+        paillier::DecryptionKey,
+        ring_pedersen::VerifiedRingPedersen,
+        utils::{random_plusminus_by_size_with_minimum, testing::init_testing},
     };
-    use test_log::test;
 
     fn random_paillier_log_proof<R: RngCore + CryptoRng>(rng: &mut R, x: &BigNumber) -> Result<()> {
         let (decryption_key, _, _) = DecryptionKey::new(rng)?;
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_paillier_log_proof() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         let x_small = random_plusminus_by_size(&mut rng, ELL);
         let x_large =

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -31,7 +31,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 use utils::CurvePoint;
 
 /// Proof of knowledge that:
@@ -246,6 +246,7 @@ impl Proof for PiLogProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiLogProof"))]
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // See the comment in `prove` for a high-level description of how the protocol
         // works.

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -31,6 +31,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use utils::CurvePoint;
 
 /// Proof of knowledge that:
@@ -260,7 +261,8 @@ impl Proof for PiLogProof {
         )?;
         // ... and check that it's the correct challenge.
         if challenge != self.challenge {
-            return verify_err!("Fiat-Shamir consistency check failed");
+            warn!("Fiat-Shamir consistency check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Check that the Paillier encryption of the secret plaintext is valid.
@@ -276,7 +278,8 @@ impl Proof for PiLogProof {
             lhs == rhs
         };
         if !paillier_encryption_is_valid {
-            return verify_err!("paillier encryption check (first equality check) failed");
+            warn!("paillier encryption check (first equality check) failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
         // Check that the group exponentiation of the secret plaintext is valid.
         let group_exponentiation_is_valid = {
@@ -288,7 +291,8 @@ impl Proof for PiLogProof {
             lhs == rhs
         };
         if !group_exponentiation_is_valid {
-            return verify_err!("group exponentiation check (second equality check) failed");
+            warn!("group exponentiation check (second equality check) failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Check that the ring-Pedersen commitment of the secret plaintext is valid.
@@ -304,13 +308,15 @@ impl Proof for PiLogProof {
             lhs == rhs
         };
         if !ring_pedersen_commitment_is_valid {
-            return verify_err!("ring Pedersen commitment check (third equality check) failed");
+            warn!("ring Pedersen commitment check (third equality check) failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Do a range check on the plaintext response, which validates that the
         // plaintext falls within the same range.
         if !within_bound_by_size(&self.plaintext_response, ELL + EPSILON) {
-            return verify_err!("plaintext range check failed");
+            warn!("plaintext range check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         Ok(())

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -31,7 +31,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 use utils::CurvePoint;
 
 /// Proof of knowledge that:
@@ -246,7 +246,6 @@ impl Proof for PiLogProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiLogProof"))]
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // See the comment in `prove` for a high-level description of how the protocol
         // works.

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -394,12 +394,12 @@ mod tests {
     use crate::{
         paillier::{prime_gen, DecryptionKey},
         parameters::SOUNDNESS_PARAMETER,
+        utils::testing::init_testing,
     };
-    use test_log::test;
 
     #[test]
     fn test_jacobi() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
         let N = &p * &q;
 
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_square_roots_mod_prime() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let p = prime_gen::try_get_prime_from_pool_insecure(&mut rng).unwrap();
 
         for _ in 0..100 {
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn test_square_roots_mod_composite() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
         let N = &p * &q;
 
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_fourth_roots_mod_composite() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
         let N = &p * &q;
 
@@ -517,7 +517,7 @@ mod tests {
 
     #[test]
     fn chinese_remainder_theorem_works() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         // This guarantees p and q are coprime and not equal.
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
         assert!(p != q);
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn chinese_remainder_theorem_integers_must_be_in_range() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         // This guarantees p and q are coprime and not equal.
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn chinese_remainder_theorem_moduli_must_be_coprime() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         // This guarantees p and q are coprime and not equal.
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_blum_modulus_proof_elements_roundtrip() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let pbelement = random_pbmpe(&mut rng);
         let buf = bincode::serialize(&pbelement).unwrap();
         let roundtrip_pbelement: PiModProofElements = bincode::deserialize(&buf).unwrap();
@@ -660,9 +660,9 @@ mod tests {
 
     #[test]
     fn test_blum_modulus_roundtrip() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
+
         let w = random_big_number(&mut rng);
-        let mut rng = crate::utils::get_test_rng();
         let num_elements = rng.next_u64() as u8;
         let elements = (0..num_elements)
             .map(|_| random_pbmpe(&mut rng))
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn pimod_proof_verifies() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
         let (proof, input) = random_pimod_proof(&mut rng);
         let mut transcript = Transcript::new(b"PiMod Test");
         assert!(proof.verify(&input, &mut transcript).is_ok());
@@ -697,7 +697,7 @@ mod tests {
 
     #[test]
     fn pimod_proof_requires_correct_number_of_elements_for_soundness() {
-        let mut rng = get_test_rng();
+        let mut rng = init_testing();
 
         let transform = |proof: &PiModProof| {
             // Remove iterations from the proof

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -88,21 +88,16 @@ impl Proof for PiModProof {
         let mut elements = vec![];
         for _ in 0..LAMBDA {
             let y = positive_bn_random_from_transcript(transcript, &input.N);
-
             let (a, b, x) = y_prime_combinations(&w, &y, &secret.p, &secret.q)?;
 
             // Compute phi(N) = (p-1) * (q-1)
             let phi_n = (&secret.p - 1) * (&secret.q - 1);
-            let exp_result = input
-                .N
-                .invert(&phi_n)
-                .ok_or(InternalError::CouldNotGenerateProof);
-
-            if exp_result.is_err() {
+            let exp = input.N.invert(&phi_n).ok_or_else(|| {
                 error!("Could not invert a BigNumber");
-            }
-            let exp = exp_result?;
+                InternalError::CouldNotGenerateProof
+            })?;
             let z = modpow(&y, &exp, &input.N);
+
             elements.push(PiModProofElements {
                 x: x[0].clone(),
                 a,

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -28,7 +28,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 
 // Soundness parameter.
 const SOUNDNESS: usize = crate::parameters::SOUNDNESS_PARAMETER;
@@ -123,7 +123,6 @@ impl Proof for PiPrmProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiPrmProof"))]
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // Check that all the lengths equal the soundness parameter.
         if self.commitments.len() != SOUNDNESS

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -28,7 +28,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 // Soundness parameter.
 const SOUNDNESS: usize = crate::parameters::SOUNDNESS_PARAMETER;
@@ -123,6 +123,7 @@ impl Proof for PiPrmProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiPrmProof"))]
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // Check that all the lengths equal the soundness parameter.
         if self.commitments.len() != SOUNDNESS

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -167,9 +167,8 @@ impl Proof for PiPrmProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paillier::DecryptionKey;
+    use crate::{paillier::DecryptionKey, utils::testing::init_testing};
     use rand::Rng;
-    use test_log::test;
 
     fn random_ring_pedersen_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
@@ -184,7 +183,7 @@ mod tests {
 
     #[test]
     fn piprm_proof_verifies() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         let mut transcript = Transcript::new(b"PiPrmProof");
         proof.verify(&input, &mut transcript)
@@ -192,7 +191,7 @@ mod tests {
 
     #[test]
     fn piprm_proof_serializes() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         let serialized = bincode::serialize(&proof).unwrap();
         let deserialized: PiPrmProof = bincode::deserialize(&serialized).unwrap();
@@ -203,7 +202,7 @@ mod tests {
 
     #[test]
     fn incorrect_lengths_fails() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         // Validate that the proof is okay.
         let mut transcript = Transcript::new(b"PiPrmProof");
@@ -267,7 +266,7 @@ mod tests {
 
     #[test]
     fn bad_secret_exponent_fails() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof, _, totient) = random_ring_pedersen_proof(&mut rng)?;
         let bad_lambda = random_positive_bn(&mut rng, &totient);
         let secrets = PiPrmSecret::new(bad_lambda, totient);
@@ -284,7 +283,7 @@ mod tests {
 
     #[test]
     fn bad_secret_totient_fails() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (input, proof, lambda, _) = random_ring_pedersen_proof(&mut rng)?;
         let bad_totient = random_positive_bn(&mut rng, input.modulus());
         let secrets = PiPrmSecret::new(lambda, bad_totient);
@@ -300,7 +299,8 @@ mod tests {
 
     #[test]
     fn incorrect_ring_pedersen_fails() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
+
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         let (bad_input, _, _, _) = random_ring_pedersen_proof(&mut rng)?;
         let mut transcript = Transcript::new(b"PiPrmProof");
@@ -313,7 +313,8 @@ mod tests {
 
     #[test]
     fn invalid_values_fails() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
+
         let (input, proof, _, _) = random_ring_pedersen_proof(&mut rng)?;
         for i in 0..SOUNDNESS {
             let mut bad_proof = proof.clone();

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -18,7 +18,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{instrument, warn};
 use utils::CurvePoint;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -94,6 +94,7 @@ impl Proof for PiSchProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
+    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // First check Fiat-Shamir challenge consistency
 
@@ -153,6 +154,7 @@ impl PiSchProof {
         let proof = Self { A, e, z };
         Ok(proof)
     }
+    #[instrument(skip_all, err(Debug))]
     pub fn verify_with_transcript(
         &self,
         input: &PiSchInput,

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -195,7 +195,7 @@ impl PiSchProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test_log::test;
+    use crate::utils::testing::init_testing;
 
     fn random_schnorr_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_schnorr_proof() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         let (input, proof) = random_schnorr_proof(&mut rng, false)?;
         let mut transcript = Transcript::new(b"PiSchProof Test");
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_precommit_proof() -> Result<()> {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
 
         let q = crate::utils::k256_order();
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -18,7 +18,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 use utils::CurvePoint;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -94,7 +94,6 @@ impl Proof for PiSchProof {
     }
 
     #[cfg_attr(feature = "flame_it", flame("PiEncProof"))]
-    #[instrument(skip_all, err(Debug))]
     fn verify(&self, input: &Self::CommonInput, transcript: &mut Transcript) -> Result<()> {
         // First check Fiat-Shamir challenge consistency
 
@@ -154,7 +153,6 @@ impl PiSchProof {
         let proof = Self { A, e, z };
         Ok(proof)
     }
-    #[instrument(skip_all, err(Debug))]
     pub fn verify_with_transcript(
         &self,
         input: &PiSchInput,

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -18,6 +18,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use utils::CurvePoint;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -102,7 +103,8 @@ impl Proof for PiSchProof {
         // Verifier samples e in F_q
         let e = positive_bn_random_from_transcript(transcript, &input.q);
         if e != self.e {
-            return verify_err!("Fiat-Shamir consistency check failed");
+            warn!("Fiat-Shamir consistency check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Do equality checks
@@ -113,7 +115,8 @@ impl Proof for PiSchProof {
             lhs == rhs
         };
         if !eq_check_1 {
-            return verify_err!("eq_check_1 failed");
+            warn!("eq_check_1 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         Ok(())
@@ -162,7 +165,8 @@ impl PiSchProof {
         // Verifier samples e in F_q
         let e = positive_bn_random_from_transcript(&mut local_transcript, &input.q);
         if e != self.e {
-            return verify_err!("Fiat-Shamir consistency check failed");
+            warn!("Fiat-Shamir consistency check failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         // Do equality checks
@@ -173,7 +177,8 @@ impl PiSchProof {
             lhs == rhs
         };
         if !eq_check_1 {
-            return verify_err!("eq_check_1 failed");
+            warn!("eq_check_1 failed");
+            return Err(InternalError::FailedToVerifyProof);
         }
 
         Ok(())

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -2,7 +2,7 @@ use crate::{errors::InternalError, utils};
 use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::warn;
+use tracing::{warn, instrument};
 
 /// Tool for verifying and operating on elements of the multiplicative
 /// group of integers mod `N`, for some modulus `N`.
@@ -24,6 +24,7 @@ impl ZStarNBuilder {
     /// respect to the current [`ZStarNBuilder`]. This is one of two ways of
     /// constructing elements of [`ZStarN`]. The other way is by randomly
     /// sampling the element in the multiplicative group modulo n.
+    #[instrument(skip_all, err(Debug))]
     pub fn validate(&self, unverified: ZStarNUnverified) -> Result<ZStarN, InternalError> {
         if unverified.value().is_zero() {
             warn!("Elements of the multiplicative group  ZK*_N cannot be zero");
@@ -106,6 +107,7 @@ impl ZStarNUnverified {
 #[cfg(test)]
 mod test {
     use crate::{paillier::DecryptionKey, zkstar::*};
+    use test_log::test;
 
     #[test]
     fn zkstar_verification_works() {

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -2,7 +2,7 @@ use crate::{errors::InternalError, utils};
 use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{warn, instrument};
+use tracing::{instrument, warn};
 
 /// Tool for verifying and operating on elements of the multiplicative
 /// group of integers mod `N`, for some modulus `N`.

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -2,6 +2,7 @@ use crate::{errors::InternalError, utils};
 use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 /// Tool for verifying and operating on elements of the multiplicative
 /// group of integers mod `N`, for some modulus `N`.
@@ -25,17 +26,21 @@ impl ZStarNBuilder {
     /// sampling the element in the multiplicative group modulo n.
     pub fn validate(&self, unverified: ZStarNUnverified) -> Result<ZStarN, InternalError> {
         if unverified.value().is_zero() {
-            return verify_err!("Elements of the multiplicative group  ZK*_N cannot be zero");
+            warn!("Elements of the multiplicative group  ZK*_N cannot be zero");
+            return Err(InternalError::FailedToVerifyProof);
         } else if unverified.value() > self.modulus() {
-            return verify_err!(
+            warn!(
                 "Elements of the multiplicative group ZK*_N cannot be larger than the RSA modulus"
             );
+            return Err(InternalError::FailedToVerifyProof);
         } else if unverified.value() < &BigNumber::zero() {
-            return verify_err!("Elements of the multiplicative group ZK*_N cannot be negative");
+            warn!("Elements of the multiplicative group ZK*_N cannot be negative");
+            return Err(InternalError::FailedToVerifyProof);
         }
         let result = unverified.value().gcd(self.modulus());
         if result != BigNumber::one() {
-            return verify_err!("Elements are not coprime");
+            warn!("Elements are not coprime");
+            return Err(InternalError::FailedToVerifyProof);
         }
         Ok(ZStarN {
             value: unverified.value().to_owned(),

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -2,7 +2,7 @@ use crate::{errors::InternalError, utils};
 use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::warn;
 
 /// Tool for verifying and operating on elements of the multiplicative
 /// group of integers mod `N`, for some modulus `N`.
@@ -24,7 +24,6 @@ impl ZStarNBuilder {
     /// respect to the current [`ZStarNBuilder`]. This is one of two ways of
     /// constructing elements of [`ZStarN`]. The other way is by randomly
     /// sampling the element in the multiplicative group modulo n.
-    #[instrument(skip_all, err(Debug))]
     pub fn validate(&self, unverified: ZStarNUnverified) -> Result<ZStarN, InternalError> {
         if unverified.value().is_zero() {
             warn!("Elements of the multiplicative group  ZK*_N cannot be zero");

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -106,12 +106,11 @@ impl ZStarNUnverified {
 
 #[cfg(test)]
 mod test {
-    use crate::{paillier::DecryptionKey, zkstar::*};
-    use test_log::test;
+    use crate::{paillier::DecryptionKey, utils::testing::init_testing, zkstar::*};
 
     #[test]
     fn zkstar_verification_works() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (_, p, q) = DecryptionKey::new(&mut rng).unwrap();
         let builder = ZStarNBuilder::new(&p * &q);
 
@@ -124,9 +123,10 @@ mod test {
         let zstar_verifies_one = builder.validate(value_verifies_one);
         assert!(zstar_verifies_one.is_ok());
     }
+
     #[test]
     fn zkstar_constructor_rejects_elements_outside_group() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (_, p, q) = DecryptionKey::new(&mut rng).unwrap();
         let builder = ZStarNBuilder::new(&p * &q);
 
@@ -153,7 +153,7 @@ mod test {
     }
     #[test]
     fn randomly_sample_element_in_zkstar_works() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (_, p, q) = DecryptionKey::new(&mut rng).unwrap();
         let builder = ZStarNBuilder::new(&p * &q);
         let zstar = ZStarN::random_element(&builder, &mut rng);
@@ -161,7 +161,7 @@ mod test {
     }
     #[test]
     fn zkstar_serialization_deserialization_works() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
         let (_, p, q) = DecryptionKey::new(&mut rng).unwrap();
         let builder = ZStarNBuilder::new(&p * &q);
 
@@ -177,7 +177,8 @@ mod test {
     }
     #[test]
     fn zkstar_rejects_deserialized_elements_outside_group() {
-        let mut rng = crate::utils::get_test_rng();
+        let mut rng = init_testing();
+
         let (_, p, q) = DecryptionKey::new(&mut rng).unwrap();
         let builder = ZStarNBuilder::new(&p * &q);
 


### PR DESCRIPTION
This PR removes the `verify_err!` macro and removes the string portion of `InternalError::FailedToVerifyProof`. The context for why the proof failed is now logged with `tracing::warn`