### PR TITLE
Remove `Identifier` from `MessageQueue` and `ProgressStore`

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -192,8 +192,7 @@ impl AuxInfoParticipant {
         let (ready_outcome, is_ready) = self.process_ready_message::<storage::Ready>(message)?;
 
         if is_ready {
-            let round_one_messages =
-                run_only_once!(self.gen_round_one_msgs(rng, message), message.id())?;
+            let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message))?;
 
             Ok(ready_outcome.with_messages(round_one_messages))
         } else {
@@ -260,15 +259,11 @@ impl AuxInfoParticipant {
 
         if r1_done {
             // Generate messages for round two...
-            let round_one_messages =
-                run_only_once!(self.gen_round_two_msgs(rng, message), message.id())?;
+            let round_one_messages = run_only_once!(self.gen_round_two_msgs(rng, message))?;
 
             // ...and process any round two messages we may have received early.
             let round_two_outcomes = self
-                .fetch_messages(
-                    MessageType::Auxinfo(AuxinfoMessageType::R2Decommit),
-                    message.id(),
-                )?
+                .fetch_messages(MessageType::Auxinfo(AuxinfoMessageType::R2Decommit))?
                 .iter()
                 .map(|msg| self.handle_round_two_msg(rng, msg, input))
                 .collect::<Result<Vec<_>>>()?;
@@ -293,8 +288,7 @@ impl AuxInfoParticipant {
         let public_keyshare_generated = self.local_storage.contains::<storage::Public>(self.id);
         let mut messages = vec![];
         if !public_keyshare_generated {
-            let more_messages =
-                run_only_once!(self.gen_round_one_msgs(rng, message), message.id())?;
+            let more_messages = run_only_once!(self.gen_round_one_msgs(rng, message))?;
             messages.extend_from_slice(&more_messages);
         }
 
@@ -352,15 +346,11 @@ impl AuxInfoParticipant {
             .contains_for_all_ids::<storage::Decommit>(&self.other_participant_ids);
         if r2_done {
             // Generate messages for round 3...
-            let round_two_messages =
-                run_only_once!(self.gen_round_three_msgs(rng, message), message.id())?;
+            let round_two_messages = run_only_once!(self.gen_round_three_msgs(rng, message))?;
 
             // ...and handle any messages that other participants have sent for round 3.
             let round_three_outcomes = self
-                .fetch_messages(
-                    MessageType::Auxinfo(AuxinfoMessageType::R3Proof),
-                    message.id(),
-                )?
+                .fetch_messages(MessageType::Auxinfo(AuxinfoMessageType::R3Proof))?
                 .iter()
                 .map(|msg| self.handle_round_three_msg(rng, msg, input))
                 .collect::<Result<Vec<_>>>()?;

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -221,11 +221,9 @@ impl BroadcastParticipant {
         // it's possible that all Redisperse messages are received before the original
         // Disperse, causing an output
         let redisperse_outcome = self.process_vote(data, message.id(), message.from())?;
-        let disperse_messages = run_only_once_per_tag!(
-            self.gen_round_two_msgs(rng, message, message.from()),
-            message.id(),
-            &tag
-        )?;
+        let disperse_messages =
+            run_only_once_per_tag!(self.gen_round_two_msgs(rng, message, message.from()), &tag)?;
+
         Ok(redisperse_outcome.with_messages(disperse_messages))
     }
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -190,8 +190,7 @@ impl KeygenParticipant {
         let (ready_outcome, is_ready) = self.process_ready_message::<storage::Ready>(message)?;
 
         if is_ready {
-            let round_one_messages =
-                run_only_once!(self.gen_round_one_msgs(rng, message), message.id())?;
+            let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message))?;
 
             Ok(ready_outcome.with_messages(round_one_messages))
         } else {
@@ -266,15 +265,11 @@ impl KeygenParticipant {
 
         if r1_done {
             // Finish round 1 by generating messages for round 2
-            let round_one_messages =
-                run_only_once!(self.gen_round_two_msgs(rng, message), message.id())?;
+            let round_one_messages = run_only_once!(self.gen_round_two_msgs(rng, message))?;
 
             // Process any round 2 messages we may have received early
             let round_two_outcomes = self
-                .fetch_messages(
-                    MessageType::Keygen(KeygenMessageType::R2Decommit),
-                    message.id(),
-                )?
+                .fetch_messages(MessageType::Keygen(KeygenMessageType::R2Decommit))?
                 .iter()
                 .map(|msg| self.handle_round_two_msg(rng, msg, input))
                 .collect::<Result<Vec<_>>>()?;
@@ -301,8 +296,7 @@ impl KeygenParticipant {
             .local_storage
             .contains::<storage::PublicKeyshare>(self.id)
         {
-            let more_messages =
-                run_only_once!(self.gen_round_one_msgs(rng, message), message.id())?;
+            let more_messages = run_only_once!(self.gen_round_one_msgs(rng, message))?;
             messages.extend_from_slice(&more_messages);
         }
 
@@ -359,15 +353,11 @@ impl KeygenParticipant {
 
         if r2_done {
             // Generate messages for round 3...
-            let round_two_messages =
-                run_only_once!(self.gen_round_three_msgs(rng, message), message.id())?;
+            let round_two_messages = run_only_once!(self.gen_round_three_msgs(rng, message))?;
 
             // ...and handle any messages that other participants have sent for round 3.
             let round_three_outcomes = self
-                .fetch_messages(
-                    MessageType::Keygen(KeygenMessageType::R3Proof),
-                    message.id(),
-                )?
+                .fetch_messages(MessageType::Keygen(KeygenMessageType::R3Proof))?
                 .iter()
                 .map(|msg| self.handle_round_three_msg(rng, msg, input))
                 .collect::<Result<Vec<_>>>()?;

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -28,7 +28,7 @@ pub(crate) trait TypeTag: 'static {
 
 pub(crate) mod storage {
     use super::TypeTag;
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     pub(crate) struct MessageQueue;
     impl TypeTag for MessageQueue {
@@ -37,8 +37,7 @@ pub(crate) mod storage {
 
     pub(crate) struct ProgressStore;
     impl TypeTag for ProgressStore {
-        // XXX We only ever store `true` here, so replace by a `HashSet` instead?
-        type Value = HashMap<String, bool>;
+        type Value = HashSet<String>;
     }
 }
 

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -37,7 +37,8 @@ pub(crate) mod storage {
 
     pub(crate) struct ProgressStore;
     impl TypeTag for ProgressStore {
-        type Value = HashMap<crate::participant::ProgressIndex, bool>;
+        // XXX We only ever store `true` here, so replace by a `HashSet` instead?
+        type Value = HashMap<String, bool>;
     }
 }
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -20,7 +20,7 @@ use tracing::{instrument, trace};
 /////////////////
 
 /// An enum consisting of all message types
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MessageType {
     /// Auxinfo messages
     Auxinfo(AuxinfoMessageType),
@@ -33,7 +33,7 @@ pub enum MessageType {
 }
 
 /// An enum consisting of all auxinfo message types
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuxinfoMessageType {
     /// Signals that auxinfo generation is ready
     Ready,
@@ -49,7 +49,7 @@ pub enum AuxinfoMessageType {
 }
 
 /// An enum consisting of all keygen message types
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum KeygenMessageType {
     /// Signals that keyshare generation is ready
     Ready,
@@ -65,7 +65,7 @@ pub enum KeygenMessageType {
 }
 
 /// An enum consisting of all presign message types
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PresignMessageType {
     /// Signals that presigning is ready
     Ready,
@@ -79,7 +79,7 @@ pub enum PresignMessageType {
     RoundThree,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BroadcastMessageType {
     /// First round: sender sends their message to everyone
     Disperse,

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -18,12 +18,6 @@ use rand::{CryptoRng, RngCore};
 use std::fmt::Debug;
 use tracing::error;
 
-#[derive(Eq, Hash, PartialEq)]
-pub(crate) struct ProgressIndex {
-    func_name: String,
-    sid: Identifier,
-}
-
 /// Possible outcomes from processing one or more messages.
 ///
 /// Processing an individual message causes various outcomes in a protocol
@@ -289,42 +283,32 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
 
     fn stash_message(&mut self, message: &Message) -> Result<()> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        message_storage.store(message.message_type(), message.id(), message.clone())?;
+        message_storage.store(message.message_type(), message.clone())?;
         Ok(())
     }
-    ///`sid` corresponds to a unique session identifier.
-    fn fetch_messages(
-        &mut self,
-        message_type: MessageType,
-        sid: Identifier,
-    ) -> Result<Vec<Message>> {
+    fn fetch_messages(&mut self, message_type: MessageType) -> Result<Vec<Message>> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        let messages = message_storage.retrieve_all(message_type, sid)?;
+        let messages = message_storage.retrieve_all(message_type)?;
         Ok(messages)
     }
-    ///`sid` corresponds to a unique session identifier.
     fn fetch_messages_by_sender(
         &mut self,
         message_type: MessageType,
-        sid: Identifier,
         sender: ParticipantIdentifier,
     ) -> Result<Vec<Message>> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        let messages = message_storage.retrieve(message_type, sid, sender)?;
+        let messages = message_storage.retrieve(message_type, sender)?;
         Ok(messages)
     }
-    ///`sid` corresponds to a unique session identifier.
-    fn write_progress(&mut self, func_name: String, sid: Identifier) -> Result<()> {
-        let key = ProgressIndex { func_name, sid };
+    fn write_progress(&mut self, func_name: String) -> Result<()> {
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>()?;
-        let _ = progress_storage.insert(key, true);
+        let _ = progress_storage.insert(func_name, true);
         Ok(())
     }
 
-    fn read_progress(&mut self, func_name: String, sid: Identifier) -> Result<bool> {
-        let key = ProgressIndex { func_name, sid };
+    fn read_progress(&mut self, func_name: String) -> Result<bool> {
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>()?;
-        let result = match progress_storage.get(&key) {
+        let result = match progress_storage.get(&func_name) {
             None => false,
             Some(value) => *value,
         };
@@ -382,11 +366,11 @@ pub(crate) trait Broadcast {
 /// A macro to keep track of which functions have already been run in a given
 /// session Must be a self.function() so that we can access storage
 macro_rules! run_only_once {
-    ($self:ident . $func_name:ident $args:tt, $sid:expr) => {{
-        if $self.read_progress(stringify!($func_name).to_string(), $sid)? {
+    ($self:ident . $func_name:ident $args:tt) => {{
+        if $self.read_progress(stringify!($func_name).to_string())? {
             Ok(vec![])
         } else {
-            $self.write_progress(stringify!($func_name).to_string(), $sid)?;
+            $self.write_progress(stringify!($func_name).to_string())?;
             $self.$func_name$args
         }
     }};
@@ -396,12 +380,12 @@ macro_rules! run_only_once {
 /// A macro to keep track of which function||tag combos have already been run in
 /// a given session
 macro_rules! run_only_once_per_tag {
-    ($self:ident . $func_name:ident $args:tt, $sid:expr, $tag:expr) => {{
+    ($self:ident . $func_name:ident $args:tt, $tag:expr) => {{
         let tag_str = format!("{:?}", $tag);
-        if $self.read_progress(stringify!($func_name).to_string() + &tag_str, $sid)? {
+        if $self.read_progress(stringify!($func_name).to_string() + &tag_str)? {
             Ok(vec![])
         } else {
-            $self.write_progress(stringify!($func_name).to_string(), $sid)?;
+            $self.write_progress(stringify!($func_name).to_string())?;
             $self.$func_name$args
         }
     }};

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -283,13 +283,12 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
 
     fn stash_message(&mut self, message: &Message) -> Result<()> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        message_storage.store(message.message_type(), message.clone())?;
+        message_storage.store(message.clone())?;
         Ok(())
     }
     fn fetch_messages(&mut self, message_type: MessageType) -> Result<Vec<Message>> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        let messages = message_storage.retrieve_all(message_type)?;
-        Ok(messages)
+        Ok(message_storage.retrieve_all(message_type))
     }
     fn fetch_messages_by_sender(
         &mut self,
@@ -297,22 +296,17 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
         sender: ParticipantIdentifier,
     ) -> Result<Vec<Message>> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        let messages = message_storage.retrieve(message_type, sender)?;
-        Ok(messages)
+        Ok(message_storage.retrieve(message_type, sender))
     }
     fn write_progress(&mut self, func_name: String) -> Result<()> {
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>()?;
-        let _ = progress_storage.insert(func_name, true);
+        let _ = progress_storage.insert(func_name);
         Ok(())
     }
 
     fn read_progress(&mut self, func_name: String) -> Result<bool> {
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>()?;
-        let result = match progress_storage.get(&func_name) {
-            None => false,
-            Some(value) => *value,
-        };
-        Ok(result)
+        Ok(progress_storage.get(&func_name).is_some())
     }
 }
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -342,10 +342,8 @@ impl PresignParticipant {
 
         // Additionally, handle any round 1 messages which may have been received too
         // early
-        let retrieved_messages = self.fetch_messages(
-            MessageType::Presign(PresignMessageType::RoundOne),
-            message.id(),
-        )?;
+        let retrieved_messages =
+            self.fetch_messages(MessageType::Presign(PresignMessageType::RoundOne))?;
         let round_two_outcomes = retrieved_messages
             .iter()
             .map(|msg| self.handle_round_one_msg(rng, msg, input))
@@ -376,7 +374,6 @@ impl PresignParticipant {
         // retrieve and process it
         let retrieved_messages = self.fetch_messages_by_sender(
             MessageType::Presign(PresignMessageType::RoundOne),
-            message.id(),
             message.from(),
         )?;
         let non_broadcasted_portion = match retrieved_messages.get(0) {
@@ -482,7 +479,6 @@ impl PresignParticipant {
         // Check if there's a round 2 message that this now allows us to process
         let retrieved_messages = self.fetch_messages_by_sender(
             MessageType::Presign(PresignMessageType::RoundTwo),
-            message.id(),
             message.from(),
         )?;
 
@@ -599,10 +595,8 @@ impl PresignParticipant {
 
         // Additionally, handle any round 3 messages which may have been received too
         // early
-        let retrieved_messages = self.fetch_messages(
-            MessageType::Presign(PresignMessageType::RoundThree),
-            message.id(),
-        )?;
+        let retrieved_messages =
+            self.fetch_messages(MessageType::Presign(PresignMessageType::RoundThree))?;
         let round_three_outcomes = retrieved_messages
             .iter()
             .map(|msg| self.handle_round_three_msg(rng, msg, input))


### PR DESCRIPTION
Closes #261.

Now that session IDs are no longer used in `Participant`s, we can remove them from the `MessageQueue` and `ProgressStore` structs used in `LocalStorage`.