### PR TITLE
update rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project relies on the `libpaillier` Rust crate using the GMP backend. GMP s
 
 ### Rust Dependencies and Versions
 
-The minimum supported stable Rust version is cargo 1.68.2. 
+The minimum supported stable Rust version is cargo 1.68.
 
 This library has been tested with GMP version 6.2.1.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable-2023-04-20"


### PR DESCRIPTION
Closes #300 

I added a rust toolchain file, but since this update doesn't actually introduce any changes we need to fix, I left the MSRV in the README as the previous version. Is that reasonable?

I also looked into renovate (link in issue) and it seems a lot more powerful than we need. I'm just going to add "make a new issue for the next version" as a task in each update issue and hopefully we can be self-perpetuating.