### PR TITLE
Move Session IDs into `Participant` structs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,6 +57,8 @@ pub enum InternalError {
         "Tried to start a new protocol instance with an Identifier used in an existing instance"
     )]
     IdentifierInUse,
+    #[error("Message session identifier does not match protocol session identifier")]
+    InvalidSessionIdentifier,
 }
 
 macro_rules! serialize {

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -356,7 +356,7 @@ pub(crate) trait Broadcast {
 
 #[macro_export]
 /// A macro to keep track of which functions have already been run in a given
-/// session Must be a self.function() so that we can access storage
+/// session. Must be a self.function() so that we can access local storage.
 macro_rules! run_only_once {
     ($self:ident . $func_name:ident $args:tt, $sid:expr) => {{
         if $self.read_progress(stringify!($func_name).to_string(), $sid)? {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -164,6 +164,7 @@ impl Broadcast for PresignParticipant {
 
 impl PresignParticipant {
     pub(crate) fn from_ids(
+        sid: Identifier,
         id: ParticipantIdentifier,
         other_participant_ids: Vec<ParticipantIdentifier>,
     ) -> Self {
@@ -172,7 +173,7 @@ impl PresignParticipant {
             other_participant_ids: other_participant_ids.clone(),
             local_storage: Default::default(),
             presign_map: HashMap::new(),
-            broadcast_participant: BroadcastParticipant::from_ids(id, other_participant_ids),
+            broadcast_participant: BroadcastParticipant::from_ids(sid, id, other_participant_ids),
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -608,9 +608,9 @@ mod tests {
             Output::Presign(_) => participant.is_presigning_done(),
             Output::Sign(_) => Ok(true), // this doesn't have a check
             Output::None => {
-                let auxinfo = participant.is_auxinfo_done();
-                let keygen = participant.is_keygen_done();
-                let presign = participant.is_presigning_done();
+                let _auxinfo = participant.is_auxinfo_done();
+                let _keygen = participant.is_keygen_done();
+                let _presign = participant.is_presigning_done();
 
                 // The current behavior of these is weird -- they return Ok even if the `sid`
                 // corresponds to a different protocol. Perhaps the "most

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -594,7 +594,8 @@ mod tests {
         );
         let (sid, output, messages) = participant.process_single_message(&message, rng)?;
         if sid != participant.sid {
-            // The returned Session ID should _always_ be the same as the participant's Session ID.
+            // The returned Session ID should _always_ be the same as the participant's
+            // Session ID.
             return Err(InternalError::InternalInvariantFailed);
         }
         deliver_all(&messages, inboxes)?;


### PR DESCRIPTION
This commit changes the `Participant` struct so that it "owns" its own session ID, towards the goal of making each `Participant` only support a single session ID. Currently, we enforce that the correct session ID is used by checking in `process_message` that the `message.id()` matches the local session ID, error-ing out if not.