### PR TITLE
Add more documentation to clarify the role of identifiers.

### DIFF
--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -34,6 +34,7 @@ impl AuxInfoCommit {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+///`sid` corresponds to a unique session identifier.
 pub(crate) struct AuxInfoDecommit {
     sid: Identifier,
     sender: ParticipantIdentifier,
@@ -57,6 +58,7 @@ impl Debug for AuxInfoDecommit {
 }
 
 impl AuxInfoDecommit {
+    ///`sid` corresponds to a unique session identifier.
     pub(crate) fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         sid: &Identifier,
@@ -141,6 +143,7 @@ impl AuxInfoDecommit {
 
     /// Verify that this [`AuxInfoDecommit`] corresponds to the given
     /// [`AuxInfoCommit`].
+    /// `sid` is a unique session identifier.
     #[instrument(skip_all, err(Debug))]
     pub(crate) fn verify(
         &self,

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -69,6 +69,7 @@ impl AuxInfoProof {
         Ok(Self { pimod, pifac })
     }
 
+    ///`sid` corresponds to a unique session identifier.
     pub(crate) fn verify(
         &self,
         sid: Identifier,

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -35,6 +35,7 @@ impl KeygenCommit {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct KeygenDecommit {
+    ///`sid` corresponds to a unique session identifier.
     pub sid: Identifier,
     pub sender: ParticipantIdentifier,
     pub rid: [u8; 32],
@@ -44,6 +45,7 @@ pub(crate) struct KeygenDecommit {
 }
 
 impl KeygenDecommit {
+    ///`sid` corresponds to a unique session identifier.
     pub(crate) fn new<R: RngCore + CryptoRng>(
         rng: &mut R,
         sid: &Identifier,
@@ -86,6 +88,7 @@ impl KeygenDecommit {
     }
 
     #[instrument(skip_all, err(Debug))]
+    /// `sid` is a unique session identifier.
     pub(crate) fn verify(
         &self,
         sid: &Identifier,

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -64,7 +64,7 @@ mod storage {
 
 #[derive(Debug)]
 pub(crate) struct KeygenParticipant {
-    /// A unique identifier for this participant
+    /// A unique identifier for this participant.
     id: ParticipantIdentifier,
     /// A list of all other participant identifiers participating in the
     /// protocol

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -51,6 +51,8 @@ pub(crate) struct LocalStorage {
 impl LocalStorage {
     /// Stores `value` via a [`TypeTag`], [`Identifier`], and
     /// [`ParticipantIdentifier`] tuple.
+    ///
+    /// `id` correspond to unique session identifier.
     pub(crate) fn store<T: TypeTag>(
         &mut self,
         id: Identifier,
@@ -64,6 +66,8 @@ impl LocalStorage {
 
     /// Retrieves a reference to a value via its [`TypeTag`], [`Identifier`],
     /// and [`ParticipantIdentifier`].
+    ///
+    /// `id` correspond to unique session identifier.
     pub(crate) fn retrieve<T: TypeTag>(
         &self,
         id: Identifier,
@@ -80,6 +84,8 @@ impl LocalStorage {
 
     /// Retrieves a mutable reference to a value via its [`TypeTag`],
     /// [`Identifier`], and [`ParticipantIdentifier`].
+    ///
+    /// `id` correspond to unique session identifier.
     pub(crate) fn retrieve_mut<T: TypeTag>(
         &mut self,
         id: Identifier,
@@ -116,6 +122,8 @@ impl LocalStorage {
     /// Checks whether values exist for the given [`TypeTag`], [`Identifier`],
     /// and each of the `participant_ids` provided, returning `true` if so
     /// and `false` otherwise.
+    ///
+    ///`id` corresponds to a unique session identifier.
     pub(crate) fn contains_for_all_ids<T: TypeTag>(
         &self,
         id: Identifier,
@@ -131,6 +139,8 @@ impl LocalStorage {
 
     /// Returns `true` if a value exists for the given [`TypeTag`],
     /// [`Identifier`], and [`ParticipantIdentifier`].
+    ///
+    /// `id` corresponds to a unique session identifier.
     pub(crate) fn contains<T: TypeTag>(
         &self,
         id: Identifier,

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap, fmt::Debug};
 #[derive(Debug, Serialize, Deserialize)]
 struct MessageIndex {
     message_type: MessageType,
+    /// `identifier` corresponds to a unique session identifier.
     identifier: Identifier,
 }
 
@@ -36,6 +37,8 @@ impl MessageQueue {
     }
 
     /// Store a message in the MessageQueue.
+    ///
+    /// `identifier` corresponds to a unique session identifier.
     pub(crate) fn store(
         &mut self,
         message_type: MessageType,
@@ -49,6 +52,8 @@ impl MessageQueue {
 
     /// Retrieve (and remove) all messages of a given type from the
     /// MessageQueue.
+    ///
+    /// `identifier` corresponds to a unique session identifier.
     pub(crate) fn retrieve_all(
         &mut self,
         message_type: MessageType,
@@ -59,6 +64,8 @@ impl MessageQueue {
 
     /// Retrieve (and remove) all messages of a given type from a given sender
     /// from the MessageQueue.
+    ///
+    ///`identifier` corresponds to a unique session identifier.
     pub(crate) fn retrieve(
         &mut self,
         message_type: MessageType,
@@ -67,7 +74,7 @@ impl MessageQueue {
     ) -> Result<Vec<Message>> {
         self.do_retrieve(message_type, identifier, Some(sender))
     }
-
+    ///`identifier` corresponds to a unique session identifier.
     fn do_retrieve(
         &mut self,
         message_type: MessageType,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -92,11 +92,11 @@ pub enum BroadcastMessageType {
 pub struct Message {
     /// The type of the message
     pub(crate) message_type: MessageType,
-    /// The unique identifier corresponding to the object carried by the message
+    /// The globally unique session identifier that this message belongs to.
     identifier: Identifier,
-    /// Which participant this message is coming from
+    /// Which participant this message is coming from.
     from: ParticipantIdentifier,
-    /// Which participant this message is addressed to
+    /// Which participant this message is addressed to.
     to: ParticipantIdentifier,
     /// The raw bytes for the message, which need to be verified.
     /// This should be a private member of the struct, so that
@@ -110,7 +110,7 @@ impl Debug for Message {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Message")
             .field("message_type", &self.message_type)
-            .field("identifier", &self.identifier)
+            .field("session identifier", &self.identifier)
             .field("from", &self.from)
             .field("to", &self.to)
             .finish()
@@ -142,7 +142,7 @@ impl Message {
         self.message_type
     }
 
-    /// The identifier associated with the message
+    /// The session identifier associated with the message.
     pub fn id(&self) -> Identifier {
         self.identifier
     }

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -222,7 +222,7 @@ pub(crate) trait ProtocolParticipant {
         message_storage.store(message.message_type(), message.id(), message.clone())?;
         Ok(())
     }
-
+    ///`sid` corresponds to a unique session identifier.
     fn fetch_messages(
         &mut self,
         message_type: MessageType,
@@ -232,7 +232,7 @@ pub(crate) trait ProtocolParticipant {
         let messages = message_storage.retrieve_all(message_type, sid)?;
         Ok(messages)
     }
-
+    ///`sid` corresponds to a unique session identifier.
     fn fetch_messages_by_sender(
         &mut self,
         message_type: MessageType,
@@ -243,7 +243,7 @@ pub(crate) trait ProtocolParticipant {
         let messages = message_storage.retrieve(message_type, sid, sender)?;
         Ok(messages)
     }
-
+    ///`sid` corresponds to a unique session identifier.
     fn write_progress(&mut self, func_name: String, sid: Identifier) -> Result<()> {
         let key = serialize!(&ProgressIndex { func_name, sid })?;
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>(sid)?;
@@ -264,7 +264,7 @@ pub(crate) trait ProtocolParticipant {
 
 pub(crate) trait Broadcast {
     fn broadcast_participant(&mut self) -> &mut BroadcastParticipant;
-
+    ///`sid` corresponds to a unique session identifier.
     fn broadcast<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -201,7 +201,8 @@ impl PresignParticipant {
             Ok(ready_outcome)
         }
     }
-
+    /// `auxinfo_identifier`, `keyshare_identifier` and `identifier` correspond
+    /// to unique session identifiers.
     #[instrument(skip_all, err(Debug))]
     pub(crate) fn initialize_presign_message(
         &mut self,
@@ -701,6 +702,8 @@ impl PresignParticipant {
         Ok(presign_record)
     }
 
+    ///`presign_identifier` corresponds to a unique session identifier for
+    /// presigning.
     fn get_associated_identifiers_for_presign(
         &self,
         presign_identifier: &Identifier,
@@ -712,7 +715,8 @@ impl PresignParticipant {
 
         Ok((*id1, *id2))
     }
-
+    /// `auxinfo_identifier` and `keyshare_identifier` correspond to unique
+    /// session identifiers.
     #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn validate_and_store_round_two_public(
         &mut self,
@@ -760,7 +764,7 @@ impl PresignParticipant {
 
         Ok(())
     }
-
+    /// `auxinfo_identifier` corresponds to a unique session identifier.
     #[cfg_attr(feature = "flame_it", flame("presign"))]
     fn validate_and_store_round_three_public(
         &mut self,
@@ -806,6 +810,8 @@ impl PresignParticipant {
     ///
     /// This returns a HashMap with the key as the participant id and these
     /// values being mapped
+    /// `auxinfo_identifier` and `identifier` correspond to unique session
+    /// identifiers.
     fn get_other_participants_round_three_values(
         &self,
         identifier: Identifier,
@@ -861,7 +867,8 @@ impl PresignParticipant {
     /// Aggregate the other participants' round three public values from
     /// storage. But don't remove them from storage.
     ///
-    /// This returns a Vec with the values
+    /// This returns a Vec with the values.
+    /// `identifier` here correspond to a unique session identifier.
     fn get_other_participants_round_three_publics(
         &self,
         identifier: Identifier,
@@ -889,6 +896,8 @@ impl PresignParticipant {
     }
 }
 
+/// `auxinfo_identifier` and `keyshare_identifier` correspond to unique session
+/// identifiers.
 pub(crate) fn get_keyshare(
     self_id: ParticipantIdentifier,
     auxinfo_identifier: Identifier,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -33,9 +33,9 @@ impl Storable for PersistentStorageType {}
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 struct StorableIndex<T: Storable> {
     storable_type: T,
-    /// The unique identifier associated with this stored value
+    /// Identifier for the session that the stored value belongs to.
     identifier: Identifier,
-    // The participant identifier that this storable is associated with
+    // The participant identifier that this storable is associated with.
     participant: ParticipantIdentifier,
 }
 
@@ -55,6 +55,7 @@ impl Storage {
 
     /// Stores `val` in its serialied form, using `storable_type`, `identifier`,
     /// and `associated_partipant_id` as the key.
+    /// The `identifier` here corresponds to a unique session identifier.
     pub(crate) fn store<T: Storable, S: Serialize>(
         &mut self,
         storable_type: T,
@@ -72,6 +73,7 @@ impl Storage {
 
     /// Retrieves an item in its deserialized form, using `storable_type`,
     /// `identifier`, and `associated_partipant_id` as the key.
+    /// The `identifier` here corresponds to a unique session identifier.
     pub(crate) fn retrieve<T: Storable, D: DeserializeOwned>(
         &self,
         storable_type: T,
@@ -84,7 +86,7 @@ impl Storage {
             participant,
         })?)
     }
-
+    /// The `identifier` here corresponds to a unique session identifier.
     pub(crate) fn delete<T: Storable>(
         &mut self,
         storable_type: T,
@@ -139,6 +141,8 @@ impl Storage {
             .iter()
             .map(|(t, identifier, participant)| StorableIndex {
                 storable_type: *t,
+                /// The `identifier` here corresponds to a unique
+                /// session identifier.
                 identifier: *identifier,
                 participant: *participant,
             })


### PR DESCRIPTION
Addresses #162 : 

This change adds documentation for the `Identifier` struct and specifies its different uses and properties. 
It also clarifies that `identifier`s refers to session/sub-session identifiers rather than unique id for specific message values. 