### PR TITLE
Remove `Identifier` from `LocalStorage`

### DIFF
--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -202,7 +202,7 @@ impl BroadcastParticipant {
         info!("Processing broadcast vote.");
 
         let other_participant_ids = self.other_participant_ids.clone();
-        let message_votes = self.get_from_storage::<storage::Votes>(sid)?;
+        let message_votes = self.get_from_storage::<storage::Votes>()?;
 
         // if not already in database, store. else, ignore
         let idx = BroadcastIndex {


### PR DESCRIPTION
Closes #217.

Since each `Participant` now exists within a single session, we no longer need to store `Identifier` in `LocalStorage`. This commit removes that, although leaves `MessageQueue` untouched (to be addressed in #261).