### PR TITLE
Define return types for subprotocols

### DIFF
--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -24,6 +24,12 @@ struct MessageIndex {
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct MessageQueue(HashMap<Vec<u8>, Vec<Message>>);
 
+impl Default for MessageQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessageQueue {
     pub(crate) fn new() -> Self {
         Self(HashMap::new())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -166,20 +166,17 @@ impl Storage {
 
     fn retrieve_index<I: Storable>(&self, storable_index: I) -> Result<Vec<u8>> {
         let key = serialize!(&storable_index)?;
-        let ret = self
-            .0
+        self.0
             .get(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound)?
-            .clone();
-
-        Ok(ret)
+            .ok_or(InternalError::StorageItemNotFound)
+            .cloned()
     }
 
     fn delete_index<I: Storable>(&mut self, storable_index: I) -> Result<Vec<u8>> {
         let key = serialize!(&storable_index)?;
         self.0
             .remove(&key)
-            .ok_or_else(|| InternalError::StorageItemNotFound)
+            .ok_or(InternalError::StorageItemNotFound)
     }
 
     fn contains_index_batch<I: Storable>(&self, storable_indices: &[I]) -> Result<bool> {


### PR DESCRIPTION
Closes #179 

This updates the `ProtocolParticipant` trait to define an output type and to add the `process_message` driver function to the trait.

Half the protocols (broadcast, presign) were already consistent with the new return type, so those didn't really change. The other half (keygen, auxinfo), will require a lot of changes to thread checking-whether-outputs-are-ready throughout the implementation. To preserve reviewer sanity, I've pushed that work to #193 and #194. I've tried to document inline some of the most obvious places where this will change.

I would particularly like reviewers to read the documentation of the `process_message` function and give feedback on whether the output type makes sense! I experimented with much wordier, more custom types to try to describe what was happening in greater detail and decided the wordiness was worse than a simpler type. However, I'm open to either improving the docs or changing the type if it feels undescriptive to you. 