### PR TITLE
Remove most uses  of `main_storage` from `auxinfo` and `keygen`

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -715,7 +715,8 @@ mod tests {
         let outputs: Vec<_> = outputs.into_iter().flatten().collect();
         assert!(outputs.len() == QUORUM_SIZE);
 
-        // 1. Check returned outputs
+        // Check returned outputs
+        //
         // Every participant should have a public output from every other participant
         // and, for a given participant, they should be the same in every output
         for party in &quorum {
@@ -744,42 +745,6 @@ mod tests {
                 .find(|public_key| *public_key.participant() == pid);
             assert!(public_key.is_some());
             assert_eq!(*public_key.unwrap().pk(), private.encryption_key());
-        }
-
-        // 2. Do the same checks on stored outputs
-
-        // Check that all players have a PublicKeyshare stored for every player and that
-        // these values all match
-        for player in &quorum {
-            let player_id = player.id;
-            let mut stored_values = vec![];
-            // Check all outputs for `AuxInfoPublic` public keys that match
-            // the given player's ID.
-            for output in outputs.iter() {
-                for aux_info_public in output.0.iter() {
-                    if *aux_info_public.participant() == player_id {
-                        stored_values.push(aux_info_public.pk());
-                    }
-                }
-            }
-            // Make sure that all the stored values are equal.
-            let base = stored_values.pop();
-            while !stored_values.is_empty() {
-                assert!(base == stored_values.pop());
-            }
-        }
-
-        // Check that each player's own AuxInfoPublic corresponds to their
-        // AuxInfoPrivate
-        for index in 0..quorum.len() {
-            let player = quorum.get(index).unwrap();
-            let player_id = player.id;
-            let (pks, sk) = outputs.get(index).unwrap();
-            let pk = pks
-                .iter()
-                .find(|item| *item.participant() == player_id)
-                .unwrap();
-            assert_eq!(sk.encryption_key(), pk.pk().clone());
         }
 
         Ok(())

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -498,6 +498,8 @@ impl KeygenParticipant {
 
         // If so, we completed the protocol! Return the outputs.
         if keyshare_done {
+            // TODO #180: This is still needed as some protocols rely on
+            // checking that this info is available in main storage.
             for pid in self.all_participants().iter() {
                 self.local_storage.transfer::<storage::PublicKeyshare>(
                     main_storage,
@@ -517,18 +519,19 @@ impl KeygenParticipant {
                 .all_participants()
                 .iter()
                 .map(|pid| {
-                    main_storage.retrieve(PersistentStorageType::PublicKeyshare, message.id(), *pid)
+                    let value = self
+                        .local_storage
+                        .retrieve::<storage::PublicKeyshare>(message.id(), *pid)?;
+                    Ok(value.clone())
                 })
                 .collect::<Result<Vec<_>>>()?;
-            let private_key_share = main_storage.retrieve(
-                PersistentStorageType::PrivateKeyshare,
-                message.id(),
-                self.id,
-            )?;
+            let private_key_share = self
+                .local_storage
+                .retrieve::<storage::PrivateKeyshare>(message.id(), self.id)?;
 
             Ok(ProcessOutcome::Terminated((
                 public_key_shares,
-                private_key_share,
+                private_key_share.clone(),
             )))
         } else {
             // Otherwise, we'll have to wait for more round three messages.
@@ -762,14 +765,16 @@ mod tests {
         for player in quorum.iter() {
             let player_id = player.id;
             let mut stored_values = vec![];
-            for main_storage in main_storages.iter() {
-                let pk: KeySharePublic = main_storage.retrieve(
-                    PersistentStorageType::PublicKeyshare,
-                    keyshare_identifier,
-                    player_id,
-                )?;
-                stored_values.push(serialize!(&pk)?);
+            // Check all outputs for `PublicKeyshare` public keys that match
+            // the given player's ID.
+            for output in outputs.iter() {
+                for public_keyshare in output.0.iter() {
+                    if public_keyshare.participant() == player_id {
+                        stored_values.push(public_keyshare.X);
+                    }
+                }
             }
+            // Make sure that all the stored values are equal.
             let base = stored_values.pop();
             while !stored_values.is_empty() {
                 assert!(base == stored_values.pop());
@@ -781,20 +786,14 @@ mod tests {
         for index in 0..quorum.len() {
             let player = quorum.get(index).unwrap();
             let player_id = player.id;
-            let main_storage = main_storages.get(index).unwrap();
-            let pk: KeySharePublic = main_storage.retrieve(
-                PersistentStorageType::PublicKeyshare,
-                keyshare_identifier,
-                player_id,
-            )?;
-            let sk: KeySharePrivate = main_storage.retrieve(
-                PersistentStorageType::PrivateKeyshare,
-                keyshare_identifier,
-                player_id,
-            )?;
+            let (pks, sk) = outputs.get(index).unwrap();
+            let pk = pks
+                .iter()
+                .find(|item| item.participant() == player_id)
+                .unwrap();
             let g = CurvePoint::GENERATOR;
             let X = CurvePoint(g.0 * crate::utils::bn_to_scalar(&sk.x)?);
-            assert!(X == pk.X);
+            assert_eq!(X, pk.X);
         }
 
         Ok(())

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -724,7 +724,8 @@ mod tests {
         let outputs: Vec<_> = outputs.into_iter().flatten().collect();
         assert!(outputs.len() == QUORUM_SIZE);
 
-        // 1. Check returned outputs
+        // Check returned outputs
+        //
         // Every participant should have a public output from every other participant
         // and, for a given participant, they should be the same in every output
         for party in &quorum {
@@ -757,43 +758,6 @@ mod tests {
             let expected_public_share =
                 CurvePoint(CurvePoint::GENERATOR.0 * crate::utils::bn_to_scalar(&private.x)?);
             assert_eq!(public_share.unwrap().X, expected_public_share);
-        }
-
-        // 2. Check saved outputs
-        // check that all players have a PublicKeyshare stored for every player and that
-        // these values all match
-        for player in quorum.iter() {
-            let player_id = player.id;
-            let mut stored_values = vec![];
-            // Check all outputs for `PublicKeyshare` public keys that match
-            // the given player's ID.
-            for output in outputs.iter() {
-                for public_keyshare in output.0.iter() {
-                    if public_keyshare.participant() == player_id {
-                        stored_values.push(public_keyshare.X);
-                    }
-                }
-            }
-            // Make sure that all the stored values are equal.
-            let base = stored_values.pop();
-            while !stored_values.is_empty() {
-                assert!(base == stored_values.pop());
-            }
-        }
-
-        // check that each player's own PublicKeyshare corresponds to their
-        // PrivateKeyshare
-        for index in 0..quorum.len() {
-            let player = quorum.get(index).unwrap();
-            let player_id = player.id;
-            let (pks, sk) = outputs.get(index).unwrap();
-            let pk = pks
-                .iter()
-                .find(|item| item.participant() == player_id)
-                .unwrap();
-            let g = CurvePoint::GENERATOR;
-            let X = CurvePoint(g.0 * crate::utils::bn_to_scalar(&sk.x)?);
-            assert_eq!(X, pk.X);
         }
 
         Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -206,18 +206,13 @@ impl Participant {
     #[instrument(skip_all)]
     pub fn is_auxinfo_done(&self, auxinfo_identifier: Identifier) -> Result<bool> {
         let mut fetch = vec![];
-        for participant in self.other_participant_ids.clone() {
+        for participant in self.auxinfo_participant.all_participants() {
             fetch.push((
                 PersistentStorageType::AuxInfoPublic,
                 auxinfo_identifier,
                 participant,
             ));
         }
-        fetch.push((
-            PersistentStorageType::AuxInfoPublic,
-            auxinfo_identifier,
-            self.id,
-        ));
         fetch.push((
             PersistentStorageType::AuxInfoPrivate,
             auxinfo_identifier,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -98,8 +98,9 @@ impl Storage {
         })
     }
 
-    /// Returns `true` if the storage contains entries associated with a given `storage_type`,
-    /// [`Identifier`], and list of [`ParticipantIdentifier`]s.
+    /// Returns `true` if the storage contains entries associated with a given
+    /// `storage_type`, [`Identifier`], and list of
+    /// [`ParticipantIdentifier`]s.
     pub(crate) fn contains_for_all_ids<T: Storable>(
         &self,
         storage_type: T,
@@ -113,8 +114,8 @@ impl Storage {
         self.contains_batch(&fetch)
     }
 
-    /// Retrieves all items associated with a given `storage_type`, [`Identifier`], and list of
-    /// [`ParticipantIdentifier`]s.
+    /// Retrieves all items associated with a given `storage_type`,
+    /// [`Identifier`], and list of [`ParticipantIdentifier`]s.
     pub(crate) fn retrieve_for_all_ids<T: Storable, D: DeserializeOwned>(
         &self,
         storage_type: T,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -125,12 +125,10 @@ impl Storage {
         if !self.contains_for_all_ids(storage_type, identifier, participants)? {
             return Err(InternalError::StorageItemNotFound);
         }
-        let mut result = vec![];
-        for pid in participants {
-            let item = self.retrieve(PersistentStorageType::AuxInfoPublic, identifier, *pid)?;
-            result.push(item);
-        }
-        Ok(result)
+        participants
+            .iter()
+            .map(|pid| self.retrieve(PersistentStorageType::AuxInfoPublic, identifier, *pid))
+            .collect::<Result<Vec<_>>>()
     }
 
     pub(crate) fn contains_batch<T: Storable>(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -98,6 +98,40 @@ impl Storage {
         })
     }
 
+    /// Returns `true` if the storage contains entries associated with a given `storage_type`,
+    /// [`Identifier`], and list of [`ParticipantIdentifier`]s.
+    pub(crate) fn contains_for_all_ids<T: Storable>(
+        &self,
+        storage_type: T,
+        identifier: Identifier,
+        participants: &[ParticipantIdentifier],
+    ) -> Result<bool> {
+        let fetch: Vec<(T, Identifier, ParticipantIdentifier)> = participants
+            .iter()
+            .map(|participant| (storage_type, identifier, *participant))
+            .collect();
+        self.contains_batch(&fetch)
+    }
+
+    /// Retrieves all items associated with a given `storage_type`, [`Identifier`], and list of
+    /// [`ParticipantIdentifier`]s.
+    pub(crate) fn retrieve_for_all_ids<T: Storable, D: DeserializeOwned>(
+        &self,
+        storage_type: T,
+        identifier: Identifier,
+        participants: &[ParticipantIdentifier],
+    ) -> Result<Vec<D>> {
+        if !self.contains_for_all_ids(storage_type, identifier, participants)? {
+            return Err(InternalError::StorageItemNotFound);
+        }
+        let mut result = vec![];
+        for pid in participants {
+            let item = self.retrieve(PersistentStorageType::AuxInfoPublic, identifier, *pid)?;
+            result.push(item);
+        }
+        Ok(result)
+    }
+
     pub(crate) fn contains_batch<T: Storable>(
         &self,
         type_and_id: &[(T, Identifier, ParticipantIdentifier)],


### PR DESCRIPTION
Closes #226.

This commit removes the use of `main_storage` almost entirely from `auxinfo` and `keygen`, only using it currently to store values to signal protocol completion for other protocols.

This commit also moves some functionality from `utils.rs` to `Storage`. This'll make it easier to isolate components directly related to persistent storage to be removed in future commits.