### PR TITLE
Consolidate Error Messages

### DIFF
--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -26,7 +26,12 @@ pub(crate) struct AuxInfoCommit {
 impl AuxInfoCommit {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let auxinfo_commit: AuxInfoCommit = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_commit)
@@ -90,7 +95,12 @@ impl AuxInfoDecommit {
         context: &<AuxInfoParticipant as InnerProtocolParticipant>::Context,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R2Decommit) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Auxinfo(AuxinfoMessageType::R2Decommit),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let auxinfo_decommit: AuxInfoDecommit = deserialize!(&message.unverified_bytes)?;
 

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -533,7 +533,10 @@ impl AuxInfoParticipant {
     ) -> Result<(AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses)> {
         debug!("Creating new auxinfo.");
 
-        let (decryption_key, p, q) = DecryptionKey::new(rng)?;
+        let (decryption_key, p, q) = DecryptionKey::new(rng).map_err(|_| {
+            error!("Failed to create DecryptionKey");
+            InternalError::InternalInvariantFailed
+        })?;
         let params = VerifiedRingPedersen::extract(&decryption_key, &self.retrieve_context(), rng)?;
         let encryption_key = decryption_key.encryption_key();
 

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -167,8 +167,11 @@ impl ProtocolParticipant for AuxInfoParticipant {
             MessageType::Auxinfo(AuxinfoMessageType::R3Proof) => {
                 self.handle_round_three_msg(rng, message, input)
             }
-            _ => {
-                error!("Incorrect MessageType given to AuxInfoParticipant");
+            message_type => {
+                error!(
+                    "Incorrect MessageType given to AuxInfoParticipant. Got: {:?}",
+                    message_type
+                );
                 Err(InternalError::InternalInvariantFailed)
             }
         }

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -13,7 +13,7 @@ use crate::{
         proof::AuxInfoProof,
     },
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
-    errors::{InternalError, Result},
+    errors::{CallerError, InternalError, Result},
     local_storage::LocalStorage,
     messages::{AuxinfoMessageType, Message, MessageType},
     paillier::DecryptionKey,
@@ -148,7 +148,9 @@ impl ProtocolParticipant for AuxInfoParticipant {
         info!("Processing auxinfo message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::ProtocolAlreadyTerminated);
+            return Err(InternalError::CallingApplicationMistake(
+                CallerError::ProtocolAlreadyTerminated,
+            ));
         }
 
         match message.message_type() {

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -23,7 +23,7 @@ use crate::{
     run_only_once,
 };
 use rand::{CryptoRng, RngCore};
-use tracing::{debug, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 // Local storage data types.
 mod storage {
@@ -165,7 +165,6 @@ impl ProtocolParticipant for AuxInfoParticipant {
             MessageType::Auxinfo(AuxinfoMessageType::R3Proof) => {
                 self.handle_round_three_msg(rng, message, input)
             }
-            MessageType::Auxinfo(_) => Err(InternalError::MessageMustBeBroadcasted),
             _ => Err(InternalError::MisroutedMessage),
         }
     }
@@ -264,7 +263,12 @@ impl AuxInfoParticipant {
         info!("Handling round one auxinfo message.");
 
         if broadcast_message.tag != BroadcastTag::AuxinfoR1CommitHash {
-            return Err(InternalError::IncorrectBroadcastMessageTag);
+            error!(
+                "Incorrect Broadcast Tag on received message. Expected {:?}, got {:?}",
+                BroadcastTag::AuxinfoR1CommitHash,
+                broadcast_message.tag
+            );
+            return Err(InternalError::ProtocolError);
         }
         let message = &broadcast_message.msg;
         self.local_storage

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -148,9 +148,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
         info!("Processing auxinfo message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::CallingApplicationMistake(
-                CallerError::ProtocolAlreadyTerminated,
-            ));
+            Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
         match message.message_type() {

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -165,7 +165,10 @@ impl ProtocolParticipant for AuxInfoParticipant {
             MessageType::Auxinfo(AuxinfoMessageType::R3Proof) => {
                 self.handle_round_three_msg(rng, message, input)
             }
-            _ => Err(InternalError::MisroutedMessage),
+            _ => {
+                error!("Incorrect MessageType given to AuxInfoParticipant");
+                Err(InternalError::InternalInvariantFailed)
+            }
         }
     }
 

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -33,7 +33,7 @@ pub(crate) struct AuxInfoProof {
 impl AuxInfoProof {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R3Proof) {
-            return Err(InternalError::IncorrectBroadcastMessageTag);
+            return Err(InternalError::MisroutedMessage);
         }
         let auxinfo_proof: AuxInfoProof = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_proof)

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -23,6 +23,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct AuxInfoProof {
@@ -33,7 +34,12 @@ pub(crate) struct AuxInfoProof {
 impl AuxInfoProof {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Auxinfo(AuxinfoMessageType::R3Proof) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Auxinfo(AuxinfoMessageType::R3Proof),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let auxinfo_proof: AuxInfoProof = deserialize!(&message.unverified_bytes)?;
         Ok(auxinfo_proof)

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -28,7 +28,10 @@ impl BroadcastData {
         if message.message_type() != MessageType::Broadcast(BroadcastMessageType::Disperse)
             && message.message_type() != MessageType::Broadcast(BroadcastMessageType::Redisperse)
         {
-            error!("Incorrect MessageType given to Broadcast Handler");
+            error!(
+                "Incorrect MessageType given to Broadcast Handler. Got: {:?}",
+                message.message_type()
+            );
             return Err(InternalError::InternalInvariantFailed);
         }
         let broadcast_data: BroadcastData = deserialize!(&message.unverified_bytes)?;

--- a/src/broadcast/data.rs
+++ b/src/broadcast/data.rs
@@ -13,6 +13,7 @@ use crate::{
     ParticipantIdentifier,
 };
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct BroadcastData {
@@ -27,7 +28,8 @@ impl BroadcastData {
         if message.message_type() != MessageType::Broadcast(BroadcastMessageType::Disperse)
             && message.message_type() != MessageType::Broadcast(BroadcastMessageType::Redisperse)
         {
-            return Err(InternalError::MisroutedMessage);
+            error!("Incorrect MessageType given to Broadcast Handler");
+            return Err(InternalError::InternalInvariantFailed);
         }
         let broadcast_data: BroadcastData = deserialize!(&message.unverified_bytes)?;
         Ok(broadcast_data)

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -145,8 +145,11 @@ impl ProtocolParticipant for BroadcastParticipant {
             MessageType::Broadcast(BroadcastMessageType::Redisperse) => {
                 self.handle_round_two_msg(rng, message)
             }
-            _ => {
-                error!("Incorrect MessageType given to Broadcast handler");
+            message_type => {
+                error!(
+                    "Incorrect MessageType given to Broadcast handler. Got: {:?}",
+                    message_type
+                );
                 Err(InternalError::InternalInvariantFailed)
             }
         }

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -143,7 +143,10 @@ impl ProtocolParticipant for BroadcastParticipant {
             MessageType::Broadcast(BroadcastMessageType::Redisperse) => {
                 self.handle_round_two_msg(rng, message)
             }
-            _ => Err(InternalError::MisroutedMessage),
+            _ => {
+                error!("Incorrect MessageType given to Broadcast handler");
+                Err(InternalError::InternalInvariantFailed)
+            }
         }
     }
 

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -132,9 +132,7 @@ impl ProtocolParticipant for BroadcastParticipant {
             // have completed a broadcast equals the total number of other
             // participants.
             if participants.len() == self.other_participant_ids.len() {
-                return Err(InternalError::CallingApplicationMistake(
-                    CallerError::ProtocolAlreadyTerminated,
-                ));
+                Err(CallerError::ProtocolAlreadyTerminated)?;
             }
         }
 

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     broadcast::data::BroadcastData,
-    errors::{InternalError, Result},
+    errors::{CallerError, InternalError, Result},
     local_storage::LocalStorage,
     messages::{BroadcastMessageType, Message, MessageType},
     participant::{InnerProtocolParticipant, ProcessOutcome, ProtocolParticipant},
@@ -132,7 +132,9 @@ impl ProtocolParticipant for BroadcastParticipant {
             // have completed a broadcast equals the total number of other
             // participants.
             if participants.len() == self.other_participant_ids.len() {
-                return Err(InternalError::ProtocolAlreadyTerminated);
+                return Err(InternalError::CallingApplicationMistake(
+                    CallerError::ProtocolAlreadyTerminated,
+                ));
             }
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,7 @@ pub enum InternalError {
     CallingApplicationMistake(#[from] CallerError),
     #[error("Serialization Error")]
     Serialization,
-    #[error("Protocol error")]
+    #[error("Some player sent a message which does not match the protocol specification")]
     ProtocolError,
     #[error("Could not successfully generate proof")]
     CouldNotGenerateProof,
@@ -33,28 +33,14 @@ pub enum InternalError {
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
     PaillierError(#[from] paillier::Error),
-    #[error("Failed to convert BigNumber to k256::Scalar, as BigNumber was not in [0,p)")]
-    CouldNotConvertToScalar,
-    #[error("Could not invert a Scalar")]
-    CouldNotInvertScalar,
     #[error("Reached the maximum allowed number of retries")]
     RetryFailed,
     #[error("This Participant was given a message intended for somebody else")]
     WrongMessageRecipient,
     #[error("Encountered a MessageType which was not expected in this context")]
     MisroutedMessage,
-    #[error("Could not construct signature from provided scalars")]
-    SignatureInstantiationError,
-    #[error("Tried to produce a signature without including shares")]
-    NoChainedShares,
     #[error("Storage does not contain the requested item")]
     StorageItemNotFound,
-    #[error("The provided Broadcast Tag was not the expected tag for this context")]
-    IncorrectBroadcastMessageTag,
-    #[error("Encountered a Message sent directly, when it should have been broadcasted")]
-    MessageMustBeBroadcasted,
-    #[error("Broadcast has irrecoverably failed: `{0}`")]
-    BroadcastFailure(String),
     #[error(
         "Tried to start a new protocol instance with an Identifier used in an existing instance"
     )]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,8 +37,6 @@ pub enum InternalError {
     RetryFailed,
     #[error("This Participant was given a message intended for somebody else")]
     WrongMessageRecipient,
-    #[error("Encountered a MessageType which was not expected in this context")]
-    MisroutedMessage,
     #[error("Storage does not contain the requested item")]
     StorageItemNotFound,
     #[error(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,8 +25,6 @@ pub enum InternalError {
     Serialization,
     #[error("Some player sent a message which does not match the protocol specification")]
     ProtocolError,
-    #[error("Failed to verify proof")]
-    FailedToVerifyProof,
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,16 +33,8 @@ pub enum InternalError {
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
     PaillierError(#[from] paillier::Error),
-    #[error("This Participant was given a message intended for somebody else")]
-    WrongMessageRecipient,
     #[error("Storage does not contain the requested item")]
     StorageItemNotFound,
-    #[error(
-        "Tried to start a new protocol instance with an Identifier used in an existing instance"
-    )]
-    IdentifierInUse,
-    #[error("Protocol has already terminated")]
-    ProtocolAlreadyTerminated,
 }
 
 /// Errors that are caused by incorrect behavior by the calling application.
@@ -62,6 +54,8 @@ pub enum CallerError {
     WrongProtocol,
     #[error("Received a message from a sender not included in the list of participants")]
     InvalidMessageSender,
+    #[error("Received a message for a Protocol which has already terminated")]
+    ProtocolAlreadyTerminated,
     #[error("The provided RNG failed to produce suitable values after a maximum number of attempts. Please check the RNG.")]
     RetryFailed,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,8 +25,6 @@ pub enum InternalError {
     Serialization,
     #[error("Some player sent a message which does not match the protocol specification")]
     ProtocolError,
-    #[error("Could not successfully generate proof")]
-    CouldNotGenerateProof,
     #[error("Failed to verify proof")]
     FailedToVerifyProof,
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,8 +33,6 @@ pub enum InternalError {
     InternalInvariantFailed,
     #[error("Paillier error: `{0}`")]
     PaillierError(#[from] paillier::Error),
-    #[error("Reached the maximum allowed number of retries")]
-    RetryFailed,
     #[error("This Participant was given a message intended for somebody else")]
     WrongMessageRecipient,
     #[error("Storage does not contain the requested item")]
@@ -64,6 +62,8 @@ pub enum CallerError {
     WrongProtocol,
     #[error("Received a message from a sender not included in the list of participants")]
     InvalidMessageSender,
+    #[error("The provided RNG failed to produce suitable values after a maximum number of attempts. Please check the RNG.")]
+    RetryFailed,
 }
 
 macro_rules! serialize {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,6 @@
 use core::fmt::Debug;
 use thiserror::Error;
 
-use crate::paillier;
-
 /// The default Result type used in this crate
 pub type Result<T> = std::result::Result<T, InternalError>;
 
@@ -27,8 +25,6 @@ pub enum InternalError {
     ProtocolError,
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
-    #[error("Paillier error: `{0}`")]
-    PaillierError(#[from] paillier::Error),
     #[error("Storage does not contain the requested item")]
     StorageItemNotFound,
 }

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -17,7 +17,7 @@ use crate::{
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, warn};
+use tracing::{error, instrument, warn};
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub(crate) struct KeygenCommit {
@@ -26,7 +26,12 @@ pub(crate) struct KeygenCommit {
 impl KeygenCommit {
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Keygen(KeygenMessageType::R1CommitHash) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Keygen(KeygenMessageType::R1CommitHash),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let keygen_commit: KeygenCommit = deserialize!(&message.unverified_bytes)?;
         Ok(keygen_commit)
@@ -69,7 +74,12 @@ impl KeygenDecommit {
 
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Keygen(KeygenMessageType::R2Decommit) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Keygen(KeygenMessageType::R2Decommit),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let keygen_decommit: KeygenDecommit = deserialize!(&message.unverified_bytes)?;
         Ok(keygen_decommit)

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -118,7 +118,7 @@ impl KeygenDecommit {
             Ok(())
         } else {
             warn!("decommitment does not match original commitment");
-            Err(InternalError::FailedToVerifyProof)
+            Err(InternalError::ProtocolError)
         }
     }
 }

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -183,8 +183,11 @@ impl ProtocolParticipant for KeygenParticipant {
                 self.handle_round_two_msg(message)
             }
             MessageType::Keygen(KeygenMessageType::R3Proof) => self.handle_round_three_msg(message),
-            _ => {
-                error!("Incorrect MessageType given to KeygenParticipant");
+            message_type => {
+                error!(
+                    "Incorrect MessageType given to KeygenParticipant. Got: {:?}",
+                    message_type
+                );
                 Err(InternalError::InternalInvariantFailed)
             }
         }

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -181,7 +181,10 @@ impl ProtocolParticipant for KeygenParticipant {
                 self.handle_round_two_msg(message)
             }
             MessageType::Keygen(KeygenMessageType::R3Proof) => self.handle_round_three_msg(message),
-            _ => Err(InternalError::MisroutedMessage)?,
+            _ => {
+                error!("Incorrect MessageType given to KeygenParticipant");
+                Err(InternalError::InternalInvariantFailed)
+            }
         }
     }
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
-    errors::{InternalError, Result},
+    errors::{CallerError, InternalError, Result},
     keygen::{
         keygen_commit::{KeygenCommit, KeygenDecommit},
         keyshare::{KeySharePrivate, KeySharePublic},
@@ -166,7 +166,9 @@ impl ProtocolParticipant for KeygenParticipant {
         info!("Processing keygen message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::ProtocolAlreadyTerminated);
+            return Err(InternalError::CallingApplicationMistake(
+                CallerError::ProtocolAlreadyTerminated,
+            ));
         }
 
         match message.message_type() {

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -28,7 +28,7 @@ use crate::{
 use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 
 mod storage {
     use super::*;
@@ -304,7 +304,12 @@ impl KeygenParticipant {
         // message _after_ round one is complete? Likewise for all other rounds.
 
         if broadcast_message.tag != BroadcastTag::KeyGenR1CommitHash {
-            return Err(InternalError::IncorrectBroadcastMessageTag);
+            error!(
+                "Incorrect Broadcast Tag on received message. Expected {:?}, got {:?}",
+                BroadcastTag::KeyGenR1CommitHash,
+                broadcast_message.tag
+            );
+            return Err(InternalError::ProtocolError);
         }
         let message = &broadcast_message.msg;
         self.local_storage

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -166,9 +166,7 @@ impl ProtocolParticipant for KeygenParticipant {
         info!("Processing keygen message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::CallingApplicationMistake(
-                CallerError::ProtocolAlreadyTerminated,
-            ));
+            Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
         match message.message_type() {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -36,8 +36,6 @@ pub enum MessageType {
 pub enum AuxinfoMessageType {
     /// Signals that auxinfo generation is ready
     Ready,
-    /// Public auxinfo produced by auxinfo generation for a participant
-    Public,
     /// A hash commitment to the public keyshare and associated proofs
     R1CommitHash,
     /// The information committed to in Round 1

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -6,7 +6,6 @@
 // of this source tree.
 
 use crate::{
-    errors::{CallerError, InternalError, Result},
     parameters::PRIME_BITS,
     utils::{modpow, random_bn_in_z_star, CRYPTOGRAPHIC_RETRY_MAX},
 };
@@ -20,9 +19,12 @@ use zeroize::ZeroizeOnDrop;
 #[cfg(test)]
 use crate::utils::random_positive_bn;
 
+/// The default Result type used in this crate
+pub type Result<T> = std::result::Result<T, PaillierError>;
+
 /// Paillier-specific errors.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
-pub enum Error {
+pub enum PaillierError {
     #[error("Failed to create a Paillier decryption key from inputs")]
     CouldNotCreateKey,
     #[error("The inputs to a homomorphic operation on a Paillier ciphertext were malformed")]
@@ -33,6 +35,8 @@ pub enum Error {
         "Cannot encrypt out-of-range value; x must be in the group of integers mod n. Got {x}, {n}"
     )]
     EncryptionFailed { x: BigNumber, n: BigNumber },
+    #[error("The provided RNG failed to produce suitable values after a maximum number of attempts. Please check the RNG.")]
+    RetryFailed,
 
     #[cfg(test)]
     #[error("No pre-generated primes with size {0}")]
@@ -119,7 +123,8 @@ impl EncryptionKey {
     ) -> Result<(Ciphertext, Nonce)> {
         // Note: the check that `x` is in the proper range happens in
         // `encrypt_with_nonce`.
-        let nonce = random_bn_in_z_star(rng, self.modulus())?;
+        let nonce =
+            random_bn_in_z_star(rng, self.modulus()).map_err(|_| PaillierError::RetryFailed)?;
         let c = self.encrypt_with_nonce(x, &MaskedNonce(nonce.clone()))?;
         Ok((c, Nonce(nonce)))
     }
@@ -137,7 +142,7 @@ impl EncryptionKey {
         nonce: &MaskedNonce,
     ) -> Result<Ciphertext> {
         if &self.half_n() < x || x < &-self.half_n() {
-            Err(Error::EncryptionFailed {
+            Err(PaillierError::EncryptionFailed {
                 x: x.clone(),
                 n: self.modulus().clone(),
             })?
@@ -193,7 +198,7 @@ impl EncryptionKey {
         // Instead, we do the operations directly and manually do the range
         // check.
         if &self.half_n() < a || a < &-self.half_n() {
-            Err(Error::InvalidOperation)?
+            Err(PaillierError::InvalidOperation)?
         } else {
             Ok(Ciphertext(
                 modpow(&c1.0, a, self.0.nn()).modmul(&c2.0, self.0.nn()),
@@ -226,7 +231,7 @@ impl DecryptionKey {
         let mut x = self
             .0
             .decrypt(&c.0)
-            .ok_or(Error::DecryptionFailed)
+            .ok_or(PaillierError::DecryptionFailed)
             .map(BigNumber::from_slice)?;
 
         // Switch representation into `[-N/2, N/2]`. libpaillier (and indeed,
@@ -267,7 +272,7 @@ impl DecryptionKey {
             {
                 Ok((p, q))
             } else {
-                Err(Error::CouldNotCreateKey)?
+                Err(PaillierError::CouldNotCreateKey)?
             }
         };
 
@@ -279,19 +284,18 @@ impl DecryptionKey {
             .find(|result| result.is_ok())
             // We hit the maximum number of retries without getting an acceptable pair.
             // We should never hit the second `?` unless `find` breaks.
-            .ok_or(InternalError::CallingApplicationMistake(
-                CallerError::RetryFailed,
-            ))??;
+            .ok_or(PaillierError::RetryFailed)??;
 
         let decryption_key = DecryptionKey(
-            libpaillier::DecryptionKey::with_primes(&p, &q).ok_or(Error::CouldNotCreateKey)?,
+            libpaillier::DecryptionKey::with_primes(&p, &q)
+                .ok_or(PaillierError::CouldNotCreateKey)?,
         );
 
         // Double check that the modulus is the correct size.
         if decryption_key.0.n().bit_length() == 2 * PRIME_BITS {
             Ok((decryption_key, p, q))
         } else {
-            Err(Error::CouldNotCreateKey)?
+            Err(PaillierError::CouldNotCreateKey)?
         }
     }
 
@@ -361,12 +365,12 @@ pub(crate) mod prime_gen {
         rng: &mut R,
     ) -> Result<BigNumber> {
         if POOL_OF_PRIMES.len() == 0 {
-            Err(Error::NoPregeneratedPrimes(PRIME_BITS))?;
+            Err(PaillierError::NoPregeneratedPrimes(PRIME_BITS))?;
         }
-        Ok(POOL_OF_PRIMES
+        POOL_OF_PRIMES
             .get(rng.gen_range(0..POOL_OF_PRIMES.len()))
             .cloned()
-            .ok_or(Error::NoPregeneratedPrimes(PRIME_BITS))?)
+            .ok_or(PaillierError::NoPregeneratedPrimes(PRIME_BITS))
     }
 
     /// Sample a pair of independent, non-matching safe primes from a

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -6,7 +6,7 @@
 // of this source tree.
 
 use crate::{
-    errors::{InternalError, Result},
+    errors::{CallerError, InternalError, Result},
     parameters::PRIME_BITS,
     utils::{modpow, random_bn_in_z_star, CRYPTOGRAPHIC_RETRY_MAX},
 };
@@ -279,7 +279,9 @@ impl DecryptionKey {
             .find(|result| result.is_ok())
             // We hit the maximum number of retries without getting an acceptable pair.
             // We should never hit the second `?` unless `find` breaks.
-            .ok_or(InternalError::RetryFailed)??;
+            .ok_or(InternalError::CallingApplicationMistake(
+                CallerError::RetryFailed,
+            ))??;
 
         let decryption_key = DecryptionKey(
             libpaillier::DecryptionKey::with_primes(&p, &q).ok_or(Error::CouldNotCreateKey)?,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -909,9 +909,17 @@ impl PresignKeyShareAndInfo {
         let gamma = random_positive_bn(rng, &order);
 
         // Sample rho <- Z_N^* and set K = enc(k; rho)
-        let (K, rho) = self.aux_info_public.pk().encrypt(rng, &k)?;
+        let (K, rho) = self
+            .aux_info_public
+            .pk()
+            .encrypt(rng, &k)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
         // Sample nu <- Z_N^* and set G = enc(gamma; nu)
-        let (G, nu) = self.aux_info_public.pk().encrypt(rng, &gamma)?;
+        let (G, nu) = self
+            .aux_info_public
+            .pk()
+            .encrypt(rng, &gamma)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
 
         let mut r1_publics = HashMap::new();
         for aux_info_public in public_keys {
@@ -976,21 +984,41 @@ impl PresignKeyShareAndInfo {
         // values are equal. The betas are components of additive shares of
         // secret values, so it shouldn't matter where the negation happens
         // (Round 2 vs Round 3).
-        let (beta_ciphertext, s) = receiver_aux_info.pk().encrypt(rng, &beta)?;
-        let (beta_hat_ciphertext, s_hat) = receiver_aux_info.pk().encrypt(rng, &beta_hat)?;
+        let (beta_ciphertext, s) = receiver_aux_info
+            .pk()
+            .encrypt(rng, &beta)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
+        let (beta_hat_ciphertext, s_hat) = receiver_aux_info
+            .pk()
+            .encrypt(rng, &beta_hat)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
 
-        let D = receiver_aux_info.pk().multiply_and_add(
-            &sender_r1_priv.gamma,
-            &receiver_r1_pub_broadcast.K,
-            &beta_ciphertext,
-        )?;
-        let D_hat = receiver_aux_info.pk().multiply_and_add(
-            &self.keyshare_private.x,
-            &receiver_r1_pub_broadcast.K,
-            &beta_hat_ciphertext,
-        )?;
-        let (F, r) = self.aux_info_public.pk().encrypt(rng, &beta)?;
-        let (F_hat, r_hat) = self.aux_info_public.pk().encrypt(rng, &beta_hat)?;
+        let D = receiver_aux_info
+            .pk()
+            .multiply_and_add(
+                &sender_r1_priv.gamma,
+                &receiver_r1_pub_broadcast.K,
+                &beta_ciphertext,
+            )
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
+        let D_hat = receiver_aux_info
+            .pk()
+            .multiply_and_add(
+                &self.keyshare_private.x,
+                &receiver_r1_pub_broadcast.K,
+                &beta_hat_ciphertext,
+            )
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
+        let (F, r) = self
+            .aux_info_public
+            .pk()
+            .encrypt(rng, &beta)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
+        let (F_hat, r_hat) = self
+            .aux_info_public
+            .pk()
+            .encrypt(rng, &beta_hat)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
 
         let g = CurvePoint::GENERATOR;
         let Gamma = CurvePoint(g.0 * bn_to_scalar(&sender_r1_priv.gamma)?);
@@ -1092,11 +1120,13 @@ impl PresignKeyShareAndInfo {
             let alpha = self
                 .aux_info_private
                 .decryption_key()
-                .decrypt(&r2_pub_j.D)?;
+                .decrypt(&r2_pub_j.D)
+                .map_err(|_| InternalError::InternalInvariantFailed)?;
             let alpha_hat = self
                 .aux_info_private
                 .decryption_key()
-                .decrypt(&r2_pub_j.D_hat)?;
+                .decrypt(&r2_pub_j.D_hat)
+                .map_err(|_| InternalError::InternalInvariantFailed)?;
 
             delta = delta.modadd(&alpha.modsub(&r2_priv_j.beta, &order), &order);
             chi = chi.modadd(&alpha_hat.modsub(&r2_priv_j.beta_hat, &order), &order);

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -241,9 +241,7 @@ impl ProtocolParticipant for PresignParticipant {
         info!("Processing presign message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::CallingApplicationMistake(
-                CallerError::ProtocolAlreadyTerminated,
-            ));
+            Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
         match message.message_type() {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -264,7 +264,10 @@ impl ProtocolParticipant for PresignParticipant {
                 self.handle_round_three_msg(rng, message, input)
             }
 
-            _ => Err(InternalError::MisroutedMessage),
+            _ => {
+                error!("Incorrect MessageType given to PresignParticipant");
+                Err(InternalError::InternalInvariantFailed)
+            }
         }
     }
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -9,7 +9,7 @@
 use crate::{
     auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
-    errors::{InternalError, Result},
+    errors::{CallerError, InternalError, Result},
     keygen::keyshare::{KeySharePrivate, KeySharePublic},
     local_storage::LocalStorage,
     messages::{Message, MessageType, PresignMessageType},
@@ -241,7 +241,9 @@ impl ProtocolParticipant for PresignParticipant {
         info!("Processing presign message.");
 
         if *self.status() == Status::TerminatedSuccessfully {
-            return Err(InternalError::ProtocolAlreadyTerminated);
+            return Err(InternalError::CallingApplicationMistake(
+                CallerError::ProtocolAlreadyTerminated,
+            ));
         }
 
         match message.message_type() {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -266,8 +266,11 @@ impl ProtocolParticipant for PresignParticipant {
                 self.handle_round_three_msg(rng, message, input)
             }
 
-            _ => {
-                error!("Incorrect MessageType given to PresignParticipant");
+            message_type => {
+                error!(
+                    "Incorrect MessageType given to PresignParticipant. Got: {:?}",
+                    message_type
+                );
                 Err(InternalError::InternalInvariantFailed)
             }
         }

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -391,8 +391,12 @@ impl PresignParticipant {
         input: &Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         if broadcast_message.tag != BroadcastTag::PresignR1Ciphertexts {
-            error!("Incorrect tag for Presign R1 Broadcast!");
-            return Err(InternalError::IncorrectBroadcastMessageTag);
+            error!(
+                "Incorrect Broadcast Tag on received message. Expected {:?}, got {:?}",
+                BroadcastTag::PresignR1Ciphertexts,
+                broadcast_message.tag
+            );
+            return Err(InternalError::ProtocolError);
         }
         let message = &broadcast_message.msg;
         let public_broadcast: RoundOnePublicBroadcast = deserialize!(&message.unverified_bytes)?;

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -7,10 +7,7 @@
 // of this source tree.
 
 use crate::{
-    errors::{
-        InternalError::{CouldNotConvertToScalar, CouldNotInvertScalar, InternalInvariantFailed},
-        Result,
-    },
+    errors::{InternalError::InternalInvariantFailed, Result},
     presign::round_three::{Private as RoundThreePrivate, Public as RoundThreePublic},
     utils::bn_to_scalar,
     CurvePoint,
@@ -73,7 +70,10 @@ impl TryFrom<RecordPair> for PresignRecord {
             return Err(InternalInvariantFailed);
         }
 
-        let delta_inv = Option::<Scalar>::from(delta.invert()).ok_or(CouldNotInvertScalar)?;
+        let delta_inv = Option::<Scalar>::from(delta.invert()).ok_or_else(|| {
+            error!("Could not invert delta as it is 0. Either you got profoundly unlucky or more likely there's a bug");
+            InternalInvariantFailed
+        })?;
         let R = CurvePoint(private.Gamma.0 * delta_inv);
 
         Ok(PresignRecord {
@@ -87,13 +87,18 @@ impl TryFrom<RecordPair> for PresignRecord {
 impl PresignRecord {
     fn x_from_point(p: &CurvePoint) -> Result<k256::Scalar> {
         let r = &p.0.to_affine().x();
-        Option::from(k256::Scalar::from_repr(*r)).ok_or(CouldNotConvertToScalar)
+        Option::from(k256::Scalar::from_repr(*r)).ok_or_else(|| {
+            error!("Unable to create Scalar from bytes representation");
+            InternalInvariantFailed
+        })
     }
 
     pub(crate) fn sign(&self, d: sha2::Sha256) -> Result<(k256::Scalar, k256::Scalar)> {
         let r = Self::x_from_point(&self.R)?;
-        let m = Option::<Scalar>::from(k256::Scalar::from_repr(d.finalize()))
-            .ok_or(CouldNotConvertToScalar)?;
+        let m = Option::<Scalar>::from(k256::Scalar::from_repr(d.finalize())).ok_or_else(|| {
+            error!("Unable to create Scalar from bytes representation");
+            InternalInvariantFailed
+        })?;
         let s = bn_to_scalar(&self.k)? * m + r * self.chi;
 
         Ok((r, s))

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -7,7 +7,10 @@
 // of this source tree.
 
 use crate::{
-    errors::{InternalError::InternalInvariantFailed, Result},
+    errors::{
+        InternalError::{InternalInvariantFailed, ProtocolError},
+        Result,
+    },
     presign::round_three::{Private as RoundThreePrivate, Public as RoundThreePublic},
     utils::bn_to_scalar,
     CurvePoint,
@@ -67,7 +70,7 @@ impl TryFrom<RecordPair> for PresignRecord {
         let g = CurvePoint::GENERATOR;
         if CurvePoint(g.0 * delta) != Delta {
             error!("Could not create PresignRecord: mismatch between calculated private and public deltas");
-            return Err(InternalInvariantFailed);
+            return Err(ProtocolError);
         }
 
         let delta_inv = Option::<Scalar>::from(delta.invert()).ok_or_else(|| {

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -18,6 +18,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tracing::error;
 use zeroize::ZeroizeOnDrop;
 
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
@@ -80,7 +81,12 @@ impl Public {
         broadcasted_params: &PublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundOne) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Presign(PresignMessageType::RoundOne),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let round_one_public: Self = deserialize!(&message.unverified_bytes)?;
 

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -25,6 +25,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tracing::error;
 use zeroize::ZeroizeOnDrop;
 
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
@@ -92,7 +93,12 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundThree) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Presign(PresignMessageType::RoundThree),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
 
         let round_three_public: Self = deserialize!(&message.unverified_bytes)?;

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -24,6 +24,7 @@ use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tracing::error;
 use zeroize::ZeroizeOnDrop;
 
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
@@ -120,7 +121,12 @@ impl Public {
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<Self> {
         if message.message_type() != MessageType::Presign(PresignMessageType::RoundTwo) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Presign(PresignMessageType::RoundTwo),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let round_two_public: Self = deserialize!(&message.unverified_bytes)?;
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -263,7 +263,8 @@ impl SignatureShare {
             }
             (Some(prev_r), Some(new_r)) => {
                 if prev_r != new_r {
-                    return Err(InternalError::SignatureInstantiationError);
+                    error!("Failed to create signature as prev_r != new_r");
+                    return Err(InternalError::InternalInvariantFailed);
                 }
                 Ok(prev_r)
             }
@@ -285,10 +286,15 @@ impl SignatureShare {
         if bool::from(s.is_high()) {
             s = s.negate();
         }
-        let r = self.r.ok_or(InternalError::NoChainedShares)?;
+        let r = self.r.ok_or_else(|| {
+            error!("Tried to produce a signature without including shares");
+            InternalError::InternalInvariantFailed
+        })?;
 
-        k256::ecdsa::Signature::from_scalars(r, s)
-            .map_err(|_| InternalError::SignatureInstantiationError)
+        k256::ecdsa::Signature::from_scalars(r, s).map_err(|_| {
+            error!("Unable to create ECDSA signature from provided r and s");
+            InternalError::InternalInvariantFailed
+        })
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -263,7 +263,11 @@ impl SignatureShare {
             }
             (Some(prev_r), Some(new_r)) => {
                 if prev_r != new_r {
-                    error!("Failed to create signature as prev_r != new_r");
+                    error!(
+                        "Failed to chain signature shares together because 
+                        r-values were different. Got {:?}, expected {:?}.",
+                        &prev_r, new_r
+                    );
                     return Err(InternalError::InternalInvariantFailed);
                 }
                 Ok(prev_r)

--- a/src/ring_pedersen.rs
+++ b/src/ring_pedersen.rs
@@ -181,7 +181,7 @@ impl VerifiedRingPedersen {
         rng: &mut (impl RngCore + CryptoRng),
         context: &impl ProofContext,
     ) -> Result<Self> {
-        let (sk, _, _) = DecryptionKey::new(rng)?;
+        let (sk, _, _) = DecryptionKey::new(rng).unwrap();
         Self::extract(&sk, context, rng)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,10 +6,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use crate::errors::{
-    InternalError::{self, RetryFailed},
-    Result,
-};
+use crate::errors::{CallerError, InternalError, Result};
 use generic_array::GenericArray;
 use k256::{
     elliptic_curve::{bigint::Encoding, group::ff::PrimeField, AffinePoint, Curve},
@@ -214,7 +211,9 @@ pub(crate) fn random_bn_in_z_star<R: RngCore + CryptoRng>(
     std::iter::repeat_with(|| BigNumber::from_rng(n, rng))
         .take(CRYPTOGRAPHIC_RETRY_MAX)
         .find(|result| result != &BigNumber::zero() && result.gcd(n) == BigNumber::one())
-        .ok_or(RetryFailed)
+        .ok_or(InternalError::CallingApplicationMistake(
+            CallerError::RetryFailed,
+        ))
 }
 
 // Returns x: BigNumber as a k256::Scalar mod k256_order

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::errors::{
-    InternalError::{CouldNotConvertToScalar, RetryFailed},
+    InternalError::{self, RetryFailed},
     Result,
 };
 use generic_array::GenericArray;
@@ -20,6 +20,7 @@ use merlin::Transcript;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Debug;
+use tracing::error;
 use zeroize::Zeroize;
 
 pub(crate) const CRYPTOGRAPHIC_RETRY_MAX: usize = 500usize;
@@ -136,8 +137,6 @@ pub(crate) fn random_plusminus_by_size_with_minimum<R: RngCore + CryptoRng>(
     max: usize,
     min: usize,
 ) -> crate::errors::Result<BigNumber> {
-    use crate::errors::InternalError;
-
     if min >= max {
         tracing::error!(
             "Can't sample from specified range because lower bound is not smaller
@@ -218,6 +217,7 @@ pub(crate) fn random_bn_in_z_star<R: RngCore + CryptoRng>(
         .ok_or(RetryFailed)
 }
 
+// Returns x: BigNumber as a k256::Scalar mod k256_order
 pub(crate) fn bn_to_scalar(x: &BigNumber) -> Result<k256::Scalar> {
     // Take (mod q)
     let order = k256_order();
@@ -230,7 +230,10 @@ pub(crate) fn bn_to_scalar(x: &BigNumber) -> Result<k256::Scalar> {
     let mut ret: k256::Scalar = Option::from(k256::Scalar::from_repr(
         GenericArray::clone_from_slice(&slice),
     ))
-    .ok_or(CouldNotConvertToScalar)?;
+    .ok_or_else(|| {
+        error!("Failed to convert BigNumber into k256::Scalar");
+        InternalError::InternalInvariantFailed
+    })?;
 
     // Make sure to negate the scalar if the original input was negative
     if x < &BigNumber::zero() {

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -204,7 +204,7 @@ impl Proof for PiAffgProof {
 
         if e != self.e {
             warn!("Fiat-Shamir consistency check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Do equality checks
@@ -217,7 +217,7 @@ impl Proof for PiAffgProof {
         };
         if !eq_check_1 {
             warn!("eq_check_1 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_2 = {
@@ -227,7 +227,7 @@ impl Proof for PiAffgProof {
         };
         if !eq_check_2 {
             warn!("eq_check_2 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_3 = {
@@ -238,7 +238,7 @@ impl Proof for PiAffgProof {
         };
         if !eq_check_3 {
             warn!("eq_check_3 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_4 = {
@@ -251,7 +251,7 @@ impl Proof for PiAffgProof {
         };
         if !eq_check_4 {
             warn!("eq_check_4 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_5 = {
@@ -264,7 +264,7 @@ impl Proof for PiAffgProof {
         };
         if !eq_check_5 {
             warn!("eq_check_5 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Do range check
@@ -273,11 +273,11 @@ impl Proof for PiAffgProof {
         let ell_prime_bound = BigNumber::one() << (ELL_PRIME + EPSILON);
         if self.z1 < -ell_bound.clone() || self.z1 > ell_bound {
             warn!("self.z1 > ell_bound check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         if self.z2 < -ell_prime_bound.clone() || self.z2 > ell_prime_bound {
             warn!("self.z2 > ell_prime_bound check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -139,10 +139,19 @@ impl Proof for PiAffgProof {
         // Sample beta from 2^{ELL_PRIME + EPSILON}.
         let beta = random_plusminus_by_size(rng, ELL_PRIME + EPSILON);
 
-        let (b, r) = input.pk0.encrypt(rng, &beta)?;
-        let A = input.pk0.multiply_and_add(&alpha, &input.C, &b)?;
+        let (b, r) = input
+            .pk0
+            .encrypt(rng, &beta)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
+        let A = input
+            .pk0
+            .multiply_and_add(&alpha, &input.C, &b)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
         let B_x = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
-        let (B_y, r_y) = input.pk1.encrypt(rng, &beta)?;
+        let (B_y, r_y) = input
+            .pk1
+            .encrypt(rng, &beta)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
         let (E, gamma) = input
             .setup_params
             .scheme()
@@ -210,9 +219,18 @@ impl Proof for PiAffgProof {
         // Do equality checks
 
         let eq_check_1 = {
-            let a = input.pk0.encrypt_with_nonce(&self.z2, &self.w)?;
-            let lhs = input.pk0.multiply_and_add(&self.z1, &input.C, &a)?;
-            let rhs = input.pk0.multiply_and_add(&self.e, &input.D, &self.A)?;
+            let a = input
+                .pk0
+                .encrypt_with_nonce(&self.z2, &self.w)
+                .map_err(|_| InternalError::ProtocolError)?;
+            let lhs = input
+                .pk0
+                .multiply_and_add(&self.z1, &input.C, &a)
+                .map_err(|_| InternalError::ProtocolError)?;
+            let rhs = input
+                .pk0
+                .multiply_and_add(&self.e, &input.D, &self.A)
+                .map_err(|_| InternalError::ProtocolError)?;
             lhs == rhs
         };
         if !eq_check_1 {
@@ -231,9 +249,15 @@ impl Proof for PiAffgProof {
         }
 
         let eq_check_3 = {
-            let lhs = input.pk1.encrypt_with_nonce(&self.z2, &self.w_y)?;
+            let lhs = input
+                .pk1
+                .encrypt_with_nonce(&self.z2, &self.w_y)
+                .map_err(|_| InternalError::ProtocolError)?;
 
-            let rhs = input.pk1.multiply_and_add(&self.e, &input.Y, &self.B_y)?;
+            let rhs = input
+                .pk1
+                .multiply_and_add(&self.e, &input.Y, &self.B_y)
+                .map_err(|_| InternalError::ProtocolError)?;
             lhs == rhs
         };
         if !eq_check_3 {
@@ -331,23 +355,23 @@ mod tests {
         x: &BigNumber,
         y: &BigNumber,
     ) -> Result<(PiAffgProof, PiAffgInput, Transcript)> {
-        let (decryption_key_0, _, _) = DecryptionKey::new(rng)?;
+        let (decryption_key_0, _, _) = DecryptionKey::new(rng).unwrap();
         let pk0 = decryption_key_0.encryption_key();
 
-        let (decryption_key_1, _, _) = DecryptionKey::new(rng)?;
+        let (decryption_key_1, _, _) = DecryptionKey::new(rng).unwrap();
         let pk1 = decryption_key_1.encryption_key();
 
         let g = k256::ProjectivePoint::GENERATOR;
 
         let X = CurvePoint(g * utils::bn_to_scalar(x)?);
-        let (Y, rho_y) = pk1.encrypt(rng, y)?;
+        let (Y, rho_y) = pk1.encrypt(rng, y).unwrap();
 
         let C = pk0.random_ciphertext(rng);
 
         // Compute D = C^x * (1 + N0)^y rho^N0 (mod N0^2)
         let (D, rho) = {
-            let (D_intermediate, rho) = pk0.encrypt(rng, y)?;
-            let D = pk0.multiply_and_add(x, &C, &D_intermediate)?;
+            let (D_intermediate, rho) = pk0.encrypt(rng, y).unwrap();
+            let D = pk0.multiply_and_add(x, &C, &D_intermediate).unwrap();
             (D, rho)
         };
 

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -205,7 +205,7 @@ impl Proof for PiEncProof {
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
         if e != self.challenge {
             warn!("Fiat-Shamir didn't verify");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Check that the plaintext and nonce responses are well-formed (e.g. that the
@@ -223,7 +223,7 @@ impl Proof for PiEncProof {
         };
         if !ciphertext_mask_is_well_formed {
             warn!("ciphertext mask check (first equality check) failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Check that the plaintext and commitment randomness responses are well formed
@@ -243,14 +243,14 @@ impl Proof for PiEncProof {
         };
         if !responses_match_commitments {
             warn!("response validation check (second equality check) failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Make sure the ciphertext response is in range
         let bound = BigNumber::one() << (ELL + EPSILON);
         if self.plaintext_response < -bound.clone() || self.plaintext_response > bound {
             warn!("bounds check on plaintext response failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -141,7 +141,10 @@ impl Proof for PiEncProof {
                 .scheme()
                 .commit(&secret.plaintext, ELL, rng);
         // Encrypt the mask for the plaintext (aka `A, r`)
-        let (ciphertext_mask, nonce_mask) = input.encryption_key.encrypt(rng, &plaintext_mask)?;
+        let (ciphertext_mask, nonce_mask) = input
+            .encryption_key
+            .encrypt(rng, &plaintext_mask)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
         // Commit to the mask for the plaintext (aka `C`)
         let (plaintext_mask_commit, gamma) =
             input
@@ -213,12 +216,12 @@ impl Proof for PiEncProof {
         let ciphertext_mask_is_well_formed = {
             let lhs = input
                 .encryption_key
-                .encrypt_with_nonce(&self.plaintext_response, &self.nonce_response)?;
-            let rhs = input.encryption_key.multiply_and_add(
-                &e,
-                &input.ciphertext,
-                &self.ciphertext_mask,
-            )?;
+                .encrypt_with_nonce(&self.plaintext_response, &self.nonce_response)
+                .map_err(|_| InternalError::ProtocolError)?;
+            let rhs = input
+                .encryption_key
+                .multiply_and_add(&e, &input.ciphertext, &self.ciphertext_mask)
+                .map_err(|_| InternalError::ProtocolError)?;
             lhs == rhs
         };
         if !ciphertext_mask_is_well_formed {
@@ -299,10 +302,10 @@ mod tests {
         rng: &mut R,
         plaintext: BigNumber,
     ) -> Result<(PiEncProof, PiEncInput)> {
-        let (decryption_key, _, _) = DecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = DecryptionKey::new(rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
-        let (ciphertext, nonce) = encryption_key.encrypt(rng, &plaintext)?;
+        let (ciphertext, nonce) = encryption_key.encrypt(rng, &plaintext).unwrap();
         let setup_params = VerifiedRingPedersen::gen(rng, &())?;
 
         let input = PiEncInput {
@@ -496,12 +499,12 @@ mod tests {
         let rng = &mut init_testing();
 
         // Form common inputs
-        let (decryption_key, _, _) = DecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = DecryptionKey::new(rng).unwrap();
         let encryption_key = decryption_key.encryption_key();
 
         // Form secret input
         let plaintext = random_plusminus_by_size(rng, ELL);
-        let (ciphertext, nonce) = encryption_key.encrypt(rng, &plaintext)?;
+        let (ciphertext, nonce) = encryption_key.encrypt(rng, &plaintext).unwrap();
         let setup_params = VerifiedRingPedersen::extract(&decryption_key, &(), rng)?;
 
         let input = PiEncInput {
@@ -543,7 +546,7 @@ mod tests {
         assert!(proof.verify(&input, &(), &mut transcript).is_err());
 
         // Forming with the wrong nonce fails
-        let (_, wrong_nonce) = encryption_key.encrypt(rng, &plaintext)?;
+        let (_, wrong_nonce) = encryption_key.encrypt(rng, &plaintext).unwrap();
         assert_ne!(wrong_nonce, nonce);
         let mut transcript = Transcript::new(b"PiEncProof");
         let proof = PiEncProof::prove(
@@ -576,7 +579,7 @@ mod tests {
         assert!(proof.verify(&input, &(), &mut transcript).is_ok());
 
         // Verification fails with the wrong setup params
-        let (bad_decryption_key, _, _) = DecryptionKey::new(&mut rng)?;
+        let (bad_decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let bad_setup_params = VerifiedRingPedersen::extract(&bad_decryption_key, &(), &mut rng)?;
         let setup_params = input.setup_params;
         input.setup_params = bad_setup_params;
@@ -585,7 +588,7 @@ mod tests {
         input.setup_params = setup_params;
 
         // Verification fails with the wrong encryption key
-        let bad_encryption_key = DecryptionKey::new(&mut rng)?.0.encryption_key();
+        let bad_encryption_key = DecryptionKey::new(&mut rng).unwrap().0.encryption_key();
         let encryption_key = input.encryption_key;
         input.encryption_key = bad_encryption_key;
         let mut transcript = Transcript::new(b"PiEncProof");
@@ -593,7 +596,7 @@ mod tests {
         input.encryption_key = encryption_key;
 
         // Verification fails with the wrong ciphertext
-        let (bad_ciphertext, _) = input.encryption_key.encrypt(&mut rng, &plaintext)?;
+        let (bad_ciphertext, _) = input.encryption_key.encrypt(&mut rng, &plaintext).unwrap();
         let ciphertext = input.ciphertext;
         input.ciphertext = bad_ciphertext;
         let mut transcript = Transcript::new(b"PiEncProof");

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -174,7 +174,7 @@ impl Proof for PiFacProof {
         };
         if !eq_check_1 {
             warn!("eq_check_1 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_2 = {
@@ -184,7 +184,7 @@ impl Proof for PiFacProof {
         };
         if !eq_check_2 {
             warn!("eq_check_2 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let eq_check_3 = {
@@ -201,7 +201,7 @@ impl Proof for PiFacProof {
         };
         if !eq_check_3 {
             warn!("eq_check_3 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let sqrt_N0 = sqrt(&input.N0);
@@ -211,11 +211,11 @@ impl Proof for PiFacProof {
         let z_bound = &sqrt_N0 * &two_ell_eps;
         if self.z1 < -z_bound.clone() || self.z1 > z_bound {
             warn!("self.z1 > z_bound check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         if self.z2 < -z_bound.clone() || self.z2 > z_bound {
             warn!("self.z2 > z_bound check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -220,7 +220,10 @@ impl Proof for PiLogProof {
             input.ring_pedersen.commit(&secret.plaintext, ELL, rng);
         // Encrypt the random plaintext using Paillier (producing variables `A` and `r`
         // in the paper).
-        let (mask_ciphertext, mask_nonce) = input.prover_encryption_key.encrypt(rng, &mask)?;
+        let (mask_ciphertext, mask_nonce) = input
+            .prover_encryption_key
+            .encrypt(rng, &mask)
+            .map_err(|_| InternalError::InternalInvariantFailed)?;
         // Commit to the random plaintext using discrete log (`Y` in the paper).
         let mask_dlog_commit = input.generator.multiply_by_scalar(&mask)?;
         // Commit to the random plaintext using ring-Pedersen (producing variables `D`
@@ -290,12 +293,12 @@ impl Proof for PiLogProof {
         let paillier_encryption_is_valid = {
             let lhs = input
                 .prover_encryption_key
-                .encrypt_with_nonce(&self.plaintext_response, &self.nonce_response)?;
-            let rhs = input.prover_encryption_key.multiply_and_add(
-                &self.challenge,
-                &input.ciphertext,
-                &self.mask_ciphertext,
-            )?;
+                .encrypt_with_nonce(&self.plaintext_response, &self.nonce_response)
+                .map_err(|_| InternalError::ProtocolError)?;
+            let rhs = input
+                .prover_encryption_key
+                .multiply_and_add(&self.challenge, &input.ciphertext, &self.mask_ciphertext)
+                .map_err(|_| InternalError::ProtocolError)?;
             lhs == rhs
         };
         if !paillier_encryption_is_valid {
@@ -358,13 +361,13 @@ mod tests {
         rng: &mut R,
         x: &BigNumber,
     ) -> Result<(PiLogProof, CommonInput, Transcript)> {
-        let (decryption_key, _, _) = DecryptionKey::new(rng)?;
+        let (decryption_key, _, _) = DecryptionKey::new(rng).unwrap();
         let pk = decryption_key.encryption_key();
 
         let g = CurvePoint(k256::ProjectivePoint::GENERATOR);
 
         let X = CurvePoint(g.0 * utils::bn_to_scalar(x)?);
-        let (C, rho) = pk.encrypt(rng, x)?;
+        let (C, rho) = pk.encrypt(rng, x).unwrap();
 
         let setup_params = VerifiedRingPedersen::gen(rng, &())?;
 

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -283,7 +283,7 @@ impl Proof for PiLogProof {
         // ... and check that it's the correct challenge.
         if challenge != self.challenge {
             warn!("Fiat-Shamir consistency check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Check that the Paillier encryption of the secret plaintext is valid.
@@ -300,7 +300,7 @@ impl Proof for PiLogProof {
         };
         if !paillier_encryption_is_valid {
             warn!("paillier encryption check (first equality check) failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         // Check that the group exponentiation of the secret plaintext is valid.
         let group_exponentiation_is_valid = {
@@ -313,7 +313,7 @@ impl Proof for PiLogProof {
         };
         if !group_exponentiation_is_valid {
             warn!("group exponentiation check (second equality check) failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Check that the ring-Pedersen commitment of the secret plaintext is valid.
@@ -330,14 +330,14 @@ impl Proof for PiLogProof {
         };
         if !ring_pedersen_commitment_is_valid {
             warn!("ring Pedersen commitment check (third equality check) failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Do a range check on the plaintext response, which validates that the
         // plaintext falls within the same range.
         if !within_bound_by_size(&self.plaintext_response, ELL + EPSILON) {
             warn!("plaintext range check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -139,7 +139,7 @@ impl Proof for PiModProof {
                     self.elements.len(),
                     LAMBDA,
                 );
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
             Ordering::Greater => {
                 warn!(
@@ -147,7 +147,7 @@ impl Proof for PiModProof {
                     self.elements.len(),
                     LAMBDA
                 );
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
             Ordering::Equal => {}
         }
@@ -155,12 +155,12 @@ impl Proof for PiModProof {
         // Verify that N is an odd composite number
         if &input.N % BigNumber::from(2u64) == BigNumber::zero() {
             warn!("N is even");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         if input.N.is_prime() {
             warn!("N is not composite");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         Self::fill_transcript(transcript, context, input, &self.w)?;
 
@@ -169,29 +169,29 @@ impl Proof for PiModProof {
             let y = positive_bn_random_from_transcript(transcript, &input.N);
             if y != elements.y {
                 warn!("y does not match Fiat-Shamir challenge");
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
 
             let y_candidate = modpow(&elements.z, &input.N, &input.N);
             if elements.y != y_candidate {
                 warn!("z^N != y (mod N)");
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
 
             if elements.a != 0 && elements.a != 1 {
                 warn!("a not in {{0,1}}");
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
 
             if elements.b != 0 && elements.b != 1 {
                 warn!("b not in {{0,1}}");
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
 
             let y_prime = y_prime_from_y(&elements.y, &self.w, elements.a, elements.b, &input.N);
             if modpow(&elements.x, &BigNumber::from(4u64), &input.N) != y_prime {
                 warn!("x^4 != y' (mod N)");
-                return Err(InternalError::FailedToVerifyProof);
+                return Err(InternalError::ProtocolError);
             }
         }
 

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -105,8 +105,8 @@ impl Proof for PiModProof {
             // Compute phi(N) = (p-1) * (q-1)
             let phi_n = (&secret.p - 1) * (&secret.q - 1);
             let exp = input.N.invert(&phi_n).ok_or_else(|| {
-                error!("Could not invert a BigNumber");
-                InternalError::CouldNotGenerateProof
+                error!("Could not invert N");
+                InternalError::InternalInvariantFailed
             })?;
             let z = modpow(&y, &exp, &input.N);
 
@@ -267,7 +267,7 @@ fn square_roots_mod_prime(n: &BigNumber, p: &BigNumber) -> Result<(BigNumber, Bi
         return Ok((r, neg_r));
     }
     warn!("Could not find square roots modulo n");
-    Err(InternalError::CouldNotGenerateProof)
+    Err(InternalError::InternalInvariantFailed)
 }
 
 // Finds an (x,y) such that ax + by = 1, or returns error if gcd(a,b) != 1
@@ -277,7 +277,7 @@ fn extended_euclidean(a: &BigNumber, b: &BigNumber) -> Result<(BigNumber, BigNum
 
     if result.gcd != BigNumber::one() {
         warn!("Elements are not coprime");
-        Err(InternalError::CouldNotGenerateProof)?
+        Err(InternalError::InternalInvariantFailed)?
     }
 
     Ok((result.x, result.y))
@@ -304,7 +304,7 @@ fn chinese_remainder_theorem(
     let zero = &BigNumber::zero();
     if a1 >= p || a1 < zero || a2 >= q || a2 < zero {
         warn!("One or more of the integer inputs to the Chinese remainder theorem were outside the expected range");
-        Err(InternalError::CouldNotGenerateProof)?
+        Err(InternalError::InternalInvariantFailed)?
     }
     let (z, w) = extended_euclidean(p, q)?;
     let x = a1 * w * q + a2 * z * p;
@@ -408,7 +408,7 @@ fn y_prime_combinations(
         error!(
             "Could not find uniqueness for fourth roots combination in Paillier-Blum modulus proof"
         );
-        return Err(InternalError::CouldNotGenerateProof);
+        return Err(InternalError::InternalInvariantFailed);
     }
 
     Ok((success_a, success_b, ret))
@@ -470,7 +470,7 @@ mod tests {
                     assert_eq!(modpow(&r1, &BigNumber::from(2), &p), a);
                     assert_eq!(modpow(&r2, &BigNumber::from(2), &p), a);
                 }
-                Err(InternalError::CouldNotGenerateProof) => {
+                Err(InternalError::InternalInvariantFailed) => {
                     assert_ne!(a_p, 1);
                 }
                 Err(_) => {
@@ -575,21 +575,21 @@ mod tests {
         let a2 = BigNumber::from_rng(&q, &mut rng);
         assert_eq!(
             chinese_remainder_theorem(a1, &a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // a1 > p
         let a1 = a1 + BigNumber::one();
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // a1 < 0
         let a1 = -BigNumber::from_rng(&p, &mut rng);
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // a2 = q
@@ -597,21 +597,21 @@ mod tests {
         let a2 = &q;
         assert_eq!(
             chinese_remainder_theorem(&a1, a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // a2 > q
         let a2 = a2 + BigNumber::one();
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // a2 < 0
         let a2 = -BigNumber::from_rng(&q, &mut rng);
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
     }
 
@@ -632,21 +632,21 @@ mod tests {
         let bad_q = &p;
         assert_eq!(
             chinese_remainder_theorem(&a1, &a1, &p, bad_q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // p = kq for some k
         let mult_p = &q + &q;
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &mult_p, &q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         // q = kp for some k
         let mult_q = &p + &p;
         assert_eq!(
             chinese_remainder_theorem(&a1, &a2, &p, &mult_q),
-            Err(InternalError::CouldNotGenerateProof)
+            Err(InternalError::InternalInvariantFailed)
         );
 
         assert!(chinese_remainder_theorem(&a1, &a2, &p, &q).is_ok());

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -153,13 +153,13 @@ impl Proof for PiPrmProof {
             || self.responses.len() != SOUNDNESS
         {
             warn!("length of values provided does not match soundness parameter");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         let challenges = generate_challenge_bytes(input, &self.commitments, context, transcript)?;
         // Check Fiat-Shamir consistency.
         if challenges != self.challenge_bytes.as_slice() {
             warn!("Fiat-Shamir does not verify");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         let is_sound = challenges
@@ -180,7 +180,7 @@ impl Proof for PiPrmProof {
 
         if !is_sound {
             warn!("response validation check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -196,7 +196,7 @@ mod tests {
     fn random_ring_pedersen_proof<R: RngCore + CryptoRng>(
         rng: &mut R,
     ) -> Result<(RingPedersen, PiPrmProof, BigNumber, BigNumber)> {
-        let (sk, _, _) = DecryptionKey::new(rng)?;
+        let (sk, _, _) = DecryptionKey::new(rng).unwrap();
         let (scheme, lambda, totient) = RingPedersen::extract(&sk, rng)?;
         let secrets = PiPrmSecret::new(lambda.clone(), totient.clone());
         let mut transcript = Transcript::new(b"PiPrmProof");

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -117,7 +117,7 @@ impl Proof for PiSchProof {
         let e = positive_bn_random_from_transcript(transcript, &input.q);
         if e != self.e {
             warn!("Fiat-Shamir consistency check failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         // Do equality checks
@@ -129,7 +129,7 @@ impl Proof for PiSchProof {
         };
         if !eq_check_1 {
             warn!("eq_check_1 failed");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
 
         Ok(())

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -19,7 +19,7 @@ use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use tracing::warn;
+use tracing::{error, warn};
 use utils::CurvePoint;
 use zeroize::ZeroizeOnDrop;
 
@@ -169,7 +169,12 @@ impl PiSchProof {
     }
     pub(crate) fn from_message(message: &Message) -> Result<Self> {
         if message.message_type() != MessageType::Keygen(KeygenMessageType::R3Proof) {
-            return Err(InternalError::MisroutedMessage);
+            error!(
+                "Encountered unexpected MessageType. Expected {:?}, Got {:?}",
+                MessageType::Keygen(KeygenMessageType::R3Proof),
+                message.message_type()
+            );
+            return Err(InternalError::InternalInvariantFailed);
         }
         let keygen_decommit: PiSchProof = deserialize!(&message.unverified_bytes)?;
         Ok(keygen_decommit)

--- a/src/zkstar.rs
+++ b/src/zkstar.rs
@@ -27,20 +27,20 @@ impl ZStarNBuilder {
     pub fn validate(&self, unverified: ZStarNUnverified) -> Result<ZStarN, InternalError> {
         if unverified.value().is_zero() {
             warn!("Elements of the multiplicative group  ZK*_N cannot be zero");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         } else if unverified.value() > self.modulus() {
             warn!(
                 "Elements of the multiplicative group ZK*_N cannot be larger than the RSA modulus"
             );
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         } else if unverified.value() < &BigNumber::zero() {
             warn!("Elements of the multiplicative group ZK*_N cannot be negative");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         let result = unverified.value().gcd(self.modulus());
         if result != BigNumber::one() {
             warn!("Elements are not coprime");
-            return Err(InternalError::FailedToVerifyProof);
+            return Err(InternalError::ProtocolError);
         }
         Ok(ZStarN {
             value: unverified.value().to_owned(),


### PR DESCRIPTION
Addresses a component of #157 by further reducing the number of error types. The lost context is instead replaced by logging

Also closes #266 