### PR TITLE
Add sid and input to ProtocolParticipant

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -18,7 +18,7 @@ use crate::{
     messages::{AuxinfoMessageType, Message, MessageType},
     paillier::DecryptionKey,
     participant::{Broadcast, InnerProtocolParticipant, ProcessOutcome, ProtocolParticipant},
-    protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
+    protocol::{Identifier, ParticipantIdentifier, ProtocolType, SharedContext},
     ring_pedersen::VerifiedRingPedersen,
     run_only_once,
 };
@@ -91,6 +91,10 @@ pub enum Status {
 
 #[derive(Debug)]
 pub struct AuxInfoParticipant {
+    /// The current session identifier
+    sid: Identifier,
+    /// The current protocol input
+    input: (),
     /// A unique identifier for this participant
     id: ParticipantIdentifier,
     /// A list of all other participant identifiers participating in the
@@ -111,12 +115,19 @@ impl ProtocolParticipant for AuxInfoParticipant {
     type Output = (Vec<AuxInfoPublic>, AuxInfoPrivate);
     type Status = Status;
 
-    fn new(id: ParticipantIdentifier, other_participant_ids: Vec<ParticipantIdentifier>) -> Self {
+    fn new(
+        sid: Identifier,
+        id: ParticipantIdentifier,
+        other_participant_ids: Vec<ParticipantIdentifier>,
+        input: Self::Input,
+    ) -> Self {
         Self {
+            sid,
+            input,
             id,
             other_participant_ids: other_participant_ids.clone(),
             local_storage: Default::default(),
-            broadcast_participant: BroadcastParticipant::new(id, other_participant_ids),
+            broadcast_participant: BroadcastParticipant::new(sid, id, other_participant_ids, input),
             status: Status::Initialized,
         }
     }
@@ -135,6 +146,14 @@ impl ProtocolParticipant for AuxInfoParticipant {
 
     fn other_ids(&self) -> &Vec<ParticipantIdentifier> {
         &self.other_participant_ids
+    }
+
+    fn sid(&self) -> Identifier {
+        self.sid
+    }
+
+    fn input(&self) -> &Self::Input {
+        &self.input
     }
 
     #[cfg_attr(feature = "flame_it", flame("auxinfo"))]
@@ -542,6 +561,8 @@ mod tests {
 
     impl AuxInfoParticipant {
         pub fn new_quorum<R: RngCore + CryptoRng>(
+            sid: Identifier,
+            input: (),
             quorum_size: usize,
             rng: &mut R,
         ) -> Result<Vec<Self>> {
@@ -559,7 +580,7 @@ mod tests {
                             other_ids.push(id);
                         }
                     }
-                    Self::new(participant_id, other_ids)
+                    Self::new(sid, participant_id, other_ids, input)
                 })
                 .collect::<Vec<AuxInfoParticipant>>();
             Ok(participants)
@@ -651,7 +672,8 @@ mod tests {
     fn test_run_auxinfo_protocol() -> Result<()> {
         let QUORUM_SIZE = 3;
         let mut rng = init_testing();
-        let mut quorum = AuxInfoParticipant::new_quorum(QUORUM_SIZE, &mut rng)?;
+        let sid = Identifier::random(&mut rng);
+        let mut quorum = AuxInfoParticipant::new_quorum(sid, (), QUORUM_SIZE, &mut rng)?;
         let mut inboxes = HashMap::new();
         for participant in &quorum {
             let _ = inboxes.insert(participant.id, vec![]);

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -54,6 +54,8 @@ pub enum Status {
 
 #[derive(Debug)]
 pub(crate) struct BroadcastParticipant {
+    /// The current session identifier
+    sid: Identifier,
     /// A unique identifier for this participant
     id: ParticipantIdentifier,
     /// A list of all other participant identifiers participating in the
@@ -90,8 +92,14 @@ impl ProtocolParticipant for BroadcastParticipant {
     type Output = BroadcastOutput;
     type Status = Status;
 
-    fn new(id: ParticipantIdentifier, other_participant_ids: Vec<ParticipantIdentifier>) -> Self {
+    fn new(
+        sid: Identifier,
+        id: ParticipantIdentifier,
+        other_participant_ids: Vec<ParticipantIdentifier>,
+        _input: Self::Input,
+    ) -> Self {
         Self {
+            sid,
             id,
             other_participant_ids,
             local_storage: Default::default(),
@@ -107,6 +115,13 @@ impl ProtocolParticipant for BroadcastParticipant {
         &self.other_participant_ids
     }
 
+    fn sid(&self) -> Identifier {
+        self.sid
+    }
+
+    fn input(&self) -> &Self::Input {
+        &()
+    }
     fn ready_type() -> MessageType {
         // I'm not totally confident since broadcast takes a different shape than the
         // other protocols, but this is definitely the first message in the

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -170,7 +170,7 @@ where
 /// protocol.
 pub trait ProtocolParticipant {
     /// Input type for a new protocol instance.
-    type Input: Debug;
+    type Input: Debug + Clone;
     /// Output type of a successful protocol execution.
     type Output: Debug;
     /// Type to determine status of protocol execution.
@@ -184,7 +184,12 @@ pub trait ProtocolParticipant {
     fn protocol_type() -> ProtocolType;
 
     /// Create a new [`ProtocolParticipant`] from the given ids.
-    fn new(id: ParticipantIdentifier, other_participant_ids: Vec<ParticipantIdentifier>) -> Self;
+    fn new(
+        sid: Identifier,
+        id: ParticipantIdentifier,
+        other_participant_ids: Vec<ParticipantIdentifier>,
+        input: Self::Input,
+    ) -> Self;
 
     /// Return the participant id
     fn id(&self) -> ParticipantIdentifier;
@@ -229,6 +234,12 @@ pub trait ProtocolParticipant {
 
     /// The status of the protocol execution.
     fn status(&self) -> &Self::Status;
+
+    /// The session identifier for the current session
+    fn sid(&self) -> Identifier;
+
+    /// The input of the current session
+    fn input(&self) -> &Self::Input;
 }
 
 pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {


### PR DESCRIPTION
Close #326 : Add the session identifier and input to `ProtocolParticipant` instantiations in `Keygen`, `Broadcast`, `Presign`, `Auxinfo`. These fields will later be incorporated into the different contexts.