### PR TITLE
Add randomness to keygen output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, repoened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test:

--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -143,8 +143,8 @@ fn run_benchmarks_for_given_size(c: &mut Criterion, num_players: usize) {
     let presign_inputs = auxinfo_outputs
         .into_iter()
         .zip(keygen_outputs)
-        .map(|((aux_pub, aux_priv), (key_pub, key_priv))| {
-            PresignInput::new(aux_pub, aux_priv, key_pub, key_priv).unwrap()
+        .map(|((aux_pub, aux_priv), keygen_output)| {
+            PresignInput::new(aux_pub, aux_priv, keygen_output).unwrap()
         })
         .collect::<Vec<_>>();
 

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -51,7 +51,7 @@ impl AsRef<BigNumber> for KeySharePrivate {
     }
 }
 
-/// A [`CurvePoint`] representing a given [`Participant`](crate::Participant)'s
+/// A curve point representing a given [`Participant`](crate::Participant)'s
 /// public key.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeySharePublic {

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -7,9 +7,9 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
-pub(crate) mod keygen_commit;
-pub(crate) mod keyshare;
-pub mod participant;
+mod keygen_commit;
+mod keyshare;
+mod participant;
 
 pub use keyshare::{KeySharePrivate, KeySharePublic};
-pub use participant::Output;
+pub use participant::{KeygenParticipant, Output, Status};

--- a/src/keygen/mod.rs
+++ b/src/keygen/mod.rs
@@ -10,3 +10,6 @@
 pub(crate) mod keygen_commit;
 pub(crate) mod keyshare;
 pub mod participant;
+
+pub use keyshare::{KeySharePrivate, KeySharePublic};
+pub use participant::Output;

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -20,13 +20,14 @@ use crate::{
     participant::{Broadcast, InnerProtocolParticipant, ProcessOutcome, ProtocolParticipant},
     protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once,
-    utils::k256_order,
+    utils::{k256_order, CurvePoint},
     zkp::{
         pisch::{PiSchInput, PiSchPrecommit, PiSchProof, PiSchSecret},
         Proof,
     },
-    CurvePoint, Identifier,
+    Identifier,
 };
+use k256::ecdsa::VerifyingKey;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use tracing::{error, info, instrument};
@@ -80,14 +81,15 @@ pub enum Status {
 /// The protocol takes no input.
 ///
 /// # Protocol output
-/// Upon successful completion, the participant outputs the following:
-/// - A [`Vec`] of [`KeySharePublic`]s, which correspond to the public keyshares
-///   of each participant (including this participant), and
-/// - A single [`KeySharePrivate`], which corresponds to the **private**
-///   keyshare of this participant.
+/// Upon successful completion, the participant produces [`Output`], which
+/// includes:
+/// - A list of public key shares, one for each participant (including this
+///   participant);
+/// - A single private key share for this participant; and
+/// - A random value, agreed on by all participants.
 ///
 /// # 🔒 Storage requirements
-/// The [`KeySharePrivate`] output requires secure persistent storage.
+/// The private key share in the output requires secure persistent storage.
 ///
 /// # High-level protocol description
 /// The key generation protocol runs in four rounds:
@@ -102,7 +104,9 @@ pub enum Status {
 ///   other participants.
 /// - Finally, in the last round each participant checks the validity of all
 ///   other participants' Schnorr proofs. If that succeeds, each participant
-///   outputs all the public key shares alongside its own private key share.
+///   outputs all the public key shares alongside its own private key share and
+///   a global random value, produced with contributory randonmness from all
+///   parties.
 ///
 /// [^cite]: Ran Canetti, Rosario Gennaro, Steven Goldfeder, Nikolaos
 /// Makriyannis, and Udi Peled. UC Non-Interactive, Proactive, Threshold ECDSA
@@ -125,11 +129,70 @@ pub struct KeygenParticipant {
     status: Status,
 }
 
+/// Output type from key generation, including all parties' public key shares,
+/// this party's private key share, and a bit of global randomness.
+#[derive(Debug, Clone)]
+pub struct Output {
+    public_key_shares: Vec<KeySharePublic>,
+    private_key_share: KeySharePrivate,
+    #[allow(unused)]
+    rid: [u8; 32],
+}
+
+impl Output {
+    /// Construct the generated public key.
+    pub fn public_key(&self) -> Result<VerifyingKey> {
+        let mut vk_point = CurvePoint::IDENTITY;
+        for keyshare in &self.public_key_shares {
+            vk_point = CurvePoint(vk_point.0 + keyshare.as_ref().0);
+        }
+        VerifyingKey::from_encoded_point(&vk_point.0.to_affine().into()).map_err(|_| {
+            error!("Keygen output does not produce a valid public key.");
+            InternalError::InternalInvariantFailed
+        })
+    }
+
+    pub(crate) fn public_key_shares(&self) -> &[KeySharePublic] {
+        &self.public_key_shares
+    }
+
+    pub(crate) fn private_key_share(&self) -> &KeySharePrivate {
+        &self.private_key_share
+    }
+
+    /// Simulate the output of a keygen run with the given participants.
+    ///
+    /// This should __never__ be called outside of tests!
+    #[cfg(test)]
+    pub(crate) fn simulate(
+        pids: &[ParticipantIdentifier],
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> Self {
+        use rand::Rng;
+
+        let (mut private_key_shares, public_key_shares): (Vec<_>, Vec<_>) = pids
+            .iter()
+            .map(|&pid| {
+                // TODO #340: Replace with KeyShare methods once they exist.
+                let secret = KeySharePrivate::random(rng);
+                let public = secret.public_share().unwrap();
+                (secret, KeySharePublic::new(pid, public))
+            })
+            .unzip();
+
+        let rid = rng.gen();
+
+        Self {
+            private_key_share: private_key_shares.pop().unwrap(),
+            public_key_shares,
+            rid,
+        }
+    }
+}
+
 impl ProtocolParticipant for KeygenParticipant {
     type Input = ();
-    // The output type includes public key shares `KeySharePublic` for all
-    // participants (including ourselves) and `KeySharePrivate` for ourselves.
-    type Output = (Vec<KeySharePublic>, KeySharePrivate);
+    type Output = Output;
     type Status = Status;
 
     fn new(
@@ -505,7 +568,7 @@ impl KeygenParticipant {
         }
         self.local_storage
             .store::<storage::GlobalRid>(self.id, global_rid);
-        let transcript = schnorr_proof_transcript(global_rid)?;
+        let transcript = schnorr_proof_transcript(&global_rid)?;
 
         let precom = self
             .local_storage
@@ -561,16 +624,12 @@ impl KeygenParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling round three keygen message.");
 
-        if self
-            .local_storage
-            .retrieve::<storage::GlobalRid>(self.id)
-            .is_err()
-        {
+        if !self.local_storage.contains::<storage::GlobalRid>(self.id) {
             self.stash_message(message)?;
             return Ok(ProcessOutcome::Incomplete);
         }
         let proof = PiSchProof::from_message(message)?;
-        let global_rid = self.local_storage.retrieve::<storage::GlobalRid>(self.id)?;
+        let global_rid = *self.local_storage.retrieve::<storage::GlobalRid>(self.id)?;
         let decom = self
             .local_storage
             .retrieve::<storage::Decommit>(message.from())?;
@@ -579,7 +638,7 @@ impl KeygenParticipant {
         let g = CurvePoint::GENERATOR;
         let input = PiSchInput::new(&g, &q, decom.pk.as_ref());
 
-        let mut transcript = schnorr_proof_transcript(*global_rid)?;
+        let mut transcript = schnorr_proof_transcript(&global_rid)?;
         proof.verify(&input, &self.retrieve_context(), &mut transcript)?;
 
         // Only if the proof verifies do we store the participant's public key
@@ -609,10 +668,13 @@ impl KeygenParticipant {
                 .local_storage
                 .retrieve::<storage::PrivateKeyshare>(self.id)?;
             self.status = Status::TerminatedSuccessfully;
-            Ok(ProcessOutcome::Terminated((
+
+            let output = Output {
                 public_key_shares,
-                private_key_share.clone(),
-            )))
+                private_key_share: private_key_share.clone(),
+                rid: global_rid,
+            };
+            Ok(ProcessOutcome::Terminated(output))
         } else {
             // Otherwise, we'll have to wait for more round three messages.
             Ok(ProcessOutcome::Incomplete)
@@ -621,9 +683,9 @@ impl KeygenParticipant {
 }
 
 /// Generate a [`Transcript`] for [`PiSchProof`].
-fn schnorr_proof_transcript(global_rid: [u8; 32]) -> Result<Transcript> {
+fn schnorr_proof_transcript(global_rid: &[u8; 32]) -> Result<Transcript> {
     let mut transcript = Transcript::new(b"keygen schnorr");
-    transcript.append_message(b"rid", &serialize!(&global_rid)?);
+    transcript.append_message(b"rid", &serialize!(global_rid)?);
     Ok(transcript)
 }
 
@@ -687,10 +749,7 @@ mod tests {
         quorum: &mut Vec<KeygenParticipant>,
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
         rng: &mut R,
-    ) -> Option<(
-        usize,
-        ProcessOutcome<(Vec<KeySharePublic>, KeySharePrivate)>,
-    )> {
+    ) -> Option<(usize, ProcessOutcome<Output>)> {
         // Pick a random participant to process
         let index = rng.gen_range(0..quorum.len());
         let participant = quorum.get_mut(index).unwrap();
@@ -778,8 +837,9 @@ mod tests {
 
             // Collect the KeySharePublic associated with pid from every output
             let mut publics_for_pid = vec![];
-            for (publics, _) in &outputs {
-                let key_share = publics
+            for output in &outputs {
+                let key_share = output
+                    .public_key_shares
                     .iter()
                     .find(|key_share| key_share.participant() == pid);
 
@@ -804,19 +864,25 @@ mod tests {
 
         // Check that each participant's own `PublicKeyshare` corresponds to their
         // `PrivateKeyshare`
-        for ((publics, private), pid) in outputs
+        for (output, pid) in outputs
             .iter()
             .zip(quorum.iter().map(ProtocolParticipant::id))
         {
-            let public_share = publics
+            let public_share = output
+                .public_key_shares
                 .iter()
                 .find(|public_share| public_share.participant() == pid);
             assert!(public_share.is_some());
 
             let expected_public_share =
-                CurvePoint(CurvePoint::GENERATOR.0 * crate::utils::bn_to_scalar(private.as_ref())?);
-            assert_eq!(*public_share.unwrap().as_ref(), expected_public_share);
+                CurvePoint::GENERATOR.multiply_by_scalar(output.private_key_share.as_ref())?;
+            assert_eq!(public_share.unwrap().as_ref(), &expected_public_share);
         }
+
+        // Check that every participant has the same `rid` value
+        assert!(outputs
+            .windows(2)
+            .all(|outputs| outputs[0].rid == outputs[1].rid));
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub use auxinfo::{
     info::{AuxInfoPrivate, AuxInfoPublic},
     participant::AuxInfoParticipant,
 };
-pub use keygen::participant::KeygenParticipant;
+pub use keygen::KeygenParticipant;
 pub use messages::Message;
 pub use participant::ProtocolParticipant;
 pub use presign::{
@@ -201,8 +201,7 @@ pub use presign::{
     record::PresignRecord,
 };
 pub use protocol::{
-    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, SharedContext,
-    SignatureShare,
+    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, SignatureShare,
 };
 
 use crate::presign::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,10 +193,7 @@ pub use auxinfo::{
     info::{AuxInfoPrivate, AuxInfoPublic},
     participant::AuxInfoParticipant,
 };
-pub use keygen::{
-    keyshare::{KeySharePrivate, KeySharePublic},
-    participant::KeygenParticipant,
-};
+pub use keygen::participant::KeygenParticipant;
 pub use messages::Message;
 pub use participant::ProtocolParticipant;
 pub use presign::{
@@ -204,10 +201,9 @@ pub use presign::{
     record::PresignRecord,
 };
 pub use protocol::{
-    Identifier, Output, Participant, ParticipantConfig, ParticipantIdentifier, SharedContext,
+    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, SharedContext,
     SignatureShare,
 };
-pub use utils::CurvePoint;
 
 use crate::presign::*;
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -12,10 +12,7 @@ use crate::{
     auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
     errors::{CallerError, InternalError, Result},
-    keygen::{
-        self,
-        keyshare::{KeySharePrivate, KeySharePublic},
-    },
+    keygen::{self, KeySharePrivate, KeySharePublic},
     local_storage::LocalStorage,
     messages::{Message, MessageType, PresignMessageType},
     parameters::ELL_PRIME,
@@ -97,7 +94,7 @@ pub enum Status {
 /// and includes [`SharedContext`] and [`AuxInfoPublic`]s for all participants
 /// (including this participant).
 #[derive(Debug)]
-pub struct PresignContext {
+pub(crate) struct PresignContext {
     shared_context: SharedContext,
     auxinfo_public: Vec<AuxInfoPublic>,
 }
@@ -154,7 +151,7 @@ impl PresignContext {
 /// The goal of the presign protocol is to generate [`PresignRecord`]s for all
 /// protocol participants. The protocol proceeds in four rounds, and utilizes
 /// the [`KeySharePrivate`] (`xᵢ` in the paper) constructed during the
-/// [`keygen`](crate::keygen::participant::KeygenParticipant) protocol.
+/// [`keygen`](crate::keygen::KeygenParticipant) protocol.
 ///
 /// 1. In round one, each participant generates two values corresponding to a
 ///    "key share" (`kᵢ` in the paper) and an "exponent share" (`ɣᵢ` in the
@@ -246,7 +243,7 @@ pub struct Input {
 impl Input {
     /// Creates a new [`Input`] from the outputs of the
     /// [`auxinfo`](crate::auxinfo::participant::AuxInfoParticipant) and
-    /// [`keygen`](crate::keygen::participant::KeygenParticipant) protocols.
+    /// [`keygen`](crate::keygen::KeygenParticipant) protocols.
     pub fn new(
         all_auxinfo_public: Vec<AuxInfoPublic>,
         auxinfo_private: AuxInfoPrivate,

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -12,7 +12,10 @@ use crate::{
     auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
     errors::{CallerError, InternalError, Result},
-    keygen::keyshare::{KeySharePrivate, KeySharePublic},
+    keygen::{
+        self,
+        keyshare::{KeySharePrivate, KeySharePublic},
+    },
     local_storage::LocalStorage,
     messages::{Message, MessageType, PresignMessageType},
     parameters::ELL_PRIME,
@@ -28,14 +31,14 @@ use crate::{
     },
     protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once,
-    utils::{bn_to_scalar, k256_order, random_plusminus_by_size, random_positive_bn},
+    utils::{bn_to_scalar, k256_order, random_plusminus_by_size, random_positive_bn, CurvePoint},
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof, PiAffgSecret},
         pienc::{PiEncInput, PiEncProof, PiEncSecret},
         pilog::{CommonInput, PiLogProof, ProverSecret},
         Proof, ProofContext,
     },
-    CurvePoint, Identifier,
+    Identifier,
 };
 use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
@@ -125,11 +128,12 @@ impl PresignContext {
 /// A [`ProtocolParticipant`] that runs the presign protocol[^cite].
 ///
 /// # Protocol input
-/// The protocol takes as input the following:
-/// - A [`Vec`] of [`KeySharePublic`]s, which correspond to the public keyshares
-///   of each participant (including this participant), and
-/// - A single [`KeySharePrivate`], which corresponds to the **private**
-///   keyshare of this participant.
+/// The protocol takes an [`Input`] which includes:
+/// - The [`Output`](keygen::Output) of a [`keygen`] protocol execution
+///   - A list of public key shares, one for each participant (including this
+///     participant);
+///   - A single private key share for this participant; and
+///   - A random value, agreed on by all participants.
 /// - A [`Vec`] of [`AuxInfoPublic`]s, which correspond to the public auxiliary
 ///   information of each participant (including this participant), and
 /// - A single [`AuxInfoPrivate`], which corresponds to the **private**
@@ -231,11 +235,8 @@ pub struct PresignParticipant {
 /// Input needed for [`PresignParticipant`] to run.
 #[derive(Debug, Clone)]
 pub struct Input {
-    /// The private keyshare of this participant.
-    keyshare_private: KeySharePrivate,
-    /// The public keyshares of all the participants (including this
-    /// participant).
-    all_keyshare_public: Vec<KeySharePublic>,
+    /// The key share material for the key corresponding to the presign run.
+    keygen_output: keygen::Output,
     /// The private auxinfo of this participant.
     auxinfo_private: AuxInfoPrivate,
     /// The public auxinfo of all the participants (including this participant).
@@ -249,14 +250,13 @@ impl Input {
     pub fn new(
         all_auxinfo_public: Vec<AuxInfoPublic>,
         auxinfo_private: AuxInfoPrivate,
-        all_keyshare_public: Vec<KeySharePublic>,
-        keyshare_private: KeySharePrivate,
+        keygen_output: keygen::Output,
     ) -> Result<Self> {
-        if all_auxinfo_public.len() != all_keyshare_public.len() {
+        if all_auxinfo_public.len() != keygen_output.public_key_shares().len() {
             error!(
                 "Number of auxinfo ({:?}) and keyshare ({:?}) public entries is not equal",
                 all_auxinfo_public.len(),
-                all_keyshare_public.len()
+                keygen_output.public_key_shares().len()
             );
             Err(CallerError::BadInput)?
         }
@@ -266,7 +266,8 @@ impl Input {
             .iter()
             .map(|auxinfo| auxinfo.participant())
             .collect::<HashSet<_>>();
-        let key_sids = all_keyshare_public
+        let key_sids = keygen_output
+            .public_key_shares()
             .iter()
             .map(|keyshare| keyshare.participant())
             .collect::<HashSet<_>>();
@@ -277,14 +278,15 @@ impl Input {
 
         // There shouldn't be duplicates. Since we checked equality of the sets and the
         // lengths already, this also applies to auxinfo.
-        if key_sids.len() != all_keyshare_public.len() {
+        if key_sids.len() != keygen_output.public_key_shares().len() {
             error!("Duplicate participant IDs appeared in AuxInfo and KeyShare public input.");
             Err(CallerError::BadInput)?
         }
 
         // The private values should map to one of the public values.
-        let expected_public_share = keyshare_private.public_share()?;
-        if !all_keyshare_public
+        let expected_public_share = keygen_output.private_key_share().public_share()?;
+        if !keygen_output
+            .public_key_shares()
             .iter()
             .any(|public_share| expected_public_share == *public_share.as_ref())
         {
@@ -302,8 +304,7 @@ impl Input {
         Ok(Self {
             all_auxinfo_public,
             auxinfo_private,
-            all_keyshare_public,
-            keyshare_private,
+            keygen_output,
         })
     }
 
@@ -312,7 +313,8 @@ impl Input {
     /// By construction, this must be the same for the auxinfo and key share
     /// lists.
     fn participants(&self) -> Vec<ParticipantIdentifier> {
-        self.all_keyshare_public
+        self.keygen_output
+            .public_key_shares()
             .iter()
             .map(KeySharePublic::participant)
             .collect()
@@ -333,7 +335,8 @@ impl Input {
     /// Returns the [`KeySharePublic`] associated with the given
     /// [`ParticipantIdentifier`].
     fn find_keyshare_public(&self, pid: ParticipantIdentifier) -> Result<&KeySharePublic> {
-        self.all_keyshare_public
+        self.keygen_output
+            .public_key_shares()
             .iter()
             .find(|item| item.participant() == pid)
             .ok_or_else(|| {
@@ -1022,7 +1025,7 @@ impl PresignKeyShareAndInfo {
         Ok(Self {
             aux_info_private: input.auxinfo_private.clone(),
             aux_info_public: input.find_auxinfo_public(id)?.clone(),
-            keyshare_private: input.keyshare_private.clone(),
+            keyshare_private: input.keygen_output.private_key_share().clone(),
             keyshare_public: input.find_keyshare_public(id)?.clone(),
         })
     }
@@ -1338,35 +1341,18 @@ impl PresignKeyShareAndInfo {
 
 #[cfg(test)]
 mod test {
+    use rand::rngs::StdRng;
+
     use super::Input;
     use crate::{
         errors::{CallerError, InternalError, Result},
+        keygen,
         paillier::DecryptionKey,
         ring_pedersen::VerifiedRingPedersen,
         utils::testing::init_testing,
-        AuxInfoPrivate, AuxInfoPublic, Identifier, KeySharePrivate, KeySharePublic,
-        ParticipantConfig, ParticipantIdentifier, PresignParticipant, ProtocolParticipant,
+        AuxInfoPrivate, AuxInfoPublic, Identifier, ParticipantConfig, ParticipantIdentifier,
+        PresignParticipant, ProtocolParticipant,
     };
-    use rand::rngs::StdRng;
-
-    // Simulate the output of a keygen run with the given participants.
-    fn simulate_keygen_output(
-        pids: &[ParticipantIdentifier],
-        rng: &mut StdRng,
-    ) -> (KeySharePrivate, Vec<KeySharePublic>) {
-        let (mut keygen_private_outputs, keygen_public_outputs): (Vec<_>, Vec<_>) = pids
-            .iter()
-            .map(|&pid| {
-                // TODO #340: Replace with KeyShare methods once they exist.
-                let secret = KeySharePrivate::random(rng);
-                let public = secret.public_share().unwrap();
-                (secret, KeySharePublic::new(pid, public))
-            })
-            .unzip();
-
-        (keygen_private_outputs.pop().unwrap(), keygen_public_outputs)
-    }
-
     // Simulate the output of an auxinfo run with the given participants.
     fn simulate_auxinfo_output(
         pids: &[ParticipantIdentifier],
@@ -1402,26 +1388,23 @@ mod test {
         let pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
-        let (keygen_private, keygen_public) = simulate_keygen_output(&pids, rng);
+        let keygen_output = keygen::Output::simulate(&pids, rng);
         let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&pids, rng);
 
         // Same length works
         let result = Input::new(
             auxinfo_public.clone(),
             auxinfo_private.clone(),
-            keygen_public.clone(),
-            keygen_private.clone(),
+            keygen_output.clone(),
         );
         assert!(result.is_ok());
 
         // If keygen is too short, it fails.
-        let mut short_keygen = keygen_public.clone();
-        let _dropped = short_keygen.pop();
+        let short_keygen = keygen::Output::simulate(&pids[1..], rng);
         let result = Input::new(
             auxinfo_public.clone(),
             auxinfo_private.clone(),
             short_keygen,
-            keygen_private.clone(),
         );
         assert!(result.is_err());
         assert_eq!(
@@ -1432,12 +1415,7 @@ mod test {
         // If auxinfo is too short, it fails.
         let mut short_auxinfo = auxinfo_public;
         let _dropped = short_auxinfo.pop();
-        let result = Input::new(
-            short_auxinfo,
-            auxinfo_private,
-            keygen_public,
-            keygen_private,
-        );
+        let result = Input::new(short_auxinfo, auxinfo_private, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1449,28 +1427,25 @@ mod test {
     fn inputs_must_not_have_duplicates() {
         let rng = &mut init_testing();
 
-        let pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
+        let mut pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
-        let (keygen_private, mut keygen_public) = simulate_keygen_output(&pids, rng);
         let (auxinfo_private, mut auxinfo_public) = simulate_auxinfo_output(&pids, rng);
 
         // This test doesn't bother adding a duplicate in only one of the inputs because
         // that would fail the length checks tested in `inputs_must_be_same_length`
-        let keygen_dup = keygen_public.pop().unwrap();
-        keygen_public.push(keygen_dup.clone());
-        keygen_public.push(keygen_dup);
 
+        // Push a copy of one of the auxinfo publics.
         let auxinfo_dup = auxinfo_public.pop().unwrap();
         auxinfo_public.push(auxinfo_dup.clone());
         auxinfo_public.push(auxinfo_dup);
 
-        let result = Input::new(
-            auxinfo_public,
-            auxinfo_private,
-            keygen_public,
-            keygen_private,
-        );
+        // Make a keygen output with a duplicated pid (the public key material itself
+        // will be different)
+        pids.push(pids[4]); // take the last item to match the pop'd auxinfo pid.
+        let keygen_output = keygen::Output::simulate(&pids, rng);
+
+        let result = Input::new(auxinfo_public, auxinfo_private, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1490,14 +1465,9 @@ mod test {
         let keygen_pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
-        let (keygen_private, keygen_public) = simulate_keygen_output(&keygen_pids, rng);
+        let keygen_output = keygen::Output::simulate(&keygen_pids, rng);
 
-        let result = Input::new(
-            auxinfo_public,
-            auxinfo_private,
-            keygen_public,
-            keygen_private,
-        );
+        let result = Input::new(auxinfo_public, auxinfo_private, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1513,37 +1483,24 @@ mod test {
             .take(5)
             .collect::<Vec<_>>();
 
-        let (keygen_private, keygen_public) = simulate_keygen_output(&pids, rng);
-        let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&pids, rng);
+        let keygen_output = keygen::Output::simulate(&pids, rng);
+        let (_, auxinfo_public) = simulate_auxinfo_output(&pids, rng);
 
-        // Make private components with no relation to the public inputs.
+        // Make a private auxinfo component with no relation to the public inputs.
         let fake_auxinfo_private = AuxInfoPrivate::from(DecryptionKey::new(rng).unwrap().0);
-        let fake_keygen_private = KeySharePrivate::random(rng);
+
         // Auxinfo private key must correspond to one of the public inputs.
-        let result = Input::new(
-            auxinfo_public.clone(),
-            fake_auxinfo_private,
-            keygen_public.clone(),
-            keygen_private,
-        );
+        let result = Input::new(auxinfo_public, fake_auxinfo_private, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
             InternalError::CallingApplicationMistake(CallerError::BadInput)
         );
 
-        // Keygen private share must correspond to one of the public shares.
-        let result = Input::new(
-            auxinfo_public,
-            auxinfo_private,
-            keygen_public,
-            fake_keygen_private,
-        );
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            InternalError::CallingApplicationMistake(CallerError::BadInput)
-        );
+        // Note: we can't test the same thing for keygen because the keygen
+        // output type doesn't let us muck around with its internal
+        // representation here. TODO #376: Add the equivalent test in
+        // the keygen module.
     }
 
     #[test]
@@ -1555,15 +1512,10 @@ mod test {
         let input_pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(SIZE)
             .collect::<Vec<_>>();
-        let (keygen_private, keygen_public) = simulate_keygen_output(&input_pids, rng);
+        let keygen_output = keygen::Output::simulate(&input_pids, rng);
         let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&input_pids, rng);
 
-        let input = Input::new(
-            auxinfo_public,
-            auxinfo_private,
-            keygen_public,
-            keygen_private,
-        )?;
+        let input = Input::new(auxinfo_public, auxinfo_private, keygen_output)?;
 
         // Create valid config with PIDs independent of those used to make the input set
         let config = ParticipantConfig::random(SIZE, rng);

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -13,8 +13,7 @@ use crate::{
     },
     presign::round_three::{Private as RoundThreePrivate, Public as RoundThreePublic},
     protocol::SignatureShare,
-    utils::bn_to_scalar,
-    CurvePoint,
+    utils::{bn_to_scalar, CurvePoint},
 };
 use k256::{
     elliptic_curve::{AffineXCoordinate, PrimeField},
@@ -42,7 +41,7 @@ pub(crate) struct RecordPair {
 /// A `PresignRecord` contains the following components of the ECSDA signature
 /// algorithm[^cite] (the below notation matches the notation used in the
 /// citation):
-/// - A [`CurvePoint`] (`R` in the paper) representing the point `k^{-1} · G`,
+/// - A curve point (`R` in the paper) representing the point `k^{-1} · G`,
 ///   where `k` is a random integer and `G` denotes the elliptic curve base
 ///   point.
 /// - A [`Scalar`] (`kᵢ` in the paper) representing a share of the random

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -14,11 +14,11 @@ use crate::{
         round_one::PublicBroadcast as RoundOnePublicBroadcast,
         round_two::{Private as RoundTwoPrivate, Public as RoundTwoPublic},
     },
+    utils::CurvePoint,
     zkp::{
         pilog::{CommonInput, PiLogProof},
         Proof, ProofContext,
     },
-    CurvePoint,
 };
 use k256::Scalar;
 use libpaillier::unknown_order::BigNumber;

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -13,12 +13,12 @@ use crate::{
     messages::{Message, MessageType, PresignMessageType},
     paillier::Ciphertext,
     presign::round_one::{Private as RoundOnePrivate, PublicBroadcast as RoundOnePublicBroadcast},
+    utils::CurvePoint,
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof},
         pilog::{CommonInput, PiLogProof},
         Proof, ProofContext,
     },
-    CurvePoint,
 };
 use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -9,7 +9,7 @@
 use crate::{
     auxinfo::info::AuxInfoPublic,
     errors::{InternalError, Result},
-    keygen::keyshare::KeySharePublic,
+    keygen::KeySharePublic,
     messages::{Message, MessageType, PresignMessageType},
     paillier::Ciphertext,
     presign::round_one::{Private as RoundOnePrivate, PublicBroadcast as RoundOnePublicBroadcast},

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,16 +8,12 @@
 
 //! The primary public API for executing the threshold signing protocol.
 //!
-//! This module includes the main [`Participant`] driver and defines the set of
-//! possible [`Output`]s for each subprotocol.
+//! This module includes the main [`Participant`] driver.
 
 use crate::{
-    auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
     errors::{CallerError, InternalError, Result},
-    keygen::keyshare::{KeySharePrivate, KeySharePublic},
     messages::MessageType,
     participant::{InnerProtocolParticipant, ProtocolParticipant},
-    presign::record::PresignRecord,
     utils::{k256_order, CurvePoint},
     zkp::ProofContext,
     Message,
@@ -141,9 +137,9 @@ impl<P: ProtocolParticipant> Participant<P> {
     /// Process the first message from the participant's inbox.
     ///
     /// ## Return type
-    /// This returns an output and a set of messages:
-    /// - The [`Output`] encodes the termination status and any outputs of the
-    ///   protocol with the given session ID.
+    /// This returns a possible output and a set of messages:
+    /// - The output holds the output of the protocol with the given session ID,
+    ///   if it terminated for this participant.
     /// - The messages are a (possibly empty) list of messages to be sent out to
     ///   other participants.
     #[cfg_attr(feature = "flame_it", flame)]
@@ -219,7 +215,8 @@ impl<P: ProtocolParticipant> Participant<P> {
 /// A share of the ECDSA signature.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct SignatureShare {
-    /// The x-projection of `R` from the [`PresignRecord`] (`r` in the paper).
+    /// The x-projection of `R` from the [`PresignRecord`](crate::PresignRecord)
+    /// (`r` in the paper).
     ///
     /// Note: The paper does _not_ include this as part of the share, and
     /// instead, a signature share is just the `σ` value. We include this value
@@ -227,8 +224,8 @@ pub struct SignatureShare {
     /// participants who created a share, to be able to reconstruct the
     /// signature.
     r: k256::Scalar,
-    /// The digest masked by components from [`PresignRecord`] (`σ` in the
-    /// paper).
+    /// The digest masked by components from
+    /// [`PresignRecord`](crate::PresignRecord) (`σ` in the paper).
     s: k256::Scalar,
 }
 
@@ -374,7 +371,7 @@ impl ParticipantIdentifier {
     }
 }
 
-/// The `SharedContext` contains fixed known parameters accross the entire
+/// The `SharedContext` contains fixed known parameters across the entire
 /// protocol. It does not however contain the entire protocol context.
 #[derive(Debug)]
 pub struct SharedContext {
@@ -490,9 +487,9 @@ impl std::fmt::Display for ParticipantIdentifier {
 /// The codebase relies on the calling application to generate a new, unique
 /// `Identifier` for each new session.
 ///
-/// [^outs]: These can include public key shares and shared randomness that were returned as output from
-/// a previous run of keygen and public commitment parameters that were returned
-/// as output from a previous run of auxinfo.
+/// [^outs]: These can include public key shares and shared randomness that were
+/// returned as output from a previous run of keygen and public commitment
+/// parameters that were returned as output from a previous run of auxinfo.
 ///
 /// [^bug]: In fact, we think there is a minor bug in Figure 6 of the paper, since
 /// the definition of `ssid` includes outputs of auxinfo, and thus cannot be
@@ -524,31 +521,12 @@ impl std::fmt::Display for Identifier {
     }
 }
 
-/// Encodes the termination status and output (if any) of processing a message
-/// as part of a protocol run.
-#[derive(Debug)]
-pub enum Output {
-    /// The protocol did not complete.
-    None,
-    /// AuxInfo completed; output includes public key material for all
-    /// participants and private key material for this participant.
-    AuxInfo(Vec<AuxInfoPublic>, AuxInfoPrivate),
-    /// KeyGen completed; output includes public key shares for all participants
-    /// and a private key share for this participant.
-    KeyGen(Vec<KeySharePublic>, KeySharePrivate),
-    /// Presign completed; output includes a one-time-use presign record.
-    Presign(PresignRecord),
-    /// Local signing completed; output is this participant's share of the
-    /// signature.
-    Sign(SignatureShare),
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
         auxinfo::participant::AuxInfoParticipant, keygen::participant::KeygenParticipant,
-        presign::participant::Input as PresignInput, utils::testing::init_testing, CurvePoint,
+        presign::participant::Input as PresignInput, utils::testing::init_testing,
         PresignParticipant,
     };
     use k256::ecdsa::signature::DigestVerifier;
@@ -863,12 +841,11 @@ mod tests {
             .iter()
             .all(|p| *p.status() == crate::keygen::participant::Status::TerminatedSuccessfully));
 
-        // Hideously save the list of public keys for later
-        let public_keyshares = keygen_outputs
+        // Save the public key for later
+        let saved_public_key = keygen_outputs
             .get(&configs.get(0).unwrap().id)
             .unwrap()
-            .clone()
-            .0;
+            .public_key()?;
 
         // Set up presign participants
         let presign_sid = Identifier::random(&mut rng);
@@ -882,14 +859,8 @@ mod tests {
                     keygen_outputs.get(&config.id).unwrap(),
                 )
             })
-            .map(|((aux_pub, aux_priv), (key_pub, key_priv))| {
-                PresignInput::new(
-                    aux_pub.clone(),
-                    aux_priv.clone(),
-                    key_pub.clone(),
-                    key_priv.clone(),
-                )
-                .unwrap()
+            .map(|((aux_pub, aux_priv), keygen_output)| {
+                PresignInput::new(aux_pub.clone(), aux_priv.clone(), keygen_output.clone()).unwrap()
             })
             .collect::<Vec<_>>();
 
@@ -936,17 +907,8 @@ mod tests {
             .map(|record| record.sign(hasher.clone()).unwrap());
         let signature = SignatureShare::into_signature(shares)?;
 
-        // Initialize all participants and get their public keyshares to construct the
-        // final signature verification key
-        let mut vk_point = CurvePoint::IDENTITY;
-        for keyshare in public_keyshares {
-            vk_point = CurvePoint(vk_point.0 + keyshare.as_ref().0);
-        }
-        let verification_key =
-            k256::ecdsa::VerifyingKey::from_encoded_point(&vk_point.0.to_affine().into()).unwrap();
-
         // Moment of truth, does the signature verify?
-        assert!(verification_key.verify_digest(hasher, &signature).is_ok());
+        assert!(saved_public_key.verify_digest(hasher, &signature).is_ok());
 
         #[cfg(feature = "flame_it")]
         flame::dump_html(&mut std::fs::File::create("dev/flame-graph.html").unwrap()).unwrap();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -374,7 +374,7 @@ impl ParticipantIdentifier {
 /// The `SharedContext` contains fixed known parameters across the entire
 /// protocol. It does not however contain the entire protocol context.
 #[derive(Debug)]
-pub struct SharedContext {
+pub(crate) struct SharedContext {
     sid: Identifier,
     participants: Vec<ParticipantIdentifier>,
     generator: CurvePoint,
@@ -525,7 +525,7 @@ impl std::fmt::Display for Identifier {
 mod tests {
     use super::*;
     use crate::{
-        auxinfo::participant::AuxInfoParticipant, keygen::participant::KeygenParticipant,
+        auxinfo::participant::AuxInfoParticipant, keygen::KeygenParticipant,
         presign::participant::Input as PresignInput, utils::testing::init_testing,
         PresignParticipant,
     };
@@ -839,7 +839,7 @@ mod tests {
         // And make sure all participants have successfully terminated.
         assert!(keygen_quorum
             .iter()
-            .all(|p| *p.status() == crate::keygen::participant::Status::TerminatedSuccessfully));
+            .all(|p| *p.status() == crate::keygen::Status::TerminatedSuccessfully));
 
         // Save the public key for later
         let saved_public_key = keygen_outputs

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,7 +29,7 @@ pub(crate) const CRYPTOGRAPHIC_RETRY_MAX: usize = 500usize;
 /// private type, `Debug` should be manually implemented with the field of this
 /// type explicitly redacted!
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Zeroize)]
-pub struct CurvePoint(pub k256::ProjectivePoint);
+pub(crate) struct CurvePoint(pub k256::ProjectivePoint);
 
 impl CurvePoint {
     pub(crate) const GENERATOR: Self = CurvePoint(k256::ProjectivePoint::GENERATOR);


### PR DESCRIPTION
Closes #243.
Closes #252.

This adds the `global_rid` value to the output of keygen. The value is a random string, and it's only used as context for strong fiat-Shamir in proofs. This PR does not include adding it to the proofs. I forgot that #252 was a separate issue so I accidentally did it here. Big changes include:
- Replacing all uses of the tuple returned from keygen with the new `Output` type instead
- Adjusting visibility of `CurvePoint`, which changed includes all over the place and is a side benefit of pulling public-key-related functions into the keygen output type.

Reviewing: I'm pretty confident that I pulled the global `rid` value correctly, so I'm looking more for comments on the ergonomics of the `Output` type.