### PR TITLE
Remove main storage from `auxinfo` and `keygen`

### DIFF
--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -13,9 +13,7 @@ use crate::{
     messages::{BroadcastMessageType, Message, MessageType},
     participant::{ProcessOutcome, ProtocolParticipant},
     protocol::ParticipantIdentifier,
-    run_only_once_per_tag,
-    storage::Storage,
-    Identifier,
+    run_only_once_per_tag, Identifier,
 };
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -65,6 +63,7 @@ pub(crate) struct BroadcastOutput {
 }
 
 impl ProtocolParticipant for BroadcastParticipant {
+    type Input = ();
     type Output = BroadcastOutput;
 
     fn local_storage(&self) -> &LocalStorage {
@@ -88,7 +87,7 @@ impl ProtocolParticipant for BroadcastParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        _main_storage: &mut Storage,
+        _: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing broadcast message.");
 

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -33,7 +33,6 @@ impl KeySharePublic {
 
     /// Get the ID of the participant who claims to hold the private share
     /// corresponding to this public key share.
-    #[cfg(test)]
     pub(crate) fn participant(&self) -> ParticipantIdentifier {
         self.participant
     }

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -13,7 +13,6 @@
 
 use crate::{
     errors::{InternalError, Result},
-    storage::{PersistentStorageType, Storage},
     Identifier, ParticipantIdentifier,
 };
 use std::{
@@ -38,7 +37,7 @@ pub(crate) mod storage {
 
     pub(crate) struct ProgressStore;
     impl TypeTag for ProgressStore {
-        type Value = HashMap<Vec<u8>, bool>;
+        type Value = HashMap<crate::participant::ProgressIndex, bool>;
     }
 }
 
@@ -98,25 +97,6 @@ impl LocalStorage {
                     .ok_or(InternalError::InternalInvariantFailed)
             })
             .unwrap_or(Err(InternalError::StorageItemNotFound))
-    }
-
-    /// Transfers an item associated with the given [`TypeTag`] in local storage
-    /// to `main_storage`, using the [`PersistentStorageType`],
-    /// [`Identifier`] and [`ParticipantIdentifier`] tuple as the persistent
-    /// storage key.
-    pub(crate) fn transfer<T: TypeTag>(
-        &self,
-        main_storage: &mut Storage,
-        storage_type: PersistentStorageType,
-        id: Identifier,
-        participant_id: ParticipantIdentifier,
-    ) -> Result<()>
-    where
-        T::Value: serde::Serialize,
-    {
-        let item = self.retrieve::<T>(id, participant_id)?;
-        main_storage.store(storage_type, id, participant_id, item)?;
-        Ok(())
     }
 
     /// Checks whether values exist for the given [`TypeTag`], [`Identifier`],


### PR DESCRIPTION
Closes #229.

We still need main storage in `presign`, but now we store into main storage in `Participant::process_single_message` rather than in each individual sub-protocol.

This PR also removes some unnecessarily serialization in `ProgressStore`. Apologies for the bonus code cleanup in this PR, but it's pretty small :-).