### PR TITLE
Move to using `T: Storable` instead of `StorableType` in `Storage` API

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -419,7 +419,11 @@ impl AuxInfoParticipant {
         // We can't handle this message unless we already calculated the global_rid
         if self
             .storage
-            .retrieve::<[u8; 32]>(StorableType::AuxInfoGlobalRid, message.id(), self.id)
+            .retrieve::<StorableType, [u8; 32]>(
+                StorableType::AuxInfoGlobalRid,
+                message.id(),
+                self.id,
+            )
             .is_err()
         {
             self.stash_message(message)?;
@@ -459,20 +463,20 @@ impl AuxInfoParticipant {
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                self.storage.transfer::<AuxInfoPublic>(
+                self.storage.transfer::<StorableType, AuxInfoPublic>(
                     main_storage,
                     StorableType::AuxInfoPublic,
                     message.id(),
                     *oid,
                 )?;
             }
-            self.storage.transfer::<AuxInfoPublic>(
+            self.storage.transfer::<StorableType, AuxInfoPublic>(
                 main_storage,
                 StorableType::AuxInfoPublic,
                 message.id(),
                 self.id,
             )?;
-            self.storage.transfer::<AuxInfoPrivate>(
+            self.storage.transfer::<StorableType, AuxInfoPrivate>(
                 main_storage,
                 StorableType::AuxInfoPrivate,
                 message.id(),

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -435,7 +435,11 @@ impl KeygenParticipant {
         // We can't handle this message unless we already calculated the global_rid
         if self
             .storage
-            .retrieve::<[u8; 32]>(StorableType::KeygenGlobalRid, message.id(), self.id)
+            .retrieve::<StorableType, [u8; 32]>(
+                StorableType::KeygenGlobalRid,
+                message.id(),
+                self.id,
+            )
             .is_err()
         {
             self.stash_message(message)?;
@@ -474,20 +478,20 @@ impl KeygenParticipant {
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                self.storage.transfer::<KeySharePublic>(
+                self.storage.transfer::<StorableType, KeySharePublic>(
                     main_storage,
                     StorableType::PublicKeyshare,
                     message.id(),
                     *oid,
                 )?;
             }
-            self.storage.transfer::<KeySharePublic>(
+            self.storage.transfer::<StorableType, KeySharePublic>(
                 main_storage,
                 StorableType::PublicKeyshare,
                 message.id(),
                 self.id,
             )?;
-            self.storage.transfer::<KeySharePrivate>(
+            self.storage.transfer::<StorableType, KeySharePrivate>(
                 main_storage,
                 StorableType::PrivateKeyshare,
                 message.id(),

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -635,7 +635,7 @@ impl PresignParticipant {
         // If we have not yet started round three, stash the message for later
         let r3_started = self
             .storage
-            .retrieve::<RoundThreePrivate>(
+            .retrieve::<StorableType, RoundThreePrivate>(
                 StorableType::PresignRoundThreePrivate,
                 message.id(),
                 self.id,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ use crate::{
         InternalError::{self, CouldNotConvertToScalar, RetryFailed},
         Result,
     },
-    storage::{StorableType, Storage},
+    storage::{Storable, StorableType, Storage},
     Identifier, Message, ParticipantIdentifier,
 };
 use generic_array::GenericArray;
@@ -317,14 +317,14 @@ pub(crate) fn get_other_participants_public_auxinfo(
     Ok(hm)
 }
 
-pub(crate) fn process_ready_message(
+pub(crate) fn process_ready_message<T: Storable>(
     self_id: ParticipantIdentifier,
     other_ids: &[ParticipantIdentifier],
     storage: &mut Storage,
     message: &Message,
-    storable_type: StorableType,
+    storable_type: T,
 ) -> Result<(Vec<Message>, bool)> {
-    storage.store::<[u8; 0]>(storable_type, message.id(), message.from(), &[])?;
+    storage.store::<T, [u8; 0]>(storable_type, message.id(), message.from(), &[])?;
 
     let mut messages = vec![];
 


### PR DESCRIPTION
Closes #186.

This PR replaces the use of `StorableType` in the `Storage` API with using `T: Storable` to aid in eventually replacing `StorableType` with local versions.