### PR TITLE
Add ECDSA parameters to context including group order and base point.

### DIFF
--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -50,7 +50,7 @@ impl AuxInfoProof {
         q: &BigNumber,
     ) -> Result<Self> {
         let mut pimod_transcript = Transcript::new(b"PaillierBlumModulusProof");
-        pimod_transcript.append_message(b"PiMod ProofContext", &context.as_bytes());
+        pimod_transcript.append_message(b"PiMod ProofContext", &context.as_bytes()?);
         pimod_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pimod_transcript.append_message(b"rho", &rho);
         let pimod = PiModProof::prove(
@@ -61,7 +61,7 @@ impl AuxInfoProof {
             rng,
         )?;
         let mut pifac_transcript = Transcript::new(b"PiFacProof");
-        pifac_transcript.append_message(b"PiFac ProofContext", &context.as_bytes());
+        pifac_transcript.append_message(b"PiFac ProofContext", &context.as_bytes()?);
         pifac_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pifac_transcript.append_message(b"rho", &rho);
         let pifac = PiFacProof::prove(
@@ -85,13 +85,13 @@ impl AuxInfoProof {
         N: &BigNumber,
     ) -> Result<()> {
         let mut pimod_transcript = Transcript::new(b"PaillierBlumModulusProof");
-        pimod_transcript.append_message(b"PiMod ProofContext", &context.as_bytes());
+        pimod_transcript.append_message(b"PiMod ProofContext", &context.as_bytes()?);
         pimod_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pimod_transcript.append_message(b"rho", &rho);
         self.pimod
             .verify(&PiModInput::new(N), context, &mut pimod_transcript)?;
         let mut pifac_transcript = Transcript::new(b"PiFacProof");
-        pifac_transcript.append_message(b"PiFac ProofContext", &context.as_bytes());
+        pifac_transcript.append_message(b"PiFac ProofContext", &context.as_bytes()?);
         pifac_transcript.append_message(b"Session Id", &serialize!(&sid)?);
         pifac_transcript.append_message(b"rho", &rho);
         self.pifac

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -12,7 +12,7 @@ use crate::{
     local_storage::LocalStorage,
     messages::{BroadcastMessageType, Message, MessageType},
     participant::{InnerProtocolParticipant, ProcessOutcome, ProtocolParticipant},
-    protocol::{ParticipantIdentifier, ProtocolType},
+    protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once_per_tag, Identifier,
 };
 use rand::{CryptoRng, RngCore};
@@ -153,13 +153,11 @@ impl ProtocolParticipant for BroadcastParticipant {
 }
 
 impl InnerProtocolParticipant for BroadcastParticipant {
-    type Context = Vec<ParticipantIdentifier>;
+    type Context = SharedContext;
 
     /// This method is never used.
     fn retrieve_context(&self) -> <Self as InnerProtocolParticipant>::Context {
-        let mut ids = self.all_participants();
-        ids.sort();
-        ids
+        SharedContext::collect(self)
     }
 
     fn local_storage(&self) -> &LocalStorage {

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -16,7 +16,7 @@ use crate::{
     local_storage::LocalStorage,
     messages::{KeygenMessageType, Message, MessageType},
     participant::{Broadcast, InnerProtocolParticipant, ProcessOutcome, ProtocolParticipant},
-    protocol::{ParticipantIdentifier, ProtocolType},
+    protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once,
     utils::k256_order,
     zkp::{
@@ -191,12 +191,10 @@ impl ProtocolParticipant for KeygenParticipant {
 }
 
 impl InnerProtocolParticipant for KeygenParticipant {
-    type Context = Vec<ParticipantIdentifier>;
+    type Context = SharedContext;
 
     fn retrieve_context(&self) -> <Self as InnerProtocolParticipant>::Context {
-        let mut ids = self.all_participants();
-        ids.sort();
-        ids
+        SharedContext::collect(self)
     }
 
     fn local_storage(&self) -> &LocalStorage {

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -24,7 +24,7 @@ use crate::{
         round_three::{Private as RoundThreePrivate, Public as RoundThreePublic, RoundThreeInput},
         round_two::{Private as RoundTwoPrivate, Public as RoundTwoPublic},
     },
-    protocol::{ParticipantIdentifier, ProtocolType},
+    protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     utils::{bn_to_scalar, k256_order, random_plusminus_by_size, random_positive_bn},
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof, PiAffgSecret},
@@ -274,12 +274,10 @@ impl ProtocolParticipant for PresignParticipant {
 }
 
 impl InnerProtocolParticipant for PresignParticipant {
-    type Context = Vec<ParticipantIdentifier>;
+    type Context = SharedContext;
 
     fn retrieve_context(&self) -> <Self as InnerProtocolParticipant>::Context {
-        let mut ids = self.all_participants();
-        ids.sort();
-        ids
+        SharedContext::collect(self)
     }
 
     fn local_storage(&self) -> &LocalStorage {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -16,12 +16,14 @@ use crate::{
     errors::{CallerError, InternalError, Result},
     keygen::keyshare::{KeySharePrivate, KeySharePublic},
     messages::MessageType,
-    participant::ProtocolParticipant,
+    participant::{InnerProtocolParticipant, ProtocolParticipant},
     presign::record::PresignRecord,
+    utils::{k256_order, CurvePoint},
     zkp::ProofContext,
     Message,
 };
 use k256::elliptic_curve::{Field, IsHigh};
+use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -339,9 +341,48 @@ impl ParticipantIdentifier {
     }
 }
 
-impl ProofContext for Vec<ParticipantIdentifier> {
-    fn as_bytes(&self) -> Vec<u8> {
-        self.iter().flat_map(|pid| pid.0.to_le_bytes()).collect()
+/// The SharedContext contains fixed known parameters accross the entire
+/// protocol. It does not however contain the entire protocol context.
+pub struct SharedContext {
+    participants: Vec<ParticipantIdentifier>,
+    generator: CurvePoint,
+    order: BigNumber,
+}
+impl ProofContext for SharedContext {
+    fn as_bytes(&self) -> Result<Vec<u8>> {
+        Ok([
+            self.participants
+                .iter()
+                .flat_map(|pid| pid.0.to_le_bytes())
+                .collect(),
+            bincode::serialize(&self.generator)
+                .map_err(|_| InternalError::InternalInvariantFailed)?,
+            self.order.to_bytes(),
+        ]
+        .concat())
+    }
+}
+
+impl SharedContext {
+    pub(crate) fn collect<P: InnerProtocolParticipant>(p: &P) -> Self {
+        let mut participants = p.all_participants();
+        participants.sort();
+        let generator = CurvePoint::GENERATOR;
+        let order = k256_order();
+        SharedContext {
+            participants,
+            generator,
+            order,
+        }
+    }
+    #[cfg(test)]
+    pub fn fill_context(mut participants: Vec<ParticipantIdentifier>) -> Self {
+        participants.sort();
+        SharedContext {
+            participants,
+            generator: CurvePoint::GENERATOR,
+            order: k256_order(),
+        }
     }
 }
 

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -30,13 +30,13 @@ use serde::{de::DeserializeOwned, Serialize};
 ///
 /// This context can be turned into bytes and appended to a [`Transcript`].
 pub(crate) trait ProofContext {
-    fn as_bytes(&self) -> Vec<u8>;
+    fn as_bytes(&self) -> Result<Vec<u8>>;
 }
 
 #[cfg(test)]
 impl ProofContext for () {
-    fn as_bytes(&self) -> Vec<u8> {
-        vec![]
+    fn as_bytes(&self) -> Result<Vec<u8>> {
+        Ok(vec![])
     }
 }
 
@@ -44,8 +44,8 @@ impl ProofContext for () {
 struct BadContext {}
 #[cfg(test)]
 impl ProofContext for BadContext {
-    fn as_bytes(&self) -> Vec<u8> {
-        vec![8u8]
+    fn as_bytes(&self) -> Result<Vec<u8>> {
+        Ok(vec![8u8])
     }
 }
 

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -154,7 +154,7 @@ impl Proof for PiAffgProof {
             .commit(&beta, ELL + EPSILON, rng);
         let (T, mu) = input.setup_params.scheme().commit(&secret.y, ELL, rng);
 
-        Self::fill_out_transcript(transcript, context, input, &S, &T, &A, &B_x, &B_y, &E, &F);
+        Self::fill_transcript(transcript, context, input, &S, &T, &A, &B_x, &B_y, &E, &F)?;
 
         // Verifier samples e in +- q (where q is the group order)
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
@@ -195,10 +195,10 @@ impl Proof for PiAffgProof {
         context: &impl ProofContext,
         transcript: &mut Transcript,
     ) -> Result<()> {
-        Self::fill_out_transcript(
+        Self::fill_transcript(
             transcript, context, input, &self.S, &self.T, &self.A, &self.B_x, &self.B_y, &self.E,
             &self.F,
-        );
+        )?;
         // Verifier samples e in +- q (where q is the group order)
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
 
@@ -286,7 +286,7 @@ impl Proof for PiAffgProof {
 
 impl PiAffgProof {
     #[allow(clippy::too_many_arguments)]
-    fn fill_out_transcript(
+    fn fill_transcript(
         transcript: &mut Transcript,
         context: &impl ProofContext,
         input: &PiAffgInput,
@@ -297,10 +297,10 @@ impl PiAffgProof {
         B_y: &Ciphertext,
         E: &Commitment,
         F: &Commitment,
-    ) {
+    ) -> Result<()> {
         // First, do Fiat-Shamir consistency check
-        transcript.append_message(b"PiAffg ProofContext", &context.as_bytes());
-        transcript.append_message(b"PiAffg CommonInput", &serialize!(&input).unwrap());
+        transcript.append_message(b"PiAffg ProofContext", &context.as_bytes()?);
+        transcript.append_message(b"PiAffg CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(S, T, A, B_x, B_y, E, F)",
             &[
@@ -314,6 +314,7 @@ impl PiAffgProof {
             ]
             .concat(),
         );
+        Ok(())
     }
 }
 #[cfg(test)]

--- a/src/zkp/pienc.rs
+++ b/src/zkp/pienc.rs
@@ -150,7 +150,7 @@ impl Proof for PiEncProof {
                 .commit(&plaintext_mask, ELL + EPSILON, rng);
 
         // Fill out the transcript with our fresh commitments...
-        Self::fill_out_transcript(
+        Self::fill_transcript(
             transcript,
             context,
             input,
@@ -192,7 +192,7 @@ impl Proof for PiEncProof {
     ) -> Result<()> {
         // Check Fiat-Shamir challenge consistency: update the transcript with
         // commitments...
-        Self::fill_out_transcript(
+        Self::fill_transcript(
             transcript,
             context,
             input,
@@ -260,7 +260,7 @@ impl Proof for PiEncProof {
 impl PiEncProof {
     /// Update the [`Transcript`] with all the commitment values used in the
     /// proof.
-    fn fill_out_transcript(
+    fn fill_transcript(
         transcript: &mut Transcript,
         context: &impl ProofContext,
         input: &PiEncInput,
@@ -268,7 +268,7 @@ impl PiEncProof {
         ciphertext_mask: &Ciphertext,
         plaintext_mask_commit: &Commitment,
     ) -> Result<()> {
-        transcript.append_message(b"PiEnc Context", &context.as_bytes());
+        transcript.append_message(b"PiEnc Context", &context.as_bytes()?);
         transcript.append_message(b"PiEnc CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(S, A, C)",

--- a/src/zkp/pifac.rs
+++ b/src/zkp/pifac.rs
@@ -118,7 +118,7 @@ impl Proof for PiFacProof {
             rng,
         );
 
-        Self::fill_out_transcript(transcript, context, input, &P, &Q, &A, &B, &T, &sigma);
+        Self::fill_transcript(transcript, context, input, &P, &Q, &A, &B, &T, &sigma)?;
 
         // Verifier samples e in +- q (where q is the group order)
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
@@ -152,7 +152,7 @@ impl Proof for PiFacProof {
         context: &impl ProofContext,
         transcript: &mut Transcript,
     ) -> Result<()> {
-        Self::fill_out_transcript(
+        Self::fill_transcript(
             transcript,
             context,
             input,
@@ -162,7 +162,7 @@ impl Proof for PiFacProof {
             &self.B,
             &self.T,
             &self.sigma,
-        );
+        )?;
 
         // Verifier samples e in +- q (where q is the group order)
         let e = plusminus_bn_random_from_transcript(transcript, &k256_order());
@@ -224,7 +224,7 @@ impl Proof for PiFacProof {
 
 impl PiFacProof {
     #[allow(clippy::too_many_arguments)]
-    fn fill_out_transcript(
+    fn fill_transcript(
         transcript: &mut Transcript,
         context: &impl ProofContext,
         input: &PiFacInput,
@@ -234,9 +234,9 @@ impl PiFacProof {
         B: &Commitment,
         T: &Commitment,
         sigma: &CommitmentRandomness,
-    ) {
-        transcript.append_message(b"PiFac ProofContext", &context.as_bytes());
-        transcript.append_message(b"PiFac CommonInput", &serialize!(&input).unwrap());
+    ) -> Result<()> {
+        transcript.append_message(b"PiFac ProofContext", &context.as_bytes()?);
+        transcript.append_message(b"PiFac CommonInput", &serialize!(&input)?);
         transcript.append_message(
             b"(P, Q, A, B, T, sigma)",
             &[
@@ -249,6 +249,7 @@ impl PiFacProof {
             ]
             .concat(),
         );
+        Ok(())
     }
 }
 

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -144,7 +144,7 @@ fn generate_challenge(
     mask_dlog_commit: &CurvePoint,
     mask_commit: &Commitment,
 ) -> Result<BigNumber> {
-    transcript.append_message(b"PiLog ProofContext", &context.as_bytes());
+    transcript.append_message(b"PiLog ProofContext", &context.as_bytes()?);
     transcript.append_message(b"PiLog Common input", &serialize!(&common_input)?);
     transcript.append_message(
         b"(plaintext commit, mask encryption, mask dlog commit, mask commit)",

--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -95,7 +95,7 @@ impl Proof for PiModProof {
             w = random_positive_bn(rng, &input.N);
         }
 
-        Self::fill_transcript(transcript, context, input, &w);
+        Self::fill_transcript(transcript, context, input, &w)?;
 
         let mut elements = vec![];
         for _ in 0..LAMBDA {
@@ -162,7 +162,7 @@ impl Proof for PiModProof {
             warn!("N is not composite");
             return Err(InternalError::FailedToVerifyProof);
         }
-        Self::fill_transcript(transcript, context, input, &self.w);
+        Self::fill_transcript(transcript, context, input, &self.w)?;
 
         for elements in &self.elements {
             // First, check that y came from Fiat-Shamir transcript
@@ -205,10 +205,11 @@ impl PiModProof {
         context: &impl ProofContext,
         input: &PiModInput,
         w: &BigNumber,
-    ) {
-        transcript.append_message(b"PiMod ProofContext", &context.as_bytes());
-        transcript.append_message(b"PiMod CommonInput", &serialize!(&input).unwrap());
+    ) -> Result<()> {
+        transcript.append_message(b"PiMod ProofContext", &context.as_bytes()?);
+        transcript.append_message(b"PiMod CommonInput", &serialize!(&input)?);
         transcript.append_message(b"w", &w.to_bytes());
+        Ok(())
     }
 }
 // Compute regular mod

--- a/src/zkp/piprm.rs
+++ b/src/zkp/piprm.rs
@@ -89,7 +89,7 @@ fn generate_challenge_bytes(
     context: &impl ProofContext,
     transcript: &mut Transcript,
 ) -> Result<Vec<u8>> {
-    transcript.append_message(b"PiPrm ProofContext", &context.as_bytes());
+    transcript.append_message(b"PiPrm ProofContext", &context.as_bytes()?);
     transcript.append_message(b"PiPrm Common input", &serialize!(&input)?);
     transcript.append_message(b"PiPrm Commitments", &serialize!(&commitments)?);
     // Extract challenge bytes from the transcript.

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -92,7 +92,7 @@ impl Proof for PiSchProof {
         let alpha = crate::utils::random_positive_bn(rng, &input.q);
         let A = CurvePoint(input.g.0 * utils::bn_to_scalar(&alpha)?);
 
-        Self::fill_transcript(transcript, context, input, &A);
+        Self::fill_transcript(transcript, context, input, &A)?;
 
         // Verifier samples e in F_q
         let e = positive_bn_random_from_transcript(transcript, &input.q);
@@ -111,7 +111,7 @@ impl Proof for PiSchProof {
         transcript: &mut Transcript,
     ) -> Result<()> {
         // First check Fiat-Shamir challenge consistency
-        Self::fill_transcript(transcript, context, input, &self.A);
+        Self::fill_transcript(transcript, context, input, &self.A)?;
 
         // Verifier samples e in F_q
         let e = positive_bn_random_from_transcript(transcript, &input.q);
@@ -157,7 +157,7 @@ impl PiSchProof {
         let A = com.A;
         let mut local_transcript = transcript.clone();
 
-        Self::fill_transcript(&mut local_transcript, context, input, &A);
+        Self::fill_transcript(&mut local_transcript, context, input, &A)?;
 
         // Verifier samples e in F_q
         let e = positive_bn_random_from_transcript(&mut local_transcript, &input.q);
@@ -179,10 +179,11 @@ impl PiSchProof {
         context: &impl ProofContext,
         input: &PiSchInput,
         A: &CurvePoint,
-    ) {
-        transcript.append_message(b"PiSch ProofContext", &context.as_bytes());
-        transcript.append_message(b"PiSch CommonInput", &serialize!(&input).unwrap());
-        transcript.append_message(b"A", &serialize!(A).unwrap());
+    ) -> Result<()> {
+        transcript.append_message(b"PiSch ProofContext", &context.as_bytes()?);
+        transcript.append_message(b"PiSch CommonInput", &serialize!(&input)?);
+        transcript.append_message(b"A", &serialize!(A)?);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes #240: Add the participant ids and ECDSA group order and base point to the context in keygen, auxinfo and presign. 