### PR TITLE
clean up participant config API

### DIFF
--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -82,21 +82,11 @@ fn init_new_player_set<P: ProtocolParticipant>(
     let num_players = inputs.len();
 
     // Get the sets of mine/other ids for each party
-    let ids = std::iter::repeat_with(|| ParticipantIdentifier::random(&mut rng))
-        .take(num_players)
-        .collect::<Vec<_>>();
-
-    let configs = (0..num_players)
-        .map(|i| {
-            let mut other_ids = ids.clone();
-            let id = other_ids.remove(i);
-            ParticipantConfig { id, other_ids }
-        })
-        .collect::<Vec<_>>();
+    let configs = ParticipantConfig::random_quorum(num_players, &mut rng).unwrap();
 
     // Instantiate participants
     let quorum: Vec<Participant<P>> = configs
-        .iter()
+        .into_iter()
         .zip(inputs)
         .map(|(config, input)| Participant::from_config(config, sid, input).unwrap())
         .collect();

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -175,7 +175,7 @@ fn main() -> anyhow::Result<()> {
     // Spawn worker threads. Link worker to main thread with channels.
     for config in participants {
         let (from_coordinator_tx, from_coordinator_rx) = channel::<MessageFromCoordinator>();
-        worker_messages.insert(config.id, from_coordinator_tx);
+        worker_messages.insert(config.id(), from_coordinator_tx);
 
         let outgoing = outgoing_tx.clone();
         thread::spawn(|| participant_worker(config, from_coordinator_rx, outgoing));
@@ -352,7 +352,7 @@ impl Worker {
         let rng = &mut thread_rng();
 
         let mut participant: Participant<P> =
-            Participant::from_config(&self.config, sid.0, inputs)?;
+            Participant::from_config(self.config.clone(), sid.0, inputs)?;
         let init_message = participant.initialize_message();
 
         // Output will be None.

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -648,7 +648,7 @@ mod tests {
         ) -> Result<Vec<Self>> {
             ParticipantConfig::random_quorum(quorum_size, rng)?
                 .into_iter()
-                .map(|config| Self::new(sid, config.id, config.other_ids, input))
+                .map(|config| Self::new(sid, config.id(), config.other_ids().to_vec(), input))
                 .collect::<Result<Vec<_>>>()
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,7 +48,7 @@ pub enum CallerError {
     ProtocolAlreadyTerminated,
     #[error("The provided RNG failed to produce suitable values after a maximum number of attempts. Please check the RNG.")]
     RetryFailed,
-    #[error("Received a message with too few parties (Participant Config should have at least 2 parties)")]
+    #[error("Tried to create an invalid `ParticipantConfig` (the protocol requires at least 2 uniquely identified parties)")]
     ParticipantConfigError,
     #[error("The provided input did not satisfy the requirements on the input type. See logs for details.")]
     BadInput,

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -688,7 +688,7 @@ mod tests {
         ) -> Result<Vec<Self>> {
             ParticipantConfig::random_quorum(quorum_size, rng)?
                 .into_iter()
-                .map(|config| Self::new(sid, config.id, config.other_ids, ()))
+                .map(|config| Self::new(sid, config.id(), config.other_ids().to_vec(), ()))
                 .collect::<Result<Vec<_>>>()
         }
         pub fn initialize_keygen_message(&self, keygen_identifier: Identifier) -> Message {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,8 @@ pub use presign::{
     record::PresignRecord,
 };
 pub use protocol::{
-    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, SignatureShare,
+    participant_config::ParticipantConfig, Identifier, Participant, ParticipantIdentifier,
+    SignatureShare,
 };
 
 use crate::presign::*;

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1517,8 +1517,12 @@ mod test {
         // Create valid config with PIDs independent of those used to make the input set
         let config = ParticipantConfig::random(SIZE, rng);
 
-        let result =
-            PresignParticipant::new(Identifier::random(rng), config.id, config.other_ids, input);
+        let result = PresignParticipant::new(
+            Identifier::random(rng),
+            config.id(),
+            config.other_ids().to_vec(),
+            input,
+        );
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -306,9 +306,9 @@ pub(crate) mod testing {
         let mut seeder = OsRng;
         let seed = seeder.gen();
         eprintln!(
-            "Test Failed. To recreate the randomness used, use init_testing_with_seed() with the following seed:"
+            "To re-run test with the same randomness, use init_testing_with_seed() with the following seed:"
         );
-        eprintln!("seed: {seed:?}");
+        eprintln!("\t{seed:?}");
         StdRng::from_seed(seed)
     }
 


### PR DESCRIPTION
Closes #339 

This adds guarantees about `ParticipantConfig` behavior (must be correct size, contain unique identifiers) by putting it in its own module and locking down the constructor. This doesn't address the problem of configs being invalid after deserialization, but that's a known problem (#6) for a lot of types.

Also adds a method to create an `Identifier` _not_ uniformly at random, like we expect to happen in deployments that don't involve a trusted third party.

Future work:
- Figure out deserialization validation and do it everywhere.
- There's duplication between these methods and the `ProtocolParticipant` methods on ids. Right now we copy the two config fields into `ProtocolParticipant` but it would be cleaner to just use the existing type.
