### PR TITLE
Thread output-return throughout auxinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = "1"
 sha2 = "0.9"
 thiserror = "1"
 tracing = "0.1.37"
+zeroize = "1.5"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -6,39 +6,97 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use std::fmt::Debug;
+
 use crate::{
-    errors::Result,
+    errors::{InternalError, Result},
     paillier::{DecryptionKey, EncryptionKey},
     ring_pedersen::VerifiedRingPedersen,
+    ParticipantIdentifier,
 };
+use k256::elliptic_curve::zeroize::ZeroizeOnDrop;
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 /// The private key corresponding to a given Participant's [`AuxInfoPublic`].
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, ZeroizeOnDrop)]
 pub(crate) struct AuxInfoPrivate {
-    pub(crate) sk: DecryptionKey,
+    decryption_key: DecryptionKey,
+}
+
+impl AuxInfoPrivate {
+    #[cfg(test)]
+    pub fn encryption_key(&self) -> EncryptionKey {
+        self.decryption_key.encryption_key()
+    }
+
+    pub fn decryption_key(&self) -> &DecryptionKey {
+        &self.decryption_key
+    }
+}
+
+impl From<DecryptionKey> for AuxInfoPrivate {
+    fn from(decryption_key: DecryptionKey) -> Self {
+        Self { decryption_key }
+    }
+}
+
+impl Debug for AuxInfoPrivate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuxInfoPrivate")
+            .field("decryption key", &"[redacted]")
+            .finish()
+    }
 }
 
 /// The public Auxilary Information corresponding to a given Participant.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub(crate) struct AuxInfoPublic {
-    pub(crate) pk: EncryptionKey,
-    pub(crate) params: VerifiedRingPedersen,
+    participant: ParticipantIdentifier,
+    pk: EncryptionKey,
+    params: VerifiedRingPedersen,
 }
 
 impl AuxInfoPublic {
+    pub(crate) fn new(
+        participant: ParticipantIdentifier,
+        encryption_key: EncryptionKey,
+        params: VerifiedRingPedersen,
+    ) -> Result<Self> {
+        let public = Self {
+            participant,
+            pk: encryption_key,
+            params,
+        };
+        public.verify()?;
+        Ok(public)
+    }
+
+    pub(crate) fn pk(&self) -> &EncryptionKey {
+        &self.pk
+    }
+
+    pub(crate) fn params(&self) -> &VerifiedRingPedersen {
+        &self.params
+    }
+
+    pub(crate) fn participant(&self) -> &ParticipantIdentifier {
+        &self.participant
+    }
+
     /// Verifies that the public key's modulus matches the ZKSetupParameters
     /// modulus N, and that the parameters have appropriate s and t values.
     pub(crate) fn verify(&self) -> Result<()> {
         if self.pk.modulus() != self.params.scheme().modulus() {
-            return verify_err!("Mismatch between public key modulus and setup parameters modulus");
+            error!("Mismatch between public key modulus and setup parameters modulus");
+            return Err(InternalError::Serialization);
         }
         self.params.verify()
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, ZeroizeOnDrop)]
 pub(crate) struct AuxInfoWitnesses {
     pub(crate) p: BigNumber,
     pub(crate) q: BigNumber,

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -46,7 +46,7 @@ pub(crate) struct BroadcastIndex {
     other_id: ParticipantIdentifier,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct BroadcastOutput {
     pub(crate) tag: BroadcastTag,
     pub(crate) msg: Message,
@@ -65,6 +65,10 @@ impl ProtocolParticipant for BroadcastParticipant {
 
     fn id(&self) -> ParticipantIdentifier {
         self.id
+    }
+
+    fn other_ids(&self) -> &Vec<ParticipantIdentifier> {
+        &self.other_participant_ids
     }
 
     #[instrument(skip_all, err(Debug))]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,6 +21,8 @@ pub type Result<T> = std::result::Result<T, InternalError>;
 pub enum InternalError {
     #[error("Serialization Error")]
     Serialization,
+    #[error("Protocol error")]
+    ProtocolError,
     #[error("Could not successfully generate proof")]
     CouldNotGenerateProof,
     #[error("Failed to verify proof: `{0}`")]

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -14,6 +14,7 @@ use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zeroize::ZeroizeOnDrop;
 
 #[cfg(test)]
 use crate::utils::random_positive_bn;
@@ -67,6 +68,14 @@ impl Ciphertext {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct EncryptionKey(libpaillier::EncryptionKey);
+
+// This is stupid and should have been derived by the underlying crate.
+impl PartialEq for EncryptionKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.n() == other.0.n() && self.0.nn() == other.0.nn()
+    }
+}
+impl Eq for EncryptionKey {}
 
 impl EncryptionKey {
     /// Return this [`EncryptionKey`]s modulus.
@@ -181,7 +190,7 @@ impl EncryptionKey {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
 pub(crate) struct DecryptionKey(libpaillier::DecryptionKey);
 
 impl DecryptionKey {

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -6,6 +6,8 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use std::fmt::Debug;
+
 use crate::{
     errors::{
         InternalError::{CouldNotConvertToScalar, CouldNotInvertScalar, InternalInvariantFailed},
@@ -33,6 +35,19 @@ pub(crate) struct PresignRecord {
     R: CurvePoint,
     k: BigNumber,
     chi: k256::Scalar,
+}
+
+impl Debug for PresignRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redacting all the fields because I'm not sure how sensitive they are. If
+        // later analysis suggests they're fine to print, please udpate
+        // accordingly.
+        f.debug_struct("PresignRecord")
+            .field("R", &"[redacted]")
+            .field("k", &"[redacted]")
+            .field("chi", &"[redacted]")
+            .finish()
+    }
 }
 
 impl TryFrom<RecordPair> for PresignRecord {

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -65,8 +65,8 @@ impl Public {
         let round_one_public: Self = deserialize!(&message.unverified_bytes)?;
 
         round_one_public.verify(
-            &receiver_keygen_public.params,
-            sender_keygen_public.pk.clone(),
+            receiver_keygen_public.params(),
+            sender_keygen_public.pk().clone(),
             broadcasted_params.K.clone(),
         )?;
         Ok(round_one_public)

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -54,8 +54,8 @@ impl Public {
         let psi_double_prime_input = CommonInput::new(
             sender_r1_public_broadcast.K.clone(),
             self.Delta,
-            receiver_keygen_public.params.scheme().clone(),
-            sender_keygen_public.pk.clone(),
+            receiver_keygen_public.params().scheme().clone(),
+            sender_keygen_public.pk().clone(),
             self.Gamma,
         );
         self.psi_double_prime

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -55,10 +55,10 @@ impl Public {
 
         // Verify the psi proof
         let psi_input = PiAffgInput::new(
-            &receiver_auxinfo_public.params,
+            receiver_auxinfo_public.params(),
             &g,
-            &receiver_auxinfo_public.pk,
-            &sender_auxinfo_public.pk,
+            receiver_auxinfo_public.pk(),
+            sender_auxinfo_public.pk(),
             &receiver_r1_private.K,
             &self.D,
             &self.F,
@@ -69,10 +69,10 @@ impl Public {
 
         // Verify the psi_hat proof
         let psi_hat_input = PiAffgInput::new(
-            &receiver_auxinfo_public.params,
+            receiver_auxinfo_public.params(),
             &g,
-            &receiver_auxinfo_public.pk,
-            &sender_auxinfo_public.pk,
+            receiver_auxinfo_public.pk(),
+            sender_auxinfo_public.pk(),
             &receiver_r1_private.K,
             &self.D_hat,
             &self.F_hat,
@@ -85,8 +85,8 @@ impl Public {
         let psi_prime_input = CommonInput::new(
             sender_r1_public_broadcast.G.clone(),
             self.Gamma,
-            receiver_auxinfo_public.params.scheme().clone(),
-            sender_auxinfo_public.pk.clone(),
+            receiver_auxinfo_public.params().scheme().clone(),
+            sender_auxinfo_public.pk().clone(),
             g,
         );
         let mut transcript = Transcript::new(b"PiLogProof");

--- a/src/ring_pedersen.rs
+++ b/src/ring_pedersen.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 
 /// A commitment scheme based on a ring-variant of the Pedersen commitment
 /// scheme.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct RingPedersen {
     /// The RSA modulus, corresponding to `N` in the paper.
     modulus: BigNumber,
@@ -49,6 +49,13 @@ pub(crate) struct VerifiedRingPedersen {
     /// [`VerifiedRingPedersen::scheme`].
     proof: PiPrmProof,
 }
+
+impl PartialEq for VerifiedRingPedersen {
+    fn eq(&self, other: &Self) -> bool {
+        self.scheme == other.scheme
+    }
+}
+impl Eq for VerifiedRingPedersen {}
 
 /// A commitment produced by [`RingPedersen::commit`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #193 

I let this PR expand out of reasonable scope; I apologize to the reviewers.

Primary changes are:
- Updates the auxinfo protocol to return public and private key material
    - Adds a participant ID field to public key material to indicate who it belongs to
    - Adds conditions to aux info tests to make sure the outputs are as expected
- Improves code quality of `AuxInfo{Commit, Decommit, Public, Private, Witness}`, including limiting visibility of parameters to add confidence that they're well-formed, adding validation at construction and deserialization, zeroizing secrets, and adding custom debug implementations to some maybe-secret types.
- Moves some existing functionality (`process_ready_message`) into `ProtocolParticipant` 
- Adds a new method to combine `ProcessOutcome`s in a logical way.