### PR TITLE
Change `BroadcastParticipant` to use local `StorageType`

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,13 +18,12 @@ use std::{collections::HashMap, fmt::Debug};
 /////////////////////////
 
 #[derive(Clone, Copy, Debug, Serialize)]
-#[serde(tag = "Main")]
+#[serde(tag = "Persistent")]
 pub(crate) enum PersistentStorageType {
     PrivateKeyshare,
     PublicKeyshare,
     MessageQueue,
     ProgressStore,
-    BroadcastSet,
 }
 
 impl Storable for PersistentStorageType {}


### PR DESCRIPTION
Closes #200 

This PR also (1) renames the storage type from the generic `Set` to the more descriptive `Votes`, and fixes the tag on `PersistentStorageType`.