### PR TITLE
Move presign storage types to `presign::StorageType`

### DIFF
--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -13,7 +13,7 @@ use crate::{
     participant::{ProcessOutcome, ProtocolParticipant},
     protocol::ParticipantIdentifier,
     run_only_once_per_tag,
-    storage::{StorableType, Storage},
+    storage::{MainStorageType, Storage},
     Identifier,
 };
 use rand::{CryptoRng, RngCore};
@@ -173,7 +173,7 @@ impl BroadcastParticipant {
 
         let mut message_votes: HashMap<BroadcastIndex, Vec<u8>> = self
             .storage
-            .retrieve(StorableType::BroadcastSet, sid, self.id())
+            .retrieve(MainStorageType::BroadcastSet, sid, self.id())
             .unwrap_or_default();
         // if not already in database, store. else, ignore
         let idx = BroadcastIndex {
@@ -186,8 +186,12 @@ impl BroadcastParticipant {
         }
         let _ = message_votes.insert(idx, data.data.clone());
 
-        self.storage
-            .store(StorableType::BroadcastSet, sid, self.id(), &message_votes)?;
+        self.storage.store(
+            MainStorageType::BroadcastSet,
+            sid,
+            self.id(),
+            &message_votes,
+        )?;
 
         // check if we've received all the votes for this tag||leader yet
         let mut redispersed_messages: Vec<Vec<u8>> = vec![];

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -13,7 +13,7 @@ use crate::{
     participant::{ProcessOutcome, ProtocolParticipant},
     protocol::ParticipantIdentifier,
     run_only_once_per_tag,
-    storage::{MainStorageType, Storage},
+    storage::{PersistentStorageType, Storage},
     Identifier,
 };
 use rand::{CryptoRng, RngCore};
@@ -173,7 +173,7 @@ impl BroadcastParticipant {
 
         let mut message_votes: HashMap<BroadcastIndex, Vec<u8>> = self
             .storage
-            .retrieve(MainStorageType::BroadcastSet, sid, self.id())
+            .retrieve(PersistentStorageType::BroadcastSet, sid, self.id())
             .unwrap_or_default();
         // if not already in database, store. else, ignore
         let idx = BroadcastIndex {
@@ -187,7 +187,7 @@ impl BroadcastParticipant {
         let _ = message_votes.insert(idx, data.data.clone());
 
         self.storage.store(
-            MainStorageType::BroadcastSet,
+            PersistentStorageType::BroadcastSet,
             sid,
             self.id(),
             &message_votes,

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -17,7 +17,7 @@ use crate::{
     participant::{Broadcast, ProcessOutcome, ProtocolParticipant},
     protocol::ParticipantIdentifier,
     run_only_once,
-    storage::{Storable, StorableType, Storage},
+    storage::{MainStorageType, Storable, Storage},
     utils::{k256_order, process_ready_message},
     zkp::pisch::{PiSchInput, PiSchPrecommit, PiSchProof, PiSchSecret},
     CurvePoint,
@@ -162,13 +162,13 @@ impl KeygenParticipant {
 
         let (keyshare_private, keyshare_public) = new_keyshare(rng)?;
         self.storage.store(
-            StorableType::PrivateKeyshare,
+            MainStorageType::PrivateKeyshare,
             message.id(),
             self.id,
             &keyshare_private,
         )?;
         self.storage.store(
-            StorableType::PublicKeyshare,
+            MainStorageType::PublicKeyshare,
             message.id(),
             self.id,
             &keyshare_public,
@@ -264,7 +264,7 @@ impl KeygenParticipant {
         info!("Generating round two keygen messages.");
 
         // check that we've generated our keyshare before trying to retrieve it
-        let fetch = vec![(StorableType::PublicKeyshare, message.id(), self.id)];
+        let fetch = vec![(MainStorageType::PublicKeyshare, message.id(), self.id)];
         let public_keyshare_generated = self.storage.contains_batch(&fetch)?;
         let mut messages = vec![];
         if !public_keyshare_generated {
@@ -394,12 +394,12 @@ impl KeygenParticipant {
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
         let my_pk: KeySharePublic =
             self.storage
-                .retrieve(StorableType::PublicKeyshare, message.id(), self.id)?;
+                .retrieve(MainStorageType::PublicKeyshare, message.id(), self.id)?;
         let input = PiSchInput::new(&g, &q, &my_pk.X);
 
         let my_sk: KeySharePrivate =
             self.storage
-                .retrieve(StorableType::PrivateKeyshare, message.id(), self.id)?;
+                .retrieve(MainStorageType::PrivateKeyshare, message.id(), self.id)?;
 
         let proof = PiSchProof::prove_from_precommit(
             &precom,
@@ -462,7 +462,7 @@ impl KeygenParticipant {
         proof.verify_with_transcript(&input, &transcript)?;
         let keyshare = decom.get_keyshare();
         self.storage.store(
-            StorableType::PublicKeyshare,
+            MainStorageType::PublicKeyshare,
             message.id(),
             message.from(),
             &keyshare,
@@ -470,29 +470,29 @@ impl KeygenParticipant {
 
         //check if we've stored all the public keyshares
         let keyshare_done = self.storage.contains_for_all_ids(
-            StorableType::PublicKeyshare,
+            MainStorageType::PublicKeyshare,
             message.id(),
             &[self.other_participant_ids.clone(), vec![self.id]].concat(),
         )?;
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                self.storage.transfer::<StorableType, KeySharePublic>(
+                self.storage.transfer::<MainStorageType, KeySharePublic>(
                     main_storage,
-                    StorableType::PublicKeyshare,
+                    MainStorageType::PublicKeyshare,
                     message.id(),
                     *oid,
                 )?;
             }
-            self.storage.transfer::<StorableType, KeySharePublic>(
+            self.storage.transfer::<MainStorageType, KeySharePublic>(
                 main_storage,
-                StorableType::PublicKeyshare,
+                MainStorageType::PublicKeyshare,
                 message.id(),
                 self.id,
             )?;
-            self.storage.transfer::<StorableType, KeySharePrivate>(
+            self.storage.transfer::<MainStorageType, KeySharePrivate>(
                 main_storage,
-                StorableType::PrivateKeyshare,
+                MainStorageType::PrivateKeyshare,
                 message.id(),
                 self.id,
             )?;
@@ -556,10 +556,14 @@ mod tests {
         pub fn is_keygen_done(&self, keygen_identifier: Identifier) -> Result<bool> {
             let mut fetch = vec![];
             for participant in self.other_participant_ids.clone() {
-                fetch.push((StorableType::PublicKeyshare, keygen_identifier, participant));
+                fetch.push((
+                    MainStorageType::PublicKeyshare,
+                    keygen_identifier,
+                    participant,
+                ));
             }
-            fetch.push((StorableType::PublicKeyshare, keygen_identifier, self.id));
-            fetch.push((StorableType::PrivateKeyshare, keygen_identifier, self.id));
+            fetch.push((MainStorageType::PublicKeyshare, keygen_identifier, self.id));
+            fetch.push((MainStorageType::PrivateKeyshare, keygen_identifier, self.id));
 
             self.storage.contains_batch(&fetch)
         }
@@ -659,7 +663,7 @@ mod tests {
             let mut stored_values = vec![];
             for main_storage in main_storages.iter() {
                 let pk: KeySharePublic = main_storage.retrieve(
-                    StorableType::PublicKeyshare,
+                    MainStorageType::PublicKeyshare,
                     keyshare_identifier,
                     player_id,
                 )?;
@@ -678,12 +682,12 @@ mod tests {
             let player_id = player.id;
             let main_storage = main_storages.get(index).unwrap();
             let pk: KeySharePublic = main_storage.retrieve(
-                StorableType::PublicKeyshare,
+                MainStorageType::PublicKeyshare,
                 keyshare_identifier,
                 player_id,
             )?;
             let sk: KeySharePrivate = main_storage.retrieve(
-                StorableType::PrivateKeyshare,
+                MainStorageType::PrivateKeyshare,
                 keyshare_identifier,
                 player_id,
             )?;

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -17,7 +17,7 @@ use crate::{
     participant::{Broadcast, ProcessOutcome, ProtocolParticipant},
     protocol::ParticipantIdentifier,
     run_only_once,
-    storage::{MainStorageType, Storable, Storage},
+    storage::{PersistentStorageType, Storable, Storage},
     utils::{k256_order, process_ready_message},
     zkp::pisch::{PiSchInput, PiSchPrecommit, PiSchProof, PiSchSecret},
     CurvePoint,
@@ -162,13 +162,13 @@ impl KeygenParticipant {
 
         let (keyshare_private, keyshare_public) = new_keyshare(rng)?;
         self.storage.store(
-            MainStorageType::PrivateKeyshare,
+            PersistentStorageType::PrivateKeyshare,
             message.id(),
             self.id,
             &keyshare_private,
         )?;
         self.storage.store(
-            MainStorageType::PublicKeyshare,
+            PersistentStorageType::PublicKeyshare,
             message.id(),
             self.id,
             &keyshare_public,
@@ -264,7 +264,7 @@ impl KeygenParticipant {
         info!("Generating round two keygen messages.");
 
         // check that we've generated our keyshare before trying to retrieve it
-        let fetch = vec![(MainStorageType::PublicKeyshare, message.id(), self.id)];
+        let fetch = vec![(PersistentStorageType::PublicKeyshare, message.id(), self.id)];
         let public_keyshare_generated = self.storage.contains_batch(&fetch)?;
         let mut messages = vec![];
         if !public_keyshare_generated {
@@ -394,12 +394,14 @@ impl KeygenParticipant {
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
         let my_pk: KeySharePublic =
             self.storage
-                .retrieve(MainStorageType::PublicKeyshare, message.id(), self.id)?;
+                .retrieve(PersistentStorageType::PublicKeyshare, message.id(), self.id)?;
         let input = PiSchInput::new(&g, &q, &my_pk.X);
 
-        let my_sk: KeySharePrivate =
-            self.storage
-                .retrieve(MainStorageType::PrivateKeyshare, message.id(), self.id)?;
+        let my_sk: KeySharePrivate = self.storage.retrieve(
+            PersistentStorageType::PrivateKeyshare,
+            message.id(),
+            self.id,
+        )?;
 
         let proof = PiSchProof::prove_from_precommit(
             &precom,
@@ -462,7 +464,7 @@ impl KeygenParticipant {
         proof.verify_with_transcript(&input, &transcript)?;
         let keyshare = decom.get_keyshare();
         self.storage.store(
-            MainStorageType::PublicKeyshare,
+            PersistentStorageType::PublicKeyshare,
             message.id(),
             message.from(),
             &keyshare,
@@ -470,29 +472,29 @@ impl KeygenParticipant {
 
         //check if we've stored all the public keyshares
         let keyshare_done = self.storage.contains_for_all_ids(
-            MainStorageType::PublicKeyshare,
+            PersistentStorageType::PublicKeyshare,
             message.id(),
             &[self.other_participant_ids.clone(), vec![self.id]].concat(),
         )?;
 
         if keyshare_done {
             for oid in self.other_participant_ids.iter() {
-                self.storage.transfer::<MainStorageType, KeySharePublic>(
+                self.storage.transfer::<_, KeySharePublic>(
                     main_storage,
-                    MainStorageType::PublicKeyshare,
+                    PersistentStorageType::PublicKeyshare,
                     message.id(),
                     *oid,
                 )?;
             }
-            self.storage.transfer::<MainStorageType, KeySharePublic>(
+            self.storage.transfer::<_, KeySharePublic>(
                 main_storage,
-                MainStorageType::PublicKeyshare,
+                PersistentStorageType::PublicKeyshare,
                 message.id(),
                 self.id,
             )?;
-            self.storage.transfer::<MainStorageType, KeySharePrivate>(
+            self.storage.transfer::<_, KeySharePrivate>(
                 main_storage,
-                MainStorageType::PrivateKeyshare,
+                PersistentStorageType::PrivateKeyshare,
                 message.id(),
                 self.id,
             )?;
@@ -557,13 +559,21 @@ mod tests {
             let mut fetch = vec![];
             for participant in self.other_participant_ids.clone() {
                 fetch.push((
-                    MainStorageType::PublicKeyshare,
+                    PersistentStorageType::PublicKeyshare,
                     keygen_identifier,
                     participant,
                 ));
             }
-            fetch.push((MainStorageType::PublicKeyshare, keygen_identifier, self.id));
-            fetch.push((MainStorageType::PrivateKeyshare, keygen_identifier, self.id));
+            fetch.push((
+                PersistentStorageType::PublicKeyshare,
+                keygen_identifier,
+                self.id,
+            ));
+            fetch.push((
+                PersistentStorageType::PrivateKeyshare,
+                keygen_identifier,
+                self.id,
+            ));
 
             self.storage.contains_batch(&fetch)
         }
@@ -663,7 +673,7 @@ mod tests {
             let mut stored_values = vec![];
             for main_storage in main_storages.iter() {
                 let pk: KeySharePublic = main_storage.retrieve(
-                    MainStorageType::PublicKeyshare,
+                    PersistentStorageType::PublicKeyshare,
                     keyshare_identifier,
                     player_id,
                 )?;
@@ -682,12 +692,12 @@ mod tests {
             let player_id = player.id;
             let main_storage = main_storages.get(index).unwrap();
             let pk: KeySharePublic = main_storage.retrieve(
-                MainStorageType::PublicKeyshare,
+                PersistentStorageType::PublicKeyshare,
                 keyshare_identifier,
                 player_id,
             )?;
             let sk: KeySharePrivate = main_storage.retrieve(
-                MainStorageType::PrivateKeyshare,
+                PersistentStorageType::PrivateKeyshare,
                 keyshare_identifier,
                 player_id,
             )?;

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -12,7 +12,7 @@ use crate::{
     message_queue::MessageQueue,
     messages::{Message, MessageType},
     protocol::ParticipantIdentifier,
-    storage::{MainStorageType, Storage},
+    storage::{PersistentStorageType, Storage},
     Identifier,
 };
 use rand::{CryptoRng, RngCore};
@@ -113,12 +113,12 @@ pub(crate) trait ProtocolParticipant {
     fn stash_message(&mut self, message: &Message) -> Result<()> {
         let mut message_storage: MessageQueue = self
             .storage()
-            .retrieve(MainStorageType::MessageQueue, message.id(), self.id())
+            .retrieve(PersistentStorageType::MessageQueue, message.id(), self.id())
             .unwrap_or_default();
         message_storage.store(message.message_type(), message.id(), message.clone())?;
         let my_id = self.id();
         self.storage_mut().store(
-            MainStorageType::MessageQueue,
+            PersistentStorageType::MessageQueue,
             message.id(),
             my_id,
             &message_storage,
@@ -152,27 +152,31 @@ pub(crate) trait ProtocolParticipant {
     fn get_message_queue(&mut self, sid: Identifier) -> Result<MessageQueue> {
         let message_storage: MessageQueue = self
             .storage()
-            .retrieve(MainStorageType::MessageQueue, sid, self.id())
+            .retrieve(PersistentStorageType::MessageQueue, sid, self.id())
             .unwrap_or_default();
         Ok(message_storage)
     }
 
     fn write_message_queue(&mut self, sid: Identifier, message_queue: MessageQueue) -> Result<()> {
         let my_id = self.id();
-        self.storage_mut()
-            .store(MainStorageType::MessageQueue, sid, my_id, &message_queue)
+        self.storage_mut().store(
+            PersistentStorageType::MessageQueue,
+            sid,
+            my_id,
+            &message_queue,
+        )
     }
 
     fn write_progress(&mut self, func_name: String, sid: Identifier) -> Result<()> {
         let mut progress_storage: HashMap<Vec<u8>, bool> = self
             .storage()
-            .retrieve(MainStorageType::ProgressStore, sid, self.id())
+            .retrieve(PersistentStorageType::ProgressStore, sid, self.id())
             .unwrap_or_default();
         let key = serialize!(&ProgressIndex { func_name, sid })?;
         let _ = progress_storage.insert(key, true);
         let my_id = self.id();
         self.storage_mut().store(
-            MainStorageType::ProgressStore,
+            PersistentStorageType::ProgressStore,
             sid,
             my_id,
             &progress_storage,
@@ -183,7 +187,7 @@ pub(crate) trait ProtocolParticipant {
     fn read_progress(&self, func_name: String, sid: Identifier) -> Result<bool> {
         let progress_storage: HashMap<Vec<u8>, bool> = self
             .storage()
-            .retrieve(MainStorageType::ProgressStore, sid, self.id())
+            .retrieve(PersistentStorageType::ProgressStore, sid, self.id())
             .unwrap_or_default();
         let key = serialize!(&ProgressIndex { func_name, sid })?;
         let result = match progress_storage.get(&key) {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -6,6 +6,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use super::round_two;
 use crate::{
     auxinfo::{
         info::{AuxInfoPrivate, AuxInfoPublic},
@@ -30,7 +31,7 @@ use crate::{
         round_two::{Private as RoundTwoPrivate, Public as RoundTwoPublic},
     },
     protocol::ParticipantIdentifier,
-    storage::{StorableType, Storage},
+    storage::{MainStorageType, Storable, Storage},
     utils::{
         bn_to_scalar, get_other_participants_public_auxinfo, has_collected_all_of_others,
         k256_order, process_ready_message, random_plusminus_by_size, random_positive_bn,
@@ -50,7 +51,22 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{error, info, instrument};
 
-use super::round_two;
+/// Storage identifiers for the presign protocol.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(tag = "Presign")]
+pub(crate) enum StorageType {
+    Ready,
+    RoundOnePrivate,
+    RoundOnePublic,
+    RoundOnePublicBroadcast,
+    RoundTwoPrivate,
+    RoundTwoPublic,
+    RoundThreePrivate,
+    RoundThreePublic,
+    Record,
+}
+
+impl Storable for StorageType {}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct PresignParticipant {
@@ -161,7 +177,7 @@ impl PresignParticipant {
             &self.other_participant_ids,
             &mut self.storage,
             message,
-            StorableType::PresignReady,
+            StorageType::Ready,
         )?;
 
         if is_ready {
@@ -241,7 +257,7 @@ impl PresignParticipant {
 
         // Store private round one value locally
         self.storage.store(
-            StorableType::PresignRoundOnePrivate,
+            StorageType::RoundOnePrivate,
             message.id(),
             self.id,
             &private,
@@ -310,7 +326,7 @@ impl PresignParticipant {
         let message = &broadcast_message.msg;
         let public_broadcast: RoundOnePublicBroadcast = deserialize!(&message.unverified_bytes)?;
         self.storage.store(
-            StorableType::PresignRoundOnePublicBroadcast,
+            StorageType::RoundOnePublicBroadcast,
             message.id(),
             message.from(),
             &public_broadcast,
@@ -346,15 +362,11 @@ impl PresignParticipant {
         // in order to respond and have started round one
         let search_keys = [
             (
-                StorableType::PresignRoundOnePublicBroadcast,
+                StorageType::RoundOnePublicBroadcast,
                 message.id(),
                 message.from(),
             ),
-            (
-                StorableType::PresignRoundOnePrivate,
-                message.id(),
-                message.to(),
-            ),
+            (StorageType::RoundOnePrivate, message.id(), message.to()),
         ];
         if !self.storage.contains_batch(&search_keys)? {
             self.stash_message(message)?;
@@ -407,15 +419,13 @@ impl PresignParticipant {
             .ok_or(InternalInvariantFailed)?;
 
         // Get this participant's round 1 private value
-        let r1_priv: RoundOnePrivate = self.storage.retrieve(
-            StorableType::PresignRoundOnePrivate,
-            message.id(),
-            message.to(),
-        )?;
+        let r1_priv: RoundOnePrivate =
+            self.storage
+                .retrieve(StorageType::RoundOnePrivate, message.id(), message.to())?;
 
         // Get the round one message broadcasted by this sender
         let r1_public_broadcast: RoundOnePublicBroadcast = self.storage.retrieve(
-            StorableType::PresignRoundOnePublicBroadcast,
+            StorageType::RoundOnePublicBroadcast,
             message.id(),
             message.from(),
         )?;
@@ -429,7 +439,7 @@ impl PresignParticipant {
 
         // Store the round 1 public value
         self.storage.store(
-            StorableType::PresignRoundOnePublic,
+            StorageType::RoundOnePublic,
             message.id(),
             message.from(),
             &r1_public,
@@ -440,7 +450,7 @@ impl PresignParticipant {
 
         // Store the private value for this round 2 pair
         self.storage.store(
-            StorableType::PresignRoundTwoPrivate,
+            StorageType::RoundTwoPrivate,
             message.id(),
             message.from(),
             &r2_priv_ij,
@@ -483,11 +493,7 @@ impl PresignParticipant {
         info!("Handling round two presign message.");
 
         // First, check that the sender's Round One messages have been processed
-        let search_key = [(
-            StorableType::PresignRoundOnePublic,
-            message.id(),
-            message.from(),
-        )];
+        let search_key = [(StorageType::RoundOnePublic, message.id(), message.from())];
         if !self.storage.contains_batch(&search_key)? {
             self.stash_message(message)?;
             return Ok((None, vec![]));
@@ -521,13 +527,13 @@ impl PresignParticipant {
         let all_privates_received = has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundTwoPrivate,
+            StorageType::RoundTwoPrivate,
             message.id(),
         )?;
         let all_publics_received = has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundTwoPublic,
+            StorageType::RoundTwoPublic,
             message.id(),
         )?;
         if all_privates_received && all_publics_received {
@@ -579,16 +585,16 @@ impl PresignParticipant {
         )?;
 
         // Get this participant's round 1 private value
-        let r1_priv =
-            self.storage
-                .retrieve(StorableType::PresignRoundOnePrivate, message.id(), self.id)?;
+        let r1_priv = self
+            .storage
+            .retrieve(StorageType::RoundOnePrivate, message.id(), self.id)?;
 
         let (r3_private, r3_publics_map) =
             keyshare.round_three(rng, &r1_priv, &round_three_hashmap)?;
 
         // Store round 3 private value
         self.storage.store(
-            StorableType::PresignRoundThreePrivate,
+            StorageType::RoundThreePrivate,
             message.id(),
             self.id,
             &r3_private,
@@ -642,8 +648,8 @@ impl PresignParticipant {
         // If we have not yet started round three, stash the message for later
         let r3_started = self
             .storage
-            .retrieve::<StorableType, RoundThreePrivate>(
-                StorableType::PresignRoundThreePrivate,
+            .retrieve::<StorageType, RoundThreePrivate>(
+                StorageType::RoundThreePrivate,
                 message.id(),
                 self.id,
             )
@@ -662,7 +668,7 @@ impl PresignParticipant {
         if has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundThreePublic,
+            StorageType::RoundThreePublic,
             message.id(),
         )? {
             presign_record_option = Some(self.do_presign_finish(message)?);
@@ -683,11 +689,9 @@ impl PresignParticipant {
         let r3_pubs = self.get_other_participants_round_three_publics(message.id())?;
 
         // Get this participant's round 3 private value
-        let r3_private: RoundThreePrivate = self.storage.retrieve(
-            StorableType::PresignRoundThreePrivate,
-            message.id(),
-            self.id,
-        )?;
+        let r3_private: RoundThreePrivate =
+            self.storage
+                .retrieve(StorageType::RoundThreePrivate, message.id(), self.id)?;
 
         // Check consistency across all Gamma values
         for r3_pub in r3_pubs.iter() {
@@ -733,17 +737,15 @@ impl PresignParticipant {
             message.from(),
         )?;
         let sender_keyshare_public = main_storage.retrieve(
-            StorableType::PublicKeyshare,
+            MainStorageType::PublicKeyshare,
             keyshare_identifier,
             message.from(),
         )?;
-        let receiver_r1_private = self.storage.retrieve(
-            StorableType::PresignRoundOnePrivate,
-            message.id(),
-            message.to(),
-        )?;
+        let receiver_r1_private =
+            self.storage
+                .retrieve(StorageType::RoundOnePrivate, message.id(), message.to())?;
         let sender_r1_public_broadcast = self.storage.retrieve(
-            StorableType::PresignRoundOnePublicBroadcast,
+            StorageType::RoundOnePublicBroadcast,
             message.id(),
             message.from(),
         )?;
@@ -758,7 +760,7 @@ impl PresignParticipant {
         )?;
 
         self.storage.store(
-            StorableType::PresignRoundTwoPublic,
+            StorageType::RoundTwoPublic,
             message.id(),
             message.from(),
             &round_two_public,
@@ -782,7 +784,7 @@ impl PresignParticipant {
             message.from(),
         )?;
         let sender_r1_public_broadcast = self.storage.retrieve(
-            StorableType::PresignRoundOnePublicBroadcast,
+            StorageType::RoundOnePublicBroadcast,
             message.id(),
             message.from(),
         )?;
@@ -795,7 +797,7 @@ impl PresignParticipant {
         )?;
 
         self.storage.store(
-            StorableType::PresignRoundThreePublic,
+            StorageType::RoundThreePublic,
             message.id(),
             message.from(),
             &public_message,
@@ -827,12 +829,12 @@ impl PresignParticipant {
         )? || !has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundTwoPrivate,
+            StorageType::RoundTwoPrivate,
             identifier,
         )? || !has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundTwoPublic,
+            StorageType::RoundTwoPublic,
             identifier,
         )? {
             return Err(InternalError::StorageItemNotFound);
@@ -846,12 +848,12 @@ impl PresignParticipant {
                 other_participant_id,
             )?;
             let r2_private: round_two::Private = self.storage.retrieve(
-                StorableType::PresignRoundTwoPrivate,
+                StorageType::RoundTwoPrivate,
                 identifier,
                 other_participant_id,
             )?;
             let r2_public: round_two::Public = self.storage.retrieve(
-                StorableType::PresignRoundTwoPublic,
+                StorageType::RoundTwoPublic,
                 identifier,
                 other_participant_id,
             )?;
@@ -878,7 +880,7 @@ impl PresignParticipant {
         if !has_collected_all_of_others(
             &self.other_participant_ids,
             &self.storage,
-            StorableType::PresignRoundThreePublic,
+            StorageType::RoundThreePublic,
             identifier,
         )? {
             return Err(InternalError::StorageItemNotFound);
@@ -888,7 +890,7 @@ impl PresignParticipant {
             .iter()
             .map(|other_participant_id| {
                 let r3pub = self.storage.retrieve(
-                    StorableType::PresignRoundThreePublic,
+                    StorageType::RoundThreePublic,
                     identifier,
                     *other_participant_id,
                 )?;
@@ -918,12 +920,12 @@ pub(crate) fn get_keyshare(
             self_id,
         )?,
         keyshare_private: storage.retrieve(
-            StorableType::PrivateKeyshare,
+            MainStorageType::PrivateKeyshare,
             keyshare_identifier,
             self_id,
         )?,
         keyshare_public: storage.retrieve(
-            StorableType::PublicKeyshare,
+            MainStorageType::PublicKeyshare,
             keyshare_identifier,
             self_id,
         )?,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -31,7 +31,7 @@ use crate::{
         round_two::{Private as RoundTwoPrivate, Public as RoundTwoPublic},
     },
     protocol::ParticipantIdentifier,
-    storage::{MainStorageType, Storable, Storage},
+    storage::{PersistentStorageType, Storable, Storage},
     utils::{
         bn_to_scalar, get_other_participants_public_auxinfo, has_collected_all_of_others,
         k256_order, process_ready_message, random_plusminus_by_size, random_positive_bn,
@@ -737,7 +737,7 @@ impl PresignParticipant {
             message.from(),
         )?;
         let sender_keyshare_public = main_storage.retrieve(
-            MainStorageType::PublicKeyshare,
+            PersistentStorageType::PublicKeyshare,
             keyshare_identifier,
             message.from(),
         )?;
@@ -920,12 +920,12 @@ pub(crate) fn get_keyshare(
             self_id,
         )?,
         keyshare_private: storage.retrieve(
-            MainStorageType::PrivateKeyshare,
+            PersistentStorageType::PrivateKeyshare,
             keyshare_identifier,
             self_id,
         )?,
         keyshare_public: storage.retrieve(
-            MainStorageType::PublicKeyshare,
+            PersistentStorageType::PublicKeyshare,
             keyshare_identifier,
             self_id,
         )?,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -18,7 +18,7 @@ use crate::{
         participant::{PresignParticipant, StorageType as PresignStorageType},
         record::PresignRecord,
     },
-    storage::{MainStorageType, Storage},
+    storage::{PersistentStorageType, Storage},
     utils::CurvePoint,
     Message,
 };
@@ -224,13 +224,21 @@ impl Participant {
         let mut fetch = vec![];
         for participant in self.other_participant_ids.clone() {
             fetch.push((
-                MainStorageType::PublicKeyshare,
+                PersistentStorageType::PublicKeyshare,
                 keygen_identifier,
                 participant,
             ));
         }
-        fetch.push((MainStorageType::PublicKeyshare, keygen_identifier, self.id));
-        fetch.push((MainStorageType::PrivateKeyshare, keygen_identifier, self.id));
+        fetch.push((
+            PersistentStorageType::PublicKeyshare,
+            keygen_identifier,
+            self.id,
+        ));
+        fetch.push((
+            PersistentStorageType::PrivateKeyshare,
+            keygen_identifier,
+            self.id,
+        ));
 
         self.main_storage.contains_batch(&fetch)
     }
@@ -251,9 +259,11 @@ impl Participant {
     #[instrument(skip_all, err(Debug))]
     pub fn get_public_keyshare(&self, identifier: Identifier) -> Result<CurvePoint> {
         info!("Retrieving our associated public keyshare.");
-        let keyshare_public: KeySharePublic =
-            self.main_storage
-                .retrieve(MainStorageType::PublicKeyshare, identifier, self.id)?;
+        let keyshare_public: KeySharePublic = self.main_storage.retrieve(
+            PersistentStorageType::PublicKeyshare,
+            identifier,
+            self.id,
+        )?;
         Ok(keyshare_public.X)
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -14,8 +14,10 @@ use crate::{
     keygen::{keyshare::KeySharePublic, participant::KeygenParticipant},
     messages::{AuxinfoMessageType, KeygenMessageType, MessageType},
     participant::ProtocolParticipant,
-    presign::participant::StorageType as PresignStorageType,
-    presign::{participant::PresignParticipant, record::PresignRecord},
+    presign::{
+        participant::{PresignParticipant, StorageType as PresignStorageType},
+        record::PresignRecord,
+    },
     storage::{MainStorageType, Storage},
     utils::CurvePoint,
     Message,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,24 +19,15 @@ use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(tag = "Main")]
-pub(crate) enum StorableType {
+pub(crate) enum MainStorageType {
     PrivateKeyshare,
     PublicKeyshare,
-    PresignReady,
-    PresignRoundOnePrivate,
-    PresignRoundOnePublic,
-    PresignRoundOnePublicBroadcast,
-    PresignRoundTwoPrivate,
-    PresignRoundTwoPublic,
-    PresignRoundThreePrivate,
-    PresignRoundThreePublic,
-    PresignRecord,
     MessageQueue,
     ProgressStore,
     BroadcastSet,
 }
 
-impl Storable for StorableType {}
+impl Storable for MainStorageType {}
 
 /// A message that can be posted to (and read from) the broadcast channel
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, fmt::Debug};
 
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(tag = "Main")]
-pub(crate) enum MainStorageType {
+pub(crate) enum PersistentStorageType {
     PrivateKeyshare,
     PublicKeyshare,
     MessageQueue,
@@ -27,7 +27,7 @@ pub(crate) enum MainStorageType {
     BroadcastSet,
 }
 
-impl Storable for MainStorageType {}
+impl Storable for PersistentStorageType {}
 
 /// A message that can be posted to (and read from) the broadcast channel
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Closes #190.

This commit also renames `StorableType` to `MainStorageType` to make it's purpose more clear.