### PR TITLE
Fix keygen output

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -115,7 +115,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
 
                 // This is kind of a bastardization of the outcome type, but this is basically a
                 // conversion from the broadcast outcome type (with a
-                // BroadcastOutput) to the aux-info outcome type (with a ()).
+                // BroadcastOutput) to the aux-info outcome type.
                 let broadcast_outcome = ProcessOutcome::from(None, messages);
 
                 match broadcast_option {

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -6,7 +6,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use crate::utils::CurvePoint;
+use crate::{utils::CurvePoint, ParticipantIdentifier};
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 
@@ -17,7 +17,24 @@ pub(crate) struct KeySharePrivate {
 }
 
 /// A CurvePoint representing a given Participant's public key
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct KeySharePublic {
+    participant: ParticipantIdentifier,
     pub(crate) X: CurvePoint,
+}
+
+impl KeySharePublic {
+    pub(crate) fn new(participant: ParticipantIdentifier, share: CurvePoint) -> Self {
+        Self {
+            participant,
+            X: share,
+        }
+    }
+
+    /// Get the ID of the participant who claims to hold the private share
+    /// corresponding to this public key share.
+    #[cfg(test)]
+    pub(crate) fn participant(&self) -> ParticipantIdentifier {
+        self.participant
+    }
 }


### PR DESCRIPTION
Closes #194 

This updates all the key generation message handlers to return `ProcessOutcome`s instead of lists of messages, and updates the tests to validate the returned outcomes.

I also made #207 with suggested code quality improvements :angel: