### PR TITLE
Validate presign inputs

### DIFF
--- a/src/auxinfo/auxinfo_commit.rs
+++ b/src/auxinfo/auxinfo_commit.rs
@@ -94,7 +94,7 @@ impl CommitmentScheme {
         rng.fill_bytes(u_i.as_mut_slice());
 
         public_key.verify(&auxinfo_participant.retrieve_context())?;
-        if &auxinfo_participant.id() != public_key.participant() {
+        if auxinfo_participant.id() != public_key.participant() {
             error!("Created auxinfo commitment scheme with different participant IDs in the sender and public_key fields");
             return Err(InternalError::InternalInvariantFailed);
         }
@@ -122,7 +122,7 @@ impl CommitmentScheme {
         scheme.public_key.verify(context)?;
 
         // Owner must be consistent across message, public keys, and decommit
-        if *scheme.public_key.participant() != scheme.pid {
+        if scheme.public_key.participant() != scheme.pid {
             error!(
                 "Deserialized AuxInfoDecommit has different participant IDs in the sender ({}) and public_keys ({}) fields",
                 scheme.pid,

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -29,7 +29,6 @@ pub struct AuxInfoPrivate {
 }
 
 impl AuxInfoPrivate {
-    #[cfg(test)]
     pub(crate) fn encryption_key(&self) -> EncryptionKey {
         self.decryption_key.encryption_key()
     }
@@ -88,8 +87,8 @@ impl AuxInfoPublic {
         &self.params
     }
 
-    pub(crate) fn participant(&self) -> &ParticipantIdentifier {
-        &self.participant
+    pub(crate) fn participant(&self) -> ParticipantIdentifier {
+        self.participant
     }
 
     /// Verifies that the public key's modulus matches the ZKSetupParameters

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -111,14 +111,14 @@ impl ProtocolParticipant for BroadcastParticipant {
         id: ParticipantIdentifier,
         other_participant_ids: Vec<ParticipantIdentifier>,
         _input: Self::Input,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        Ok(Self {
             sid,
             id,
             other_participant_ids,
             local_storage: Default::default(),
             status: Status::Initialized,
-        }
+        })
     }
 
     fn id(&self) -> ParticipantIdentifier {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,6 +52,8 @@ pub enum CallerError {
     RetryFailed,
     #[error("Received a message with too few parties (Participant Config should have at least 2 parties)")]
     ParticipantConfigError,
+    #[error("The provided input did not satisfy the requirements on the input type. See logs for details.")]
+    BadInput,
 }
 
 macro_rules! serialize {

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -6,7 +6,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-use crate::{utils::CurvePoint, ParticipantIdentifier};
+use crate::{errors::Result, utils::CurvePoint, ParticipantIdentifier};
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -25,6 +25,13 @@ pub struct KeySharePrivate {
 impl Debug for KeySharePrivate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("KeySharePrivate([redacted])")
+    }
+}
+
+impl KeySharePrivate {
+    // Computes the "raw" curve point corresponding to this private key.
+    pub(crate) fn public_share(&self) -> Result<CurvePoint> {
+        CurvePoint::GENERATOR.multiply_by_scalar(&self.x)
     }
 }
 

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -184,12 +184,23 @@ pub trait ProtocolParticipant {
     fn protocol_type() -> ProtocolType;
 
     /// Create a new [`ProtocolParticipant`] from the given ids.
+    ///
+    /// **Assumption**: This method _does not_ validate the
+    /// [`ParticipantIdentifier`]s. It assumes that they comprise a unique
+    /// set and that there are a valid number of participants for a session.
+    ///
+    /// This method _does_ validate the input, checking any appropriate
+    /// constraints on its type and its relationship to the participant set
+    /// (for example, it may check that the input contains one field for
+    /// each participant).
     fn new(
         sid: Identifier,
         id: ParticipantIdentifier,
         other_participant_ids: Vec<ParticipantIdentifier>,
         input: Self::Input,
-    ) -> Self;
+    ) -> Result<Self>
+    where
+        Self: Sized;
 
     /// Return the participant id
     fn id(&self) -> ParticipantIdentifier;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -124,7 +124,7 @@ impl<P: ProtocolParticipant> Participant<P> {
 
         Ok(Participant {
             id: config.id,
-            participant: P::new(sid, config.id, config.other_ids.clone(), input),
+            participant: P::new(sid, config.id, config.other_ids.clone(), input)?,
         })
     }
 
@@ -327,7 +327,7 @@ impl ParticipantConfig {
 
     ///Create a random [`ParticipantConfig`].
     #[cfg(test)]
-    fn random<R: RngCore + CryptoRng>(size: usize, rng: &mut R) -> ParticipantConfig {
+    pub(crate) fn random<R: RngCore + CryptoRng>(size: usize, rng: &mut R) -> ParticipantConfig {
         assert!(size > 1);
         let other_ids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(size - 1)


### PR DESCRIPTION
Closes #248.

This PR does the following:
- Updates constructors for `Participant` and `ProtocolParticipant`s to return `Result`s.
- Adds validation to the presign input type (and adds tests of this behavior)

This issue was not super well scoped, so I moved some of the changes around:
- Auxinfo still doesn't have input, so it's blocked on #242. I added "validate the input" as a step in that issue, but it might be better as its own issue / PR.
- The issue described some kind of `validate_input` function, but I found that moving validation to a function other than the constructor was not as good, because I'd have to either make some intermediary type or pass a bunch of parameters and it seemed to weaken the guarantees I want ("types that hold inputs have always have validated those inputs").

This also overlaps a bit with #310 in the storage handling errors.