### PR TITLE
Refactor presign message verification

### DIFF
--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -631,6 +631,8 @@ impl PresignParticipant {
         message: &Message,
         input: &Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
+        use crate::round_one::Public as RoundOnePublic;
+
         info!("Presign: Handling round one message.");
 
         // First check that we have the round one public broadcast from this
@@ -653,11 +655,11 @@ impl PresignParticipant {
 
         let info = PresignKeyShareAndInfo::new(self.id, input)?;
         let auxinfo_public = input.find_auxinfo_public(message.from())?;
-        crate::round_one::Public::validate_message(
-            message,
+        let round_one_public = RoundOnePublic::try_from(message)?;
+        round_one_public.verify(
             &self.retrieve_context(),
-            &info.aux_info_public,
-            auxinfo_public,
+            info.aux_info_public.params(),
+            auxinfo_public.pk(),
             r1_public_broadcast,
         )?;
         // Mark that we have completed round one for this participant.
@@ -963,8 +965,8 @@ impl PresignParticipant {
             .local_storage
             .retrieve::<storage::RoundOnePublicBroadcast>(message.from())?;
 
-        let round_two_public = crate::round_two::Public::from_message(
-            message,
+        let round_two_public = RoundTwoPublic::try_from(message)?;
+        round_two_public.verify(
             &self.retrieve_context(),
             receiver_auxinfo_public,
             sender_auxinfo_public,
@@ -990,9 +992,8 @@ impl PresignParticipant {
         let sender_r1_public_broadcast = self
             .local_storage
             .retrieve::<storage::RoundOnePublicBroadcast>(message.from())?;
-
-        let public_message = crate::round_three::Public::from_message(
-            message,
+        let public = RoundThreePublic::try_from(message)?;
+        public.verify(
             &self.retrieve_context(),
             receiver_auxinfo_public,
             sender_auxinfo_public,
@@ -1000,8 +1001,7 @@ impl PresignParticipant {
         )?;
 
         self.local_storage
-            .store::<storage::RoundThreePublic>(message.from(), public_message);
-
+            .store::<storage::RoundThreePublic>(message.from(), public);
         Ok(())
     }
 }
@@ -1078,7 +1078,7 @@ impl PresignKeyShareAndInfo {
                 &mut transcript,
                 rng,
             )?;
-            let r1_public = RoundOnePublic { proof };
+            let r1_public = RoundOnePublic::new(proof);
             let _ = r1_publics.insert(aux_info_public.participant(), r1_public);
         }
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -969,9 +969,9 @@ impl PresignParticipant {
         round_two_public.verify(
             &self.retrieve_context(),
             receiver_auxinfo_public,
+            receiver_r1_private,
             sender_auxinfo_public,
             sender_keyshare_public,
-            receiver_r1_private,
             sender_r1_public_broadcast,
         )?;
 
@@ -1078,7 +1078,7 @@ impl PresignKeyShareAndInfo {
                 &mut transcript,
                 rng,
             )?;
-            let r1_public = RoundOnePublic::new(proof);
+            let r1_public = RoundOnePublic::from(proof);
             let _ = r1_publics.insert(aux_info_public.participant(), r1_public);
         }
 

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -54,8 +54,8 @@ pub(crate) struct Public {
     proof: PiEncProof,
 }
 
-impl Public {
-    pub(crate) fn new(proof: PiEncProof) -> Self {
+impl From<PiEncProof> for Public {
+    fn from(proof: PiEncProof) -> Self {
         Self { proof }
     }
 }

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -7,12 +7,14 @@
 // of this source tree.
 
 use crate::{
-    auxinfo::info::AuxInfoPublic,
-    errors::Result,
+    errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
     paillier::{Ciphertext, EncryptionKey, Nonce},
     ring_pedersen::VerifiedRingPedersen,
-    zkp::{pienc::PiEncProof, Proof, ProofContext},
+    zkp::{
+        pienc::{PiEncInput, PiEncProof},
+        Proof, ProofContext,
+    },
 };
 use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
@@ -46,11 +48,19 @@ impl Debug for Private {
     }
 }
 
+/// Public information produced in round one of the presign protocol.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Public {
-    pub proof: PiEncProof,
+    proof: PiEncProof,
 }
 
+impl Public {
+    pub(crate) fn new(proof: PiEncProof) -> Self {
+        Self { proof }
+    }
+}
+
+/// Public information broadcast in round one of the presign protocol.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct PublicBroadcast {
     pub K: Ciphertext,
@@ -58,44 +68,34 @@ pub(crate) struct PublicBroadcast {
 }
 
 impl Public {
-    /// Verify the `𝚷[enc]` proof that the prover knows the plaintext
-    /// associated with `ct`.
-    fn verify(
+    /// Verify the validity of [`Public`] against the prover's [`EncryptionKey`]
+    /// and [`PublicBroadcast`] values.
+    ///
+    /// Note: The [`VerifiedRingPedersen`] value must be that of the _caller_
+    /// (i.e., the verifier).
+    pub(crate) fn verify(
         &self,
         context: &impl ProofContext,
         verifier_setup_params: &VerifiedRingPedersen,
-        prover_pk: EncryptionKey,
-        ct: Ciphertext,
+        prover_pk: &EncryptionKey,
+        prover_public_broadcast: &PublicBroadcast,
     ) -> Result<()> {
         let mut transcript = Transcript::new(b"PiEncProof");
-        let input =
-            crate::zkp::pienc::PiEncInput::new(verifier_setup_params.clone(), prover_pk, ct);
+        let input = PiEncInput::new(
+            verifier_setup_params.clone(),
+            prover_pk.clone(),
+            prover_public_broadcast.K.clone(),
+        );
         self.proof.verify(&input, context, &mut transcript)
     }
+}
 
-    /// Validate that [`Message`] is a valid proof that the [`PublicBroadcast`]
-    /// parameters are correctly constructed.
-    ///
-    /// The `verifier_auxinfo_public` argument denotes the [`AuxInfoPublic`]
-    /// type of the party validating the message, and the
-    /// `prover_auxinfo_public` argument denotes the [`AuxInfoPublic`] type of
-    /// the party providing the proof.
-    pub(crate) fn validate_message(
-        message: &Message,
-        context: &impl ProofContext,
-        verifier_auxinfo_public: &AuxInfoPublic,
-        prover_auxinfo_public: &AuxInfoPublic,
-        broadcasted_params: &PublicBroadcast,
-    ) -> Result<()> {
+impl TryFrom<&Message> for Public {
+    type Error = InternalError;
+
+    fn try_from(message: &Message) -> std::result::Result<Self, Self::Error> {
         message.check_type(MessageType::Presign(PresignMessageType::RoundOne))?;
-        let round_one_public: Self = deserialize!(&message.unverified_bytes)?;
-
-        round_one_public.verify(
-            context,
-            verifier_auxinfo_public.params(),
-            prover_auxinfo_public.pk().clone(),
-            broadcasted_params.K.clone(),
-        )?;
-        Ok(())
+        let public: Self = deserialize!(&message.unverified_bytes)?;
+        Ok(public)
     }
 }

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -49,6 +49,11 @@ impl Debug for Private {
 }
 
 /// Public information produced in round one of the presign protocol.
+///
+/// This type implements [`TryFrom`] on [`Message`], which validates that
+/// [`Message`] is a valid serialization of `Public`, but _not_ that `Public` is
+/// necessarily valid (i.e., that all the components are valid with respect to
+/// each other); use [`Public::verify`] to check this latter condition.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Public {
     proof: PiEncProof,

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -64,20 +64,26 @@ pub(crate) struct Public {
 }
 
 impl Public {
-    /// Verify the validity of [`Public`].
+    /// Verify the validity of [`Public`] against the sender's [`AuxInfoPublic`]
+    /// and [`PublicBroadcast`](crate::presign::round_one::PublicBroadcast)
+    /// values.
+    ///
+    /// Note: The `receiver_...` values must be those of the _caller_ (i.e., the
+    /// verifier), and the `sender_...` values must be those of the other party
+    /// (i.e., the prover).
     pub(crate) fn verify(
         &self,
         context: &impl ProofContext,
-        receiver_keygen_public: &AuxInfoPublic,
-        sender_keygen_public: &AuxInfoPublic,
+        receiver_auxinfo_public: &AuxInfoPublic,
+        sender_auxinfo_public: &AuxInfoPublic,
         sender_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<()> {
         let mut transcript = Transcript::new(b"PiLogProof");
         let psi_double_prime_input = CommonInput::new(
             sender_r1_public_broadcast.K.clone(),
             self.Delta,
-            receiver_keygen_public.params().scheme().clone(),
-            sender_keygen_public.pk().clone(),
+            receiver_auxinfo_public.params().scheme().clone(),
+            sender_auxinfo_public.pk().clone(),
             self.Gamma,
         );
         self.psi_double_prime

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -100,6 +100,11 @@ impl TryFrom<&Message> for Public {
     fn try_from(message: &Message) -> std::result::Result<Self, Self::Error> {
         message.check_type(MessageType::Presign(PresignMessageType::RoundThree))?;
         let public: Self = deserialize!(&message.unverified_bytes)?;
+        // TODO #369: This should check the validity of `delta` (namely that it
+        // is less than `k256_order()`). However, we are currently using an
+        // older version of the `k256` library that doesn't support comparisons,
+        // making doing this check difficult. Add this check once the `k256`
+        // library has been updated.
         Ok(public)
     }
 }

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -58,27 +58,23 @@ impl Public {
     /// Verify the validity of [`Public`] against the sender's
     /// [`AuxInfoPublic`], [`KeySharePublic`], and
     /// [`PublicBroadcast`](crate::presign::round_one::PublicBroadcast) values.
-    ///
-    /// Note: The `receiver_...` values must be those of the _caller_ (i.e., the
-    /// verifier), and the `sender_...` values must be those of the other party
-    /// (i.e., the prover).
     pub(crate) fn verify(
         &self,
         context: &impl ProofContext,
-        receiver_auxinfo_public: &AuxInfoPublic,
-        sender_auxinfo_public: &AuxInfoPublic,
-        sender_keyshare_public: &KeySharePublic,
-        receiver_r1_private: &RoundOnePrivate,
-        sender_r1_public_broadcast: &RoundOnePublicBroadcast,
+        verifier_auxinfo_public: &AuxInfoPublic,
+        verifier_r1_private: &RoundOnePrivate,
+        prover_auxinfo_public: &AuxInfoPublic,
+        prover_keyshare_public: &KeySharePublic,
+        prover_r1_public_broadcast: &RoundOnePublicBroadcast,
     ) -> Result<()> {
         let g = CurvePoint::GENERATOR;
 
         // Verify the psi proof
         let psi_input = PiAffgInput::new(
-            receiver_auxinfo_public.params().clone(),
-            receiver_auxinfo_public.pk().clone(),
-            sender_auxinfo_public.pk().clone(),
-            receiver_r1_private.K.clone(),
+            verifier_auxinfo_public.params().clone(),
+            verifier_auxinfo_public.pk().clone(),
+            prover_auxinfo_public.pk().clone(),
+            verifier_r1_private.K.clone(),
             self.D.clone(),
             self.F.clone(),
             self.Gamma,
@@ -89,13 +85,13 @@ impl Public {
 
         // Verify the psi_hat proof
         let psi_hat_input = PiAffgInput::new(
-            receiver_auxinfo_public.params().clone(),
-            receiver_auxinfo_public.pk().clone(),
-            sender_auxinfo_public.pk().clone(),
-            receiver_r1_private.K.clone(),
+            verifier_auxinfo_public.params().clone(),
+            verifier_auxinfo_public.pk().clone(),
+            prover_auxinfo_public.pk().clone(),
+            verifier_r1_private.K.clone(),
             self.D_hat.clone(),
             self.F_hat.clone(),
-            sender_keyshare_public.X,
+            prover_keyshare_public.X,
         );
         let mut transcript = Transcript::new(b"PiAffgProof");
         self.psi_hat
@@ -103,10 +99,10 @@ impl Public {
 
         // Verify the psi_prime proof
         let psi_prime_input = CommonInput::new(
-            sender_r1_public_broadcast.G.clone(),
+            prover_r1_public_broadcast.G.clone(),
             self.Gamma,
-            receiver_auxinfo_public.params().scheme().clone(),
-            sender_auxinfo_public.pk().clone(),
+            verifier_auxinfo_public.params().scheme().clone(),
+            prover_auxinfo_public.pk().clone(),
             g,
         );
         let mut transcript = Transcript::new(b"PiLogProof");

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -55,11 +55,13 @@ pub(crate) struct Public {
 }
 
 impl Public {
-    /// Verify the validity of [`Public`] against the prover's
+    /// Verify the validity of [`Public`] against the sender's
     /// [`AuxInfoPublic`], [`KeySharePublic`], and
     /// [`PublicBroadcast`](crate::presign::round_one::PublicBroadcast) values.
     ///
-    /// Note: The `verifier_...` values must be those of the _caller_.
+    /// Note: The `receiver_...` values must be those of the _caller_ (i.e., the
+    /// verifier), and the `sender_...` values must be those of the other party
+    /// (i.e., the prover).
     pub(crate) fn verify(
         &self,
         context: &impl ProofContext,

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -42,6 +42,11 @@ impl Debug for Private {
 }
 
 /// Public information produced in round two of the presign protocol.
+///
+/// This type implements [`TryFrom`] on [`Message`], which validates that
+/// [`Message`] is a valid serialization of `Public`, but _not_ that `Public` is
+/// necessarily valid (i.e., that all the components are valid with respect to
+/// each other); use [`Public::verify`] to check this latter condition.
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct Public {
     pub D: Ciphertext,


### PR DESCRIPTION
Closes #214.

This PR splits the `from_message` method in `presign::round_...` into a separate `TryFrom<&Message>` implementation and a `verify` method.