### PR TITLE
Replace `Storage::store` and `Storage::retrieve` with auto-(de)serialized versions

### DIFF
--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -168,14 +168,10 @@ impl BroadcastParticipant {
     ) -> Result<Option<BroadcastOutput>> {
         info!("Processing broadcast vote.");
 
-        let mut message_votes: HashMap<BroadcastIndex, Vec<u8>> =
-            match self
-                .storage
-                .retrieve(StorableType::BroadcastSet, sid, self.id())
-            {
-                Ok(a) => deserialize!(&a)?,
-                Err(_) => HashMap::new(),
-            };
+        let mut message_votes: HashMap<BroadcastIndex, Vec<u8>> = self
+            .storage
+            .retrieve(StorableType::BroadcastSet, sid, self.id())
+            .unwrap_or(HashMap::new());
         // if not already in database, store. else, ignore
         let idx = BroadcastIndex {
             tag: data.tag.clone(),
@@ -187,12 +183,8 @@ impl BroadcastParticipant {
         }
         let _ = message_votes.insert(idx, data.data.clone());
 
-        self.storage.store(
-            StorableType::BroadcastSet,
-            sid,
-            self.id(),
-            &serialize!(&message_votes)?,
-        )?;
+        self.storage
+            .store(StorableType::BroadcastSet, sid, self.id(), &message_votes)?;
 
         // check if we've received all the votes for this tag||leader yet
         let mut redispersed_messages: Vec<Vec<u8>> = vec![];

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -133,7 +133,7 @@ impl Participant {
                         StorableType::PresignRecord,
                         message.id(),
                         self.id,
-                        &serialize!(&presign_record)?,
+                        &presign_record,
                     )?;
                 }
 
@@ -231,11 +231,9 @@ impl Participant {
     #[instrument(skip_all, err(Debug))]
     pub fn get_public_keyshare(&self, identifier: Identifier) -> Result<CurvePoint> {
         info!("Retrieving our associated public keyshare.");
-        let keyshare_public: KeySharePublic = deserialize!(&self.main_storage.retrieve(
-            StorableType::PublicKeyshare,
-            identifier,
-            self.id,
-        )?)?;
+        let keyshare_public: KeySharePublic =
+            self.main_storage
+                .retrieve(StorableType::PublicKeyshare, identifier, self.id)?;
         Ok(keyshare_public.X)
     }
 
@@ -249,10 +247,9 @@ impl Participant {
     ) -> Result<SignatureShare> {
         info!("Issuing signature with presign record.");
 
-        let pr_bytes =
+        let presign_record: PresignRecord =
             self.main_storage
                 .retrieve(StorableType::PresignRecord, presign_identifier, self.id)?;
-        let presign_record: PresignRecord = deserialize!(&pr_bytes)?;
         let (r, s) = presign_record.sign(digest)?;
         let ret = SignatureShare { r: Some(r), s };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -312,7 +312,7 @@ pub(crate) fn get_other_participants_public_auxinfo(
             identifier,
             other_participant_id,
         )?;
-        let _ = hm.insert(other_participant_id, deserialize!(&val)?);
+        let _ = hm.insert(other_participant_id, val);
     }
     Ok(hm)
 }
@@ -324,7 +324,7 @@ pub(crate) fn process_ready_message(
     message: &Message,
     storable_type: StorableType,
 ) -> Result<(Vec<Message>, bool)> {
-    storage.store(storable_type, message.id(), message.from(), &[])?;
+    storage.store(storable_type, message.id(), message.from(), b"")?;
 
     let mut messages = vec![];
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -324,7 +324,7 @@ pub(crate) fn process_ready_message(
     message: &Message,
     storable_type: StorableType,
 ) -> Result<(Vec<Message>, bool)> {
-    storage.store(storable_type, message.id(), message.from(), b"")?;
+    storage.store::<[u8; 0]>(storable_type, message.id(), message.from(), &[])?;
 
     let mut messages = vec![];
 


### PR DESCRIPTION
Closes #177.

This (Draft!) MR replaces the `Storage::store` and `Storage::retrieve` methods with version that auto serialize/deserialize.

Currently, this MR adds `Storage::store_serialized` and `Storage::retrieve_deserialized`. Once #178 is merged in we'll be able to consolidate these two version of both `store` and `retrieve`.