### PR TITLE
Return output from `process_single_message`

### DIFF
--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -65,7 +65,7 @@ fn process_messages<R: RngCore + CryptoRng>(
     // This is done to simulate arbitrary message arrival ordering
     let index = rng.gen_range(0..inbox.len());
     let message = inbox.remove(index);
-    let messages = participant.process_single_message(&message, rng)?;
+    let (_sid, _output, messages) = participant.process_single_message(&message, rng)?;
     deliver_all(&messages, inboxes)?;
 
     Ok(())

--- a/examples/network/server.rs
+++ b/examples/network/server.rs
@@ -83,7 +83,7 @@ pub(crate) async fn process(state: &State<ParticipantState>, message_bytes: Vec<
         .ok_or_else(|| anyhow!("Config not set"))?;
 
     let mut rng = OsRng;
-    let messages = participant.process_single_message(&message, &mut rng)?;
+    let (_sid, _output, messages) = participant.process_single_message(&message, &mut rng)?;
 
     // Deliver messages to other participants
     let client = reqwest::Client::new();

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -24,17 +24,17 @@ use tracing::{error, instrument};
 /// TODO #169: Let's be more careful about allowing `Clone`, `Serialize`, etc.
 /// here due to this being sensitive data.
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
-pub(crate) struct AuxInfoPrivate {
+pub struct AuxInfoPrivate {
     decryption_key: DecryptionKey,
 }
 
 impl AuxInfoPrivate {
     #[cfg(test)]
-    pub fn encryption_key(&self) -> EncryptionKey {
+    pub(crate) fn encryption_key(&self) -> EncryptionKey {
         self.decryption_key.encryption_key()
     }
 
-    pub fn decryption_key(&self) -> &DecryptionKey {
+    pub(crate) fn decryption_key(&self) -> &DecryptionKey {
         &self.decryption_key
     }
 }
@@ -55,7 +55,7 @@ impl Debug for AuxInfoPrivate {
 
 /// The public Auxilary Information corresponding to a given Participant.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub(crate) struct AuxInfoPublic {
+pub struct AuxInfoPublic {
     participant: ParticipantIdentifier,
     pk: EncryptionKey,
     params: VerifiedRingPedersen,

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 
 /// Private key corresponding to a given [KeySharePublic]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct KeySharePrivate {
+pub struct KeySharePrivate {
     pub(crate) x: BigNumber, // in the range [1, q)
 }
 
 /// A CurvePoint representing a given Participant's public key
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(crate) struct KeySharePublic {
+pub struct KeySharePublic {
     participant: ParticipantIdentifier,
     pub(crate) X: CurvePoint,
 }
@@ -33,7 +33,7 @@ impl KeySharePublic {
 
     /// Get the ID of the participant who claims to hold the private share
     /// corresponding to this public key share.
-    pub(crate) fn participant(&self) -> ParticipantIdentifier {
+    pub fn participant(&self) -> ParticipantIdentifier {
         self.participant
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod zkstar;
 
 pub use messages::Message;
 pub use protocol::{
-    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, SignatureShare,
+    Identifier, Output, Participant, ParticipantConfig, ParticipantIdentifier, SignatureShare,
 };
 pub use utils::CurvePoint;
 

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -31,7 +31,7 @@ pub(crate) struct RecordPair {
 
 /// The precomputation used to create a partial signature
 #[derive(Serialize, Deserialize)]
-pub(crate) struct PresignRecord {
+pub struct PresignRecord {
     R: CurvePoint,
     k: BigNumber,
     chi: k256::Scalar,


### PR DESCRIPTION
Closes #203

This updates the output type of external-facing message processing and updates the tests to check that it shows up when we expect it to.

I'm marking as a draft for now because it overlaps a fair amount with #230 and #231 in the `process_single_message` method and I don't want to destroy that merge. However, it's ready for review.

This highlights the need to fix the debug view for `KeySharePrivate` -- maybe this could be done in #207.