### PR TITLE
Add `is_done` method to `ProtocolParticipant` trait

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -684,7 +684,7 @@ mod tests {
         //
         // Every participant should have a public output from every other participant
         // and, for a given participant, they should be the same in every output
-        for party in &quorum {
+        for party in quorum.iter_mut() {
             let pid = party.id;
 
             // Collect the AuxInfoPublic associated with pid from every output
@@ -701,6 +701,16 @@ mod tests {
 
             // Make sure they're all equal
             assert!(publics_for_pid.windows(2).all(|pks| pks[0] == pks[1]));
+
+            // Check that each participant fully completed its broadcast portion.
+            if let crate::broadcast::participant::Status::ParticipantCompletedBroadcast(
+                participants,
+            ) = party.broadcast_participant().status()
+            {
+                assert_eq!(participants.len(), party.other_participant_ids.len());
+            } else {
+                panic!("Broadcast not completed!");
+            }
         }
 
         // Check that private outputs are consistent

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -31,8 +31,9 @@ mod storage {
     }
 }
 
+/// Protocol status for [`BroadcastParticipant`].
 #[derive(Debug, PartialEq)]
-enum Status {
+pub enum Status {
     Initialized,
     TerminatedSuccessfully,
 }
@@ -73,6 +74,7 @@ pub(crate) struct BroadcastOutput {
 impl ProtocolParticipant for BroadcastParticipant {
     type Input = ();
     type Output = BroadcastOutput;
+    type Status = Status;
 
     fn new(id: ParticipantIdentifier, other_participant_ids: Vec<ParticipantIdentifier>) -> Self {
         Self {
@@ -122,8 +124,8 @@ impl ProtocolParticipant for BroadcastParticipant {
         }
     }
 
-    fn is_done(&self) -> bool {
-        self.status == Status::TerminatedSuccessfully
+    fn status(&self) -> &Self::Status {
+        &self.status
     }
 }
 

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -34,8 +34,22 @@ mod storage {
 /// Protocol status for [`BroadcastParticipant`].
 #[derive(Debug, PartialEq)]
 pub enum Status {
+    /// The protocol has been initialized, but no participants have completed a
+    /// broadcast.
     Initialized,
-    TerminatedSuccessfully,
+    /// A vector of participants that have completed a broadcast.
+    ///
+    /// This vector does _not_ correspond to those participants that have
+    /// _initialized_ (and hence successfully completed) a broadcast, but rather
+    /// the participants who, when either sending a message or _forwarding_ a
+    /// message, resulted in the completion of the broadcast. Since all
+    /// participants broadcast messages at the same time, this is used to track
+    /// termination of the protocol by tracking the vector _size_: If the size
+    /// is equal to the number of other participants then the broadcast has
+    /// completed (as this equates to this participant receiving the broadcasts
+    /// of all other participants, regardless of which participant was the one
+    /// who sent the final message "completing" a given broadcast).
+    ParticipantCompletedBroadcast(Vec<ParticipantIdentifier>),
 }
 
 #[derive(Debug)]
@@ -105,13 +119,14 @@ impl ProtocolParticipant for BroadcastParticipant {
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing broadcast message.");
 
-        // XXX Protocols that utilize `BroadcastParticipant` never "reset" the
-        // participant between executions, and hence an already terminated
-        // `BroadcastParticipant` may get called again!
-        //
-        // if self.is_done() {
-        //     return Err(InternalError::ProtocolAlreadyTerminated);
-        // }
+        if let Status::ParticipantCompletedBroadcast(participants) = self.status() {
+            // The protocol has terminated if the number of participants who
+            // have completed a broadcast equals the total number of other
+            // participants.
+            if participants.len() == self.other_participant_ids.len() {
+                return Err(InternalError::ProtocolAlreadyTerminated);
+            }
+        }
 
         match message.message_type() {
             MessageType::Broadcast(BroadcastMessageType::Disperse) => {
@@ -211,7 +226,6 @@ impl BroadcastParticipant {
             message.id(),
             &tag
         )?;
-
         Ok(redisperse_outcome.with_messages(disperse_messages))
     }
 
@@ -263,9 +277,17 @@ impl BroadcastParticipant {
         // output if every node voted for the same message
         for (k, v) in tally.iter() {
             if *v == self.other_participant_ids.len() {
-                let msg = Message::new(data.message_type, sid, data.leader, self.id(), k);
+                let msg = Message::new(data.message_type, sid, data.leader, self.id, k);
                 let out = BroadcastOutput { tag: data.tag, msg };
-                self.status = Status::TerminatedSuccessfully;
+                match &mut self.status {
+                    Status::Initialized => {
+                        self.status = Status::ParticipantCompletedBroadcast(vec![voter]);
+                    }
+                    Status::ParticipantCompletedBroadcast(participants) => {
+                        participants.push(voter);
+                    }
+                }
+
                 return Ok(ProcessOutcome::Terminated(out));
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,6 +59,8 @@ pub enum InternalError {
         "Tried to start a new protocol instance with an Identifier used in an existing instance"
     )]
     IdentifierInUse,
+    #[error("Protocol has already terminated")]
+    ProtocolAlreadyTerminated,
 }
 
 /// Errors that are caused by incorrect behavior by the calling application.

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -690,7 +690,7 @@ mod tests {
         //
         // Every participant should have a public output from every other participant
         // and, for a given participant, they should be the same in every output
-        for party in &quorum {
+        for party in quorum.iter_mut() {
             let pid = party.id;
 
             // Collect the KeySharePublic associated with pid from every output
@@ -707,6 +707,16 @@ mod tests {
 
             // Make sure they're all equal
             assert!(publics_for_pid.windows(2).all(|pks| pks[0] == pks[1]));
+
+            // Check that each participant fully completed its broadcast portion.
+            if let crate::broadcast::participant::Status::ParticipantCompletedBroadcast(
+                participants,
+            ) = party.broadcast_participant().status()
+            {
+                assert_eq!(participants.len(), party.other_participant_ids.len());
+            } else {
+                panic!("Broadcast not completed!");
+            }
         }
 
         // Check that each participant's own `PublicKeyshare` corresponds to their

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -61,6 +61,12 @@ mod storage {
     }
 }
 
+#[derive(Debug, PartialEq)]
+enum Status {
+    Initialized,
+    TerminatedSuccessfully,
+}
+
 /// A participant that runs the key generation protocol.
 #[derive(Debug)]
 pub struct KeygenParticipant {
@@ -73,6 +79,8 @@ pub struct KeygenParticipant {
     local_storage: LocalStorage,
     /// Broadcast subprotocol handler
     broadcast_participant: BroadcastParticipant,
+    /// Status of the protocol execution.
+    status: Status,
 }
 
 impl ProtocolParticipant for KeygenParticipant {
@@ -87,6 +95,7 @@ impl ProtocolParticipant for KeygenParticipant {
             other_participant_ids: other_participant_ids.clone(),
             local_storage: Default::default(),
             broadcast_participant: BroadcastParticipant::new(id, other_participant_ids),
+            status: Status::Initialized,
         }
     }
 
@@ -108,6 +117,10 @@ impl ProtocolParticipant for KeygenParticipant {
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing keygen message.");
 
+        if self.is_done() {
+            return Err(InternalError::ProtocolAlreadyTerminated);
+        }
+
         match message.message_type() {
             MessageType::Keygen(KeygenMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
@@ -125,6 +138,10 @@ impl ProtocolParticipant for KeygenParticipant {
             MessageType::Keygen(_) => Err(InternalError::MessageMustBeBroadcasted)?,
             _ => Err(InternalError::MisroutedMessage)?,
         }
+    }
+
+    fn is_done(&self) -> bool {
+        self.status == Status::TerminatedSuccessfully
     }
 }
 
@@ -487,7 +504,7 @@ impl KeygenParticipant {
             let private_key_share = self
                 .local_storage
                 .retrieve::<storage::PrivateKeyshare>(self.id)?;
-
+            self.status = Status::TerminatedSuccessfully;
             Ok(ProcessOutcome::Terminated((
                 public_key_shares,
                 private_key_share.clone(),
@@ -556,14 +573,8 @@ mod tests {
                 &[],
             )
         }
-        pub fn is_keygen_done(&self, _: Identifier) -> bool {
-            self.local_storage
-                .contains_for_all_ids::<storage::PublicKeyshare>(&self.all_participants())
-                && self
-                    .local_storage
-                    .contains::<storage::PrivateKeyshare>(self.id)
-        }
     }
+
     /// Delivers all messages into their respective participant's inboxes
     fn deliver_all(
         messages: &[Message],
@@ -580,13 +591,13 @@ mod tests {
         Ok(())
     }
 
-    fn is_keygen_done(quorum: &[KeygenParticipant], keygen_identifier: Identifier) -> Result<bool> {
+    fn is_keygen_done(quorum: &[KeygenParticipant]) -> bool {
         for participant in quorum {
-            if !participant.is_keygen_done(keygen_identifier) {
-                return Ok(false);
+            if !participant.is_done() {
+                return false;
             }
         }
-        Ok(true)
+        true
     }
 
     #[allow(clippy::type_complexity)]
@@ -651,7 +662,7 @@ mod tests {
             let inbox = inboxes.get_mut(&participant.id).unwrap();
             inbox.push(participant.initialize_keygen_message(keyshare_identifier));
         }
-        while !is_keygen_done(&quorum, keyshare_identifier)? {
+        while !is_keygen_done(&quorum) {
             let (index, outcome) = match process_messages(&mut quorum, &mut inboxes, &mut rng) {
                 None => continue,
                 Some(x) => x,

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -176,6 +176,8 @@ pub trait ProtocolParticipant {
     type Input: Debug;
     /// Output type of a successful protocol execution.
     type Output: Debug;
+    /// Type to determine status of protocol execution.
+    type Status: Debug + PartialEq;
 
     /// Get the type of a "ready" message, signalling that a participant
     /// is ready to begin protocol execution.
@@ -208,8 +210,8 @@ pub trait ProtocolParticipant {
         input: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>>;
 
-    /// Whether the protocol as terminated successfully or not.
-    fn is_done(&self) -> bool;
+    /// The status of the protocol execution.
+    fn status(&self) -> &Self::Status;
 }
 
 pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -207,6 +207,9 @@ pub trait ProtocolParticipant {
         message: &Message,
         input: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>>;
+
+    /// Whether the protocol as terminated successfully or not.
+    fn is_done(&self) -> bool;
 }
 
 pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -81,8 +81,9 @@ mod storage {
     }
 }
 
+/// Protocol status for [`PresignParticipant`].
 #[derive(Debug, PartialEq)]
-enum Status {
+pub enum Status {
     Initialized,
     TerminatedSuccessfully,
 }
@@ -169,6 +170,7 @@ impl Input {
 impl ProtocolParticipant for PresignParticipant {
     type Input = Input;
     type Output = PresignRecord;
+    type Status = Status;
 
     fn new(id: ParticipantIdentifier, other_participant_ids: Vec<ParticipantIdentifier>) -> Self {
         Self {
@@ -201,7 +203,7 @@ impl ProtocolParticipant for PresignParticipant {
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing presign message.");
 
-        if self.is_done() {
+        if *self.status() == Status::TerminatedSuccessfully {
             return Err(InternalError::ProtocolAlreadyTerminated);
         }
 
@@ -229,8 +231,8 @@ impl ProtocolParticipant for PresignParticipant {
         }
     }
 
-    fn is_done(&self) -> bool {
-        self.status == Status::TerminatedSuccessfully
+    fn status(&self) -> &Self::Status {
+        &self.status
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -147,6 +147,11 @@ impl<P: ProtocolParticipant> Participant<P> {
         Message::new(P::ready_type(), self.sid, self.id, self.id, &[])
     }
 
+    /// Return the protocol status.
+    pub fn status(&self) -> &P::Status {
+        self.participant.status()
+    }
+
     /// Generate a signature share on the given `digest` with the
     /// `PresignRecord`.
     ///
@@ -505,6 +510,10 @@ mod tests {
 
         // Keygen is done! Makre sure there are no more messages.
         assert!(inboxes_are_empty(&inboxes));
+        // And make sure all participants have successfully terminated.
+        assert!(keygen_quorum
+            .iter()
+            .all(|p| *p.status() == crate::keygen::participant::Status::TerminatedSuccessfully));
 
         // Hideously save the list of public keys for later
         let public_keyshares = keygen_outputs
@@ -564,6 +573,10 @@ mod tests {
 
         // Presigning is done! Make sure there are no more messages.
         assert!(inboxes_are_empty(&inboxes));
+        // And make sure all participants have successfully terminated.
+        assert!(presign_quorum
+            .iter()
+            .all(|p| *p.status() == crate::presign::participant::Status::TerminatedSuccessfully));
 
         // Now, produce a valid signature
         let mut hasher = Sha256::new();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -479,6 +479,10 @@ mod tests {
 
         // Auxinfo is done! Make sure there are no more messages.
         assert!(inboxes_are_empty(&inboxes));
+        // And make sure all participants have successfully terminated.
+        assert!(auxinfo_quorum
+            .iter()
+            .all(|p| *p.status() == crate::auxinfo::participant::Status::TerminatedSuccessfully));
 
         // Set up keygen participants
         let keygen_sid = Identifier::random(&mut rng);


### PR DESCRIPTION
Closes #160.

This allows a caller to tell when a protocol has successfully completed. In addition, this commit adds a `status` enum to each `ProtocolParticipant` instantiation to track protocol status. (Currently just `Initialized` and `TerminatedSuccessfully` is used.)