### PR TITLE
 Relax Proof Input Ownership Requirements

### DIFF
--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -13,7 +13,7 @@ use crate::{
     ring_pedersen::VerifiedRingPedersen,
     zkp::{
         pienc::{PiEncInput, PiEncProof},
-        Proof, ProofContext,
+        Proof2, ProofContext,
     },
 };
 use libpaillier::unknown_order::BigNumber;
@@ -79,19 +79,15 @@ impl Public {
     /// Note: The [`VerifiedRingPedersen`] value must be that of the _caller_
     /// (i.e., the verifier).
     pub(crate) fn verify(
-        &self,
+        self,
         context: &impl ProofContext,
         verifier_setup_params: &VerifiedRingPedersen,
         prover_pk: &EncryptionKey,
         prover_public_broadcast: &PublicBroadcast,
     ) -> Result<()> {
         let mut transcript = Transcript::new(b"PiEncProof");
-        let input = PiEncInput::new(
-            verifier_setup_params.clone(),
-            prover_pk.clone(),
-            prover_public_broadcast.K.clone(),
-        );
-        self.proof.verify(&input, context, &mut transcript)
+        let input = PiEncInput::new(verifier_setup_params, prover_pk, &prover_public_broadcast.K);
+        self.proof.verify(input, context, &mut transcript)
     }
 }
 

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -17,7 +17,7 @@ use crate::{
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof},
         pilog::{CommonInput, PiLogProof},
-        Proof, ProofContext,
+        Proof, Proof2, ProofContext,
     },
 };
 use libpaillier::unknown_order::BigNumber;
@@ -64,7 +64,7 @@ impl Public {
     /// [`AuxInfoPublic`], [`KeySharePublic`], and
     /// [`PublicBroadcast`](crate::presign::round_one::PublicBroadcast) values.
     pub(crate) fn verify(
-        &self,
+        self,
         context: &impl ProofContext,
         verifier_auxinfo_public: &AuxInfoPublic,
         verifier_r1_private: &RoundOnePrivate,
@@ -76,31 +76,31 @@ impl Public {
 
         // Verify the psi proof
         let psi_input = PiAffgInput::new(
-            verifier_auxinfo_public.params().clone(),
-            verifier_auxinfo_public.pk().clone(),
-            prover_auxinfo_public.pk().clone(),
-            verifier_r1_private.K.clone(),
-            self.D.clone(),
-            self.F.clone(),
-            self.Gamma,
+            verifier_auxinfo_public.params(),
+            verifier_auxinfo_public.pk(),
+            prover_auxinfo_public.pk(),
+            &verifier_r1_private.K,
+            &self.D,
+            &self.F,
+            &self.Gamma,
         );
         let mut transcript = Transcript::new(b"PiAffgProof");
 
-        self.psi.verify(&psi_input, context, &mut transcript)?;
+        self.psi.verify(psi_input, context, &mut transcript)?;
 
         // Verify the psi_hat proof
         let psi_hat_input = PiAffgInput::new(
-            verifier_auxinfo_public.params().clone(),
-            verifier_auxinfo_public.pk().clone(),
-            prover_auxinfo_public.pk().clone(),
-            verifier_r1_private.K.clone(),
-            self.D_hat.clone(),
-            self.F_hat.clone(),
-            *prover_keyshare_public.as_ref(),
+            verifier_auxinfo_public.params(),
+            verifier_auxinfo_public.pk(),
+            prover_auxinfo_public.pk(),
+            &verifier_r1_private.K,
+            &self.D_hat,
+            &self.F_hat,
+            prover_keyshare_public.as_ref(),
         );
         let mut transcript = Transcript::new(b"PiAffgProof");
         self.psi_hat
-            .verify(&psi_hat_input, context, &mut transcript)?;
+            .verify(psi_hat_input, context, &mut transcript)?;
 
         // Verify the psi_prime proof
         let psi_prime_input = CommonInput::new(

--- a/src/zkp/mod.rs
+++ b/src/zkp/mod.rs
@@ -51,12 +51,13 @@ impl ProofContext for BadContext {
 
 /// A trait for constructing zero knowledge proofs.
 ///
-/// The associated type [`Proof::CommonInput`] denotes the data known the both
+/// The associated type [`Proof::CommonInput`] denotes the data known to both
 /// the prover and verifier, and the associated type [`Proof::ProverSecret`]
 /// denotes the data known only to the prover.
 pub(crate) trait Proof: Sized + Serialize + DeserializeOwned {
     type CommonInput;
     type ProverSecret;
+
     /// Constructs a zero knowledge proof over [`Proof::ProverSecret`] and
     /// [`Proof::CommonInput`] using the provided [`Transcript`].
     fn prove<R: RngCore + CryptoRng>(
@@ -66,11 +67,36 @@ pub(crate) trait Proof: Sized + Serialize + DeserializeOwned {
         transcript: &mut Transcript,
         rng: &mut R,
     ) -> Result<Self>;
+
     /// Verifies a zero knowledge proof using the provided
     /// [`Proof::CommonInput`] and [`Transcript`].
     fn verify(
         &self,
         input: &Self::CommonInput,
+        context: &impl ProofContext,
+        transcript: &mut Transcript,
+    ) -> Result<()>;
+}
+
+pub(crate) trait Proof2: Sized + Serialize + DeserializeOwned {
+    type CommonInput<'a>;
+    type ProverSecret<'a>;
+
+    /// Constructs a zero knowledge proof over [`Proof::ProverSecret`] and
+    /// [`Proof::CommonInput`] using the provided [`Transcript`].
+    fn prove<R: RngCore + CryptoRng>(
+        input: Self::CommonInput<'_>,
+        secret: Self::ProverSecret<'_>,
+        context: &impl ProofContext,
+        transcript: &mut Transcript,
+        rng: &mut R,
+    ) -> Result<Self>;
+
+    /// Verifies a zero knowledge proof using the provided
+    /// [`Proof::CommonInput`] and [`Transcript`].
+    fn verify(
+        self,
+        input: Self::CommonInput<'_>,
         context: &impl ProofContext,
         transcript: &mut Transcript,
     ) -> Result<()>;


### PR DESCRIPTION
Closes #396 and #398 
Units tests are refactored to work with new lifetime requirements and cleaned up.