### PR TITLE
Adds `transfer` method to `Storage`

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -478,33 +478,24 @@ impl AuxInfoParticipant {
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                let keyshare_bytes =
-                    self.storage
-                        .retrieve(StorableType::AuxInfoPublic, message.id(), *oid)?;
-                main_storage.store(
+                self.storage.transfer(
+                    main_storage,
                     StorableType::AuxInfoPublic,
                     message.id(),
                     *oid,
-                    &keyshare_bytes,
                 )?;
             }
-            let my_pk_bytes =
-                self.storage
-                    .retrieve(StorableType::AuxInfoPublic, message.id(), self.id)?;
-            let my_sk_bytes =
-                self.storage
-                    .retrieve(StorableType::AuxInfoPrivate, message.id(), self.id)?;
-            main_storage.store(
+            self.storage.transfer(
+                main_storage,
                 StorableType::AuxInfoPublic,
                 message.id(),
                 self.id,
-                &my_pk_bytes,
             )?;
-            main_storage.store(
+            self.storage.transfer(
+                main_storage,
                 StorableType::AuxInfoPrivate,
                 message.id(),
                 self.id,
-                &my_sk_bytes,
             )?;
         }
         Ok(vec![])

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -491,33 +491,24 @@ impl KeygenParticipant {
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                let keyshare_bytes =
-                    self.storage
-                        .retrieve(StorableType::PublicKeyshare, message.id(), *oid)?;
-                main_storage.store(
+                self.storage.transfer(
+                    main_storage,
                     StorableType::PublicKeyshare,
                     message.id(),
                     *oid,
-                    &keyshare_bytes,
                 )?;
             }
-            let my_pk_bytes =
-                self.storage
-                    .retrieve(StorableType::PublicKeyshare, message.id(), self.id)?;
-            let my_sk_bytes =
-                self.storage
-                    .retrieve(StorableType::PrivateKeyshare, message.id(), self.id)?;
-            main_storage.store(
+            self.storage.transfer(
+                main_storage,
                 StorableType::PublicKeyshare,
                 message.id(),
                 self.id,
-                &my_pk_bytes,
             )?;
-            main_storage.store(
+            self.storage.transfer(
+                main_storage,
                 StorableType::PrivateKeyshare,
                 message.id(),
                 self.id,
-                &my_sk_bytes,
             )?;
         }
         Ok(vec![])

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -97,6 +97,19 @@ impl Storage {
         })
     }
 
+    /// Transfers an entry stored in `self` to [`Storage`] specified by `other`.
+    pub(crate) fn transfer(
+        &self,
+        other: &mut Self,
+        storable_type: StorableType,
+        identifier: Identifier,
+        participant: ParticipantIdentifier,
+    ) -> Result<()> {
+        let bytes = self.retrieve(storable_type, identifier, participant)?;
+        other.store(storable_type, identifier, participant, &bytes)?;
+        Ok(())
+    }
+
     pub(crate) fn delete(
         &mut self,
         storable_type: StorableType,


### PR DESCRIPTION
Closes #176.

The `transfer` method is used when we need to move an entry from local storage to main storage. It simplifies a bunch of the manual retrieve/store code in some of the participants.