### PR TITLE
Create PresignContext with AuxInfoPublic parameters.

### DIFF
--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -18,7 +18,6 @@ use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use tracing::{error, instrument};
-
 /// The private key corresponding to a given Participant's [`AuxInfoPublic`].
 ///
 /// # 🔒 Storage requirements

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -367,8 +367,9 @@ impl ParticipantIdentifier {
     }
 }
 
-/// The SharedContext contains fixed known parameters accross the entire
+/// The `SharedContext` contains fixed known parameters accross the entire
 /// protocol. It does not however contain the entire protocol context.
+#[derive(Debug)]
 pub struct SharedContext {
     sid: Identifier,
     participants: Vec<ParticipantIdentifier>,


### PR DESCRIPTION
Close #241 : Add AuxinfoPublic parameters to Presign specific context a long with shared global parameters defined by `SharedContext`.