### PR TITLE
Add an output type for auxinfo

### DIFF
--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -3,9 +3,9 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{prelude::IteratorRandom, rngs::OsRng, CryptoRng, Rng, RngCore};
 use std::collections::HashMap;
 use tss_ecdsa::{
-    auxinfo::AuxInfoParticipant, errors::Result, keygen::KeygenParticipant, Identifier, Message,
-    Participant, ParticipantConfig, ParticipantIdentifier, PresignInput, PresignParticipant,
-    ProtocolParticipant,
+    auxinfo::AuxInfoParticipant, errors::Result, keygen::KeygenParticipant, messages::Message,
+    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, PresignInput,
+    PresignParticipant, ProtocolParticipant,
 };
 
 /// Delivers all messages into their respective participant's inboxes

--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -3,8 +3,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use rand::{prelude::IteratorRandom, rngs::OsRng, CryptoRng, Rng, RngCore};
 use std::collections::HashMap;
 use tss_ecdsa::{
-    errors::Result, AuxInfoParticipant, Identifier, KeygenParticipant, Message, Participant,
-    ParticipantConfig, ParticipantIdentifier, PresignInput, PresignParticipant,
+    auxinfo::AuxInfoParticipant, errors::Result, keygen::KeygenParticipant, Identifier, Message,
+    Participant, ParticipantConfig, ParticipantIdentifier, PresignInput, PresignParticipant,
     ProtocolParticipant,
 };
 
@@ -133,8 +133,8 @@ fn run_benchmarks_for_given_size(c: &mut Criterion, num_players: usize) {
     let presign_inputs = auxinfo_outputs
         .into_iter()
         .zip(keygen_outputs)
-        .map(|((aux_pub, aux_priv), keygen_output)| {
-            PresignInput::new(aux_pub, aux_priv, keygen_output).unwrap()
+        .map(|(auxinfo_output, keygen_output)| {
+            PresignInput::new(auxinfo_output, keygen_output).unwrap()
         })
         .collect::<Vec<_>>();
 

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -37,9 +37,10 @@ use std::{
 use tracing::{debug, info, instrument, span, trace, Level};
 use tracing_subscriber::{self, EnvFilter};
 use tss_ecdsa::{
-    keygen::Output, AuxInfoParticipant, Identifier, KeygenParticipant, Message, Participant,
-    ParticipantConfig, ParticipantIdentifier, PresignInput, PresignParticipant,
-    ProtocolParticipant,
+    auxinfo::AuxInfoParticipant,
+    keygen::{KeygenParticipant, Output},
+    Identifier, Message, Participant, ParticipantConfig, ParticipantIdentifier, PresignInput,
+    PresignParticipant, ProtocolParticipant,
 };
 use utils::{MessageFromWorker, SubProtocol};
 use uuid::Uuid;
@@ -424,13 +425,9 @@ impl Worker {
 
     fn new_presign(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
         let key_shares = self.key_gen_material.take(&key_id);
-        let (aux_info_public, aux_info_private) = self.aux_info.retrieve(&key_id);
+        let auxinfo_output = self.aux_info.take(&key_id);
 
-        let inputs: PresignInput = PresignInput::new(
-            aux_info_public.clone(),
-            aux_info_private.clone(),
-            key_shares,
-        )?;
+        let inputs: PresignInput = PresignInput::new(auxinfo_output, key_shares)?;
         self.new_sub_protocol::<PresignParticipant>(sid, inputs, key_id)
     }
 }

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -39,7 +39,8 @@ use tracing_subscriber::{self, EnvFilter};
 use tss_ecdsa::{
     auxinfo::AuxInfoParticipant,
     keygen::{KeygenParticipant, Output},
-    Identifier, Message, Participant, ParticipantConfig, ParticipantIdentifier, PresignInput,
+    messages::Message,
+    Identifier, Participant, ParticipantConfig, ParticipantIdentifier, PresignInput,
     PresignParticipant, ProtocolParticipant,
 };
 use utils::{MessageFromWorker, SubProtocol};

--- a/examples/threaded_example/utils.rs
+++ b/examples/threaded_example/utils.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tss_ecdsa::Message;
+use tss_ecdsa::messages::Message;
 
 /// Sub-protocol of tss-ecdsa.
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -18,7 +18,12 @@ use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use tracing::{error, instrument};
-/// The private key corresponding to a given Participant's [`AuxInfoPublic`].
+/// Private auxiliary information for a specific
+/// [`Participant`](crate::Participant).
+///
+/// This includes a Paillier decryption key; there should be a corresponding
+/// [`AuxInfoPublic`] with the encryption key and ring-Pedersen commitment
+/// parameters formed with the same modulus.
 ///
 /// # 🔒 Storage requirements
 /// This type must be stored securely by the calling application.
@@ -52,7 +57,11 @@ impl Debug for AuxInfoPrivate {
     }
 }
 
-/// The public auxilary information corresponding to a given participant.
+/// The public auxilary information for a specific
+/// [`Participant`](crate::Participant).
+///
+/// This includes a Paillier encryption key and corresponding ring-Pedersen
+/// commitment parameters.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AuxInfoPublic {
     /// The participant's identifier.

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -16,11 +16,11 @@
 //! with Identifiable Aborts. [EPrint archive,
 //! 2021](https://eprint.iacr.org/2021/060.pdf).
 
-pub(crate) mod auxinfo_commit;
-pub(crate) mod info;
+mod auxinfo_commit;
+mod info;
 mod output;
 mod participant;
-pub(crate) mod proof;
+mod proof;
 
 pub use info::{AuxInfoPrivate, AuxInfoPublic};
 pub use output::Output;

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -18,8 +18,10 @@
 
 pub(crate) mod auxinfo_commit;
 pub(crate) mod info;
+mod output;
 mod participant;
 pub(crate) mod proof;
 
 pub use info::{AuxInfoPrivate, AuxInfoPublic};
-pub use participant::{AuxInfoParticipant, Output, Status};
+pub use output::Output;
+pub use participant::{AuxInfoParticipant, Status};

--- a/src/auxinfo/mod.rs
+++ b/src/auxinfo/mod.rs
@@ -8,7 +8,7 @@
 
 //! This module implements the auxiliary information protocol defined in Figure
 //! 6 of CGGMP21[^cite]. See
-//! [`AuxInfoParticipant`](crate::auxinfo::participant::AuxInfoParticipant) for
+//! [`AuxInfoParticipant`](crate::auxinfo::AuxInfoParticipant) for
 //! more details.
 //!
 //! [^cite]: Ran Canetti, Rosario Gennaro, Steven Goldfeder, Nikolaos
@@ -18,5 +18,8 @@
 
 pub(crate) mod auxinfo_commit;
 pub(crate) mod info;
-pub mod participant;
+mod participant;
 pub(crate) mod proof;
+
+pub use info::{AuxInfoPrivate, AuxInfoPublic};
+pub use participant::{AuxInfoParticipant, Output, Status};

--- a/src/auxinfo/output.rs
+++ b/src/auxinfo/output.rs
@@ -1,0 +1,172 @@
+//! Auxinfo output module enforces correct construction of the type!
+
+use std::collections::HashSet;
+
+use crate::{
+    auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
+    errors::{CallerError, Result},
+    protocol::ParticipantIdentifier,
+};
+use tracing::error;
+
+#[cfg(test)]
+use rand::{CryptoRng, RngCore};
+/// Output produced by running the auxinfo protocol.
+///
+/// This should include an [`AuxInfoPublic`] for every protocol participant
+/// and an [`AuxInfoPrivate`] for participant that receives this output.
+#[derive(Debug, Clone)]
+pub struct Output {
+    public_auxinfo: Vec<AuxInfoPublic>,
+    private_auxinfo: AuxInfoPrivate,
+}
+
+impl Output {
+    /// Create a new `Output` from its constituent parts.
+    ///
+    /// The parts must constitute a valid output:
+    /// - the public components should be from a unique set of participants;
+    /// - the private component should have a corresponding public component.
+    pub fn from_parts(
+        public_auxinfo: Vec<AuxInfoPublic>,
+        private_auxinfo: AuxInfoPrivate,
+    ) -> Result<Self> {
+        let pids = public_auxinfo
+            .iter()
+            .map(AuxInfoPublic::participant)
+            .collect::<HashSet<_>>();
+        if pids.len() != public_auxinfo.len() {
+            error!("Tried to create a keygen output using a set of public material from non-unique participants");
+            Err(CallerError::BadInput)?
+        }
+
+        let expected_public_key = private_auxinfo.encryption_key();
+        if !public_auxinfo
+            .iter()
+            .any(|auxinfo| &expected_public_key == auxinfo.pk())
+        {
+            error!(
+                "Auxinfo private material did not match any of the provided auxinfo public keys"
+            );
+            Err(CallerError::BadInput)?
+        }
+
+        Ok(Self {
+            public_auxinfo,
+            private_auxinfo,
+        })
+    }
+
+    /// Decompose the `Output` into its constituent parts.
+    ///
+    /// # 🔒 Storage requirements
+    /// The [`AuxInfoPrivate`] must be stored securely by the calling
+    /// application, and a best effort should be made to drop it from memory
+    /// after it's securely stored.
+    ///
+    /// The public components can be stored in the clear.
+    pub fn into_parts(self) -> (Vec<AuxInfoPublic>, AuxInfoPrivate) {
+        (self.public_auxinfo, self.private_auxinfo)
+    }
+
+    pub(crate) fn public_auxinfo(&self) -> &[AuxInfoPublic] {
+        &self.public_auxinfo
+    }
+
+    pub(crate) fn find_public(&self, pid: ParticipantIdentifier) -> Option<&AuxInfoPublic> {
+        self.public_auxinfo
+            .iter()
+            .find(|public_key| public_key.participant() == pid)
+    }
+
+    pub(crate) fn private_auxinfo(&self) -> &AuxInfoPrivate {
+        &self.private_auxinfo
+    }
+
+    /// Simulate the output of an auxinfo run with the given participants.
+    ///
+    /// This should __never__ be called outside of tests! It does not validate
+    /// the PID input.
+    #[cfg(test)]
+    pub(crate) fn simulate(
+        pids: &[ParticipantIdentifier],
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> Self {
+        use crate::{paillier::DecryptionKey, ring_pedersen::VerifiedRingPedersen};
+
+        let (mut private_auxinfo, public_auxinfo): (Vec<_>, Vec<_>) = pids
+            .iter()
+            .map(|&pid| {
+                let (key, _, _) = DecryptionKey::new(rng).unwrap();
+                (
+                    AuxInfoPrivate::from(key.clone()),
+                    AuxInfoPublic::new(
+                        &(),
+                        pid,
+                        key.encryption_key(),
+                        VerifiedRingPedersen::extract(&key, &(), rng).unwrap(),
+                    )
+                    .unwrap(),
+                )
+            })
+            .unzip();
+
+        Self {
+            private_auxinfo: private_auxinfo.pop().unwrap(),
+            public_auxinfo,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{paillier::DecryptionKey, utils::testing::init_testing};
+
+    use super::*;
+
+    #[test]
+    fn from_into_parts_works() {
+        let rng = &mut init_testing();
+        let pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
+            .take(5)
+            .collect::<Vec<_>>();
+        let output = Output::simulate(&pids, rng);
+
+        let (public, private) = output.into_parts();
+        assert!(Output::from_parts(public, private).is_ok());
+    }
+
+    #[test]
+    fn participants_must_be_unique() {
+        let rng = &mut init_testing();
+        let mut pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
+            .take(5)
+            .collect::<Vec<_>>();
+        // Duplicate one of the PIDs
+        pids.push(pids[4]);
+
+        let output = Output::simulate(&pids, rng);
+
+        let (public, private) = output.into_parts();
+        assert!(Output::from_parts(public, private).is_err());
+    }
+
+    #[test]
+    fn private_output_must_correspond_to_a_public() {
+        let rng = &mut init_testing();
+        let pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
+            .take(5)
+            .collect::<Vec<_>>();
+
+        // Use the simulate function to get a set of valid public components
+        let valid_publics = Output::simulate(&pids, rng).public_auxinfo;
+
+        // Make a random private component
+        // If randomness somehow breaks, it's possible that this could correspond to one
+        // of the public ones but it's so unlikely that we're not going to try
+        // to check that here.
+        let bad_private = AuxInfoPrivate::from(DecryptionKey::new(rng).unwrap().0);
+
+        assert!(Output::from_parts(valid_publics, bad_private).is_err());
+    }
+}

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -596,6 +596,9 @@ impl AuxInfoParticipant {
                 .collect::<Result<Vec<_>>>()?;
             let auxinfo_private = self.local_storage.remove::<storage::Private>(self.id)?;
 
+            // The normal error type of this method is `CallerError::BadInput` because it's
+            // external-facing, but in this case we somehow borked the protocol, so throw
+            // the correct error.
             let output = Output::from_parts(auxinfo_public, auxinfo_private)
                 .map_err(|_| InternalError::InternalInvariantFailed)?;
 

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -14,6 +14,7 @@ use crate::{
         auxinfo_commit::{Commitment, CommitmentScheme},
         info::{AuxInfoPrivate, AuxInfoPublic, AuxInfoWitnesses},
         proof::AuxInfoProof,
+        Output,
     },
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
     errors::{CallerError, InternalError, Result},
@@ -136,60 +137,6 @@ pub struct AuxInfoParticipant {
     broadcast_participant: BroadcastParticipant,
     /// The status of the protocol execution
     status: Status,
-}
-
-/// Output type from auxinfo, including all parties' public auxiliary info
-/// (their Paillier encryption key and ring-Pedersen parameters) and
-/// this party's private auxiliary info (the factors of their Paillier key).
-#[derive(Debug, Clone)]
-pub struct Output {
-    public_auxinfo: Vec<AuxInfoPublic>,
-    private_auxinfo: AuxInfoPrivate,
-}
-
-impl Output {
-    pub(crate) fn public_auxinfo(&self) -> &[AuxInfoPublic] {
-        &self.public_auxinfo
-    }
-
-    pub(crate) fn find_public(&self, pid: ParticipantIdentifier) -> Option<&AuxInfoPublic> {
-        self.public_auxinfo
-            .iter()
-            .find(|public_key| public_key.participant() == pid)
-    }
-
-    pub(crate) fn private_auxinfo(&self) -> &AuxInfoPrivate {
-        &self.private_auxinfo
-    }
-
-    // Simulate the output of an auxinfo run with the given participants.
-    #[cfg(test)]
-    pub(crate) fn simulate(
-        pids: &[ParticipantIdentifier],
-        rng: &mut (impl CryptoRng + RngCore),
-    ) -> Self {
-        let (mut private_auxinfo, public_auxinfo): (Vec<_>, Vec<_>) = pids
-            .iter()
-            .map(|&pid| {
-                let (key, _, _) = DecryptionKey::new(rng).unwrap();
-                (
-                    AuxInfoPrivate::from(key.clone()),
-                    AuxInfoPublic::new(
-                        &(),
-                        pid,
-                        key.encryption_key(),
-                        VerifiedRingPedersen::extract(&key, &(), rng).unwrap(),
-                    )
-                    .unwrap(),
-                )
-            })
-            .unzip();
-
-        Self {
-            private_auxinfo: private_auxinfo.pop().unwrap(),
-            public_auxinfo,
-        }
-    }
 }
 
 impl ProtocolParticipant for AuxInfoParticipant {
@@ -649,11 +596,11 @@ impl AuxInfoParticipant {
                 .collect::<Result<Vec<_>>>()?;
             let auxinfo_private = self.local_storage.remove::<storage::Private>(self.id)?;
 
-            let output = Output {
-                public_auxinfo: auxinfo_public,
-                private_auxinfo: auxinfo_private,
-            };
+            let output = Output::from_parts(auxinfo_public, auxinfo_private)
+                .map_err(|_| InternalError::InternalInvariantFailed)?;
+
             self.status = Status::TerminatedSuccessfully;
+
             Ok(ProcessOutcome::Terminated(output))
         } else {
             // Otherwise, we'll have to wait for more round three messages.

--- a/src/auxinfo/proof.rs
+++ b/src/auxinfo/proof.rs
@@ -9,7 +9,7 @@
 use crate::{
     auxinfo::participant::AuxInfoParticipant,
     errors::Result,
-    messages::{AuxinfoMessageType, MessageType},
+    messages::{AuxinfoMessageType, Message, MessageType},
     participant::InnerProtocolParticipant,
     ring_pedersen::VerifiedRingPedersen,
     zkp::{
@@ -17,7 +17,7 @@ use crate::{
         pimod::{PiModInput, PiModProof, PiModSecret},
         Proof, ProofContext,
     },
-    Identifier, Message,
+    Identifier,
 };
 use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,11 +189,6 @@ mod utils;
 mod zkp;
 mod zkstar;
 
-pub use auxinfo::{
-    info::{AuxInfoPrivate, AuxInfoPublic},
-    participant::AuxInfoParticipant,
-};
-pub use keygen::KeygenParticipant;
 pub use messages::Message;
 pub use participant::ProtocolParticipant;
 pub use presign::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,11 +97,12 @@
 //!
 //! Instead, the calling application is responsible for maintaining a mapping
 //! between the [`ParticipantIdentifier`] and the signing key associated with
-//! each entity. [`Message`]s contain a `from: ParticipantIdentifier` field
-//! which specifies the sender of a message. On receiving a message and
-//! signature over a channel, the calling application must check that the `from`
-//! field in the message matches the signing key used to generate the signature.
-//! This ensures that the sender is not lying about its identity.
+//! each entity. [`Message`](messages::Message)s contain a `from:
+//! ParticipantIdentifier` field which specifies the sender of a message. On
+//! receiving a message and signature over a channel, the calling application
+//! must check that the `from` field in the message matches the signing key used
+//! to generate the signature. This ensures that the sender is not lying about
+//! its identity.
 //!
 //! The protocol requires a UC-secure, synchronous, authenticated broadcast
 //! channel for use by the [`Participant`]s. Currently, the library handles this
@@ -123,8 +124,8 @@
 //! # Useful features
 //!
 //! A [`Participant`] processes messages received from other [`Participant`]s
-//! and generates [`Message`] for other  [`Participant`]s to process. When the
-//! current sub-protocol finishes, output values are produced.
+//! and generates [`Message`](messages::Message) for other  [`Participant`]s to
+//! process. When the current sub-protocol finishes, output values are produced.
 //!
 //! Messages may arrive from the network before a [`Participant`] is ready to
 //! process them. [`Participant`]s can be given messages at any time; when
@@ -189,7 +190,6 @@ mod utils;
 mod zkp;
 mod zkstar;
 
-pub use messages::Message;
 pub use participant::ProtocolParticipant;
 pub use presign::{
     participant::{Input as PresignInput, PresignParticipant},

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -9,7 +9,10 @@
 // of this source tree.
 
 use crate::{
-    auxinfo::info::{AuxInfoPrivate, AuxInfoPublic},
+    auxinfo::{
+        self,
+        info::{AuxInfoPrivate, AuxInfoPublic},
+    },
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
     errors::{CallerError, InternalError, Result},
     keygen::{self, KeySharePrivate, KeySharePublic},
@@ -113,7 +116,7 @@ impl ProofContext for PresignContext {
 impl PresignContext {
     /// Build a [`PresignContext`] from a [`PresignParticipant`].
     pub(crate) fn collect(p: &PresignParticipant) -> Self {
-        let mut auxinfo_public = p.input().all_auxinfo_public();
+        let mut auxinfo_public = p.input().to_public_auxinfo();
         auxinfo_public.sort_by_key(AuxInfoPublic::participant);
         Self {
             shared_context: SharedContext::collect(p),
@@ -235,38 +238,34 @@ pub struct Input {
     /// The key share material for the key corresponding to the presign run.
     keygen_output: keygen::Output,
     /// The private auxinfo of this participant.
-    auxinfo_private: AuxInfoPrivate,
     /// The public auxinfo of all the participants (including this participant).
-    all_auxinfo_public: Vec<AuxInfoPublic>,
+    auxinfo_output: auxinfo::Output,
 }
 
 impl Input {
     /// Creates a new [`Input`] from the outputs of the
-    /// [`auxinfo`](crate::auxinfo::participant::AuxInfoParticipant) and
+    /// [`auxinfo`](crate::auxinfo::AuxInfoParticipant) and
     /// [`keygen`](crate::keygen::KeygenParticipant) protocols.
-    pub fn new(
-        all_auxinfo_public: Vec<AuxInfoPublic>,
-        auxinfo_private: AuxInfoPrivate,
-        keygen_output: keygen::Output,
-    ) -> Result<Self> {
-        if all_auxinfo_public.len() != keygen_output.public_key_shares().len() {
+    pub fn new(auxinfo_output: auxinfo::Output, keygen_output: keygen::Output) -> Result<Self> {
+        if auxinfo_output.public_auxinfo().len() != keygen_output.public_key_shares().len() {
             error!(
                 "Number of auxinfo ({:?}) and keyshare ({:?}) public entries is not equal",
-                all_auxinfo_public.len(),
+                auxinfo_output.public_auxinfo().len(),
                 keygen_output.public_key_shares().len()
             );
             Err(CallerError::BadInput)?
         }
 
         // The same set of participants must have produced the key shares and aux infos.
-        let aux_sids = all_auxinfo_public
+        let aux_sids = auxinfo_output
+            .public_auxinfo()
             .iter()
-            .map(|auxinfo| auxinfo.participant())
+            .map(AuxInfoPublic::participant)
             .collect::<HashSet<_>>();
         let key_sids = keygen_output
             .public_key_shares()
             .iter()
-            .map(|keyshare| keyshare.participant())
+            .map(KeySharePublic::participant)
             .collect::<HashSet<_>>();
         if aux_sids != key_sids {
             error!("Public auxinfo and keyshare inputs to presign weren't from the same set of parties.");
@@ -280,7 +279,7 @@ impl Input {
             Err(CallerError::BadInput)?
         }
 
-        // The private values should map to one of the public values.
+        // The private key share should map to one of the public values.
         let expected_public_share = keygen_output.private_key_share().public_share()?;
         if !keygen_output
             .public_key_shares()
@@ -290,17 +289,20 @@ impl Input {
             error!("Keygen private share did not correspond to any of the provided keygen public shares.");
             Err(CallerError::BadInput)?
         }
-        if !all_auxinfo_public
+
+        // The private aux info should map to one of the public values
+        let expected_public_key = auxinfo_output.private_auxinfo().encryption_key();
+        if !auxinfo_output
+            .public_auxinfo()
             .iter()
-            .any(|auxinfo| &auxinfo_private.encryption_key() == auxinfo.pk())
+            .any(|auxinfo| &expected_public_key == auxinfo.pk())
         {
             error!("Auxinfo private key did not match any of the provided auxinfo public keys.");
             Err(CallerError::BadInput)?
         }
 
         Ok(Self {
-            all_auxinfo_public,
-            auxinfo_private,
+            auxinfo_output,
             keygen_output,
         })
     }
@@ -320,9 +322,7 @@ impl Input {
     /// Returns the [`AuxInfoPublic`] associated with the given
     /// [`ParticipantIdentifier`].
     fn find_auxinfo_public(&self, pid: ParticipantIdentifier) -> Result<&AuxInfoPublic> {
-        self.all_auxinfo_public
-            .iter()
-            .find(|item| item.participant() == pid)
+        self.auxinfo_output.find_public(pid)
             .ok_or_else(|| {
                 error!("Presign input doesn't contain a public auxinfo for {}, even though we checked for it at construction.", pid);
                 InternalError::InternalInvariantFailed
@@ -345,15 +345,16 @@ impl Input {
     /// Returns the [`AuxInfoPublic`]s associated with all the participants
     /// _except_ the given [`ParticipantIdentifier`].
     fn all_but_one_auxinfo_public(&self, pid: ParticipantIdentifier) -> Vec<&AuxInfoPublic> {
-        self.all_auxinfo_public
+        self.auxinfo_output
+            .public_auxinfo()
             .iter()
             .filter(|item| item.participant() != pid)
             .collect()
     }
     /// Returns a copy of the [`AuxInfoPublic`]s associated with all the
     /// participants (including this participant).
-    fn all_auxinfo_public(&self) -> Vec<AuxInfoPublic> {
-        self.all_auxinfo_public.clone()
+    fn to_public_auxinfo(&self) -> Vec<AuxInfoPublic> {
+        self.auxinfo_output.public_auxinfo().to_vec()
     }
 }
 
@@ -1020,7 +1021,7 @@ pub(crate) struct PresignKeyShareAndInfo {
 impl PresignKeyShareAndInfo {
     fn new(id: ParticipantIdentifier, input: &Input) -> Result<Self> {
         Ok(Self {
-            aux_info_private: input.auxinfo_private.clone(),
+            aux_info_private: input.auxinfo_output.private_auxinfo().clone(),
             aux_info_public: input.find_auxinfo_public(id)?.clone(),
             keyshare_private: input.keygen_output.private_key_share().clone(),
             keyshare_public: input.find_keyshare_public(id)?.clone(),
@@ -1329,45 +1330,15 @@ impl PresignKeyShareAndInfo {
 
 #[cfg(test)]
 mod test {
-    use rand::rngs::StdRng;
-
     use super::Input;
     use crate::{
+        auxinfo,
         errors::{CallerError, InternalError, Result},
         keygen,
-        paillier::DecryptionKey,
-        ring_pedersen::VerifiedRingPedersen,
         utils::testing::init_testing,
-        AuxInfoPrivate, AuxInfoPublic, Identifier, ParticipantConfig, ParticipantIdentifier,
-        PresignParticipant, ProtocolParticipant,
+        Identifier, ParticipantConfig, ParticipantIdentifier, PresignParticipant,
+        ProtocolParticipant,
     };
-    // Simulate the output of an auxinfo run with the given participants.
-    fn simulate_auxinfo_output(
-        pids: &[ParticipantIdentifier],
-        rng: &mut StdRng,
-    ) -> (AuxInfoPrivate, Vec<AuxInfoPublic>) {
-        let (mut auxinfo_private_outputs, auxinfo_public_outputs): (Vec<_>, Vec<_>) = pids
-            .iter()
-            .map(|&pid| {
-                let (key, _, _) = DecryptionKey::new(rng).unwrap();
-                (
-                    AuxInfoPrivate::from(key.clone()),
-                    AuxInfoPublic::new(
-                        &(),
-                        pid,
-                        key.encryption_key(),
-                        VerifiedRingPedersen::extract(&key, &(), rng).unwrap(),
-                    )
-                    .unwrap(),
-                )
-            })
-            .unzip();
-
-        (
-            auxinfo_private_outputs.pop().unwrap(),
-            auxinfo_public_outputs,
-        )
-    }
 
     #[test]
     fn inputs_must_be_same_length() {
@@ -1377,23 +1348,15 @@ mod test {
             .take(5)
             .collect::<Vec<_>>();
         let keygen_output = keygen::Output::simulate(&pids, rng);
-        let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&pids, rng);
+        let auxinfo_output = auxinfo::Output::simulate(&pids, rng);
 
         // Same length works
-        let result = Input::new(
-            auxinfo_public.clone(),
-            auxinfo_private.clone(),
-            keygen_output.clone(),
-        );
+        let result = Input::new(auxinfo_output.clone(), keygen_output.clone());
         assert!(result.is_ok());
 
         // If keygen is too short, it fails.
         let short_keygen = keygen::Output::simulate(&pids[1..], rng);
-        let result = Input::new(
-            auxinfo_public.clone(),
-            auxinfo_private.clone(),
-            short_keygen,
-        );
+        let result = Input::new(auxinfo_output, short_keygen);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1401,9 +1364,8 @@ mod test {
         );
 
         // If auxinfo is too short, it fails.
-        let mut short_auxinfo = auxinfo_public;
-        let _dropped = short_auxinfo.pop();
-        let result = Input::new(short_auxinfo, auxinfo_private, keygen_output);
+        let short_auxinfo = auxinfo::Output::simulate(&pids[1..], rng);
+        let result = Input::new(short_auxinfo, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1418,22 +1380,18 @@ mod test {
         let mut pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
-        let (auxinfo_private, mut auxinfo_public) = simulate_auxinfo_output(&pids, rng);
 
         // This test doesn't bother adding a duplicate in only one of the inputs because
         // that would fail the length checks tested in `inputs_must_be_same_length`
+        // Instead, duplicate one of the PIDs...
+        pids.push(pids[4]);
 
-        // Push a copy of one of the auxinfo publics.
-        let auxinfo_dup = auxinfo_public.pop().unwrap();
-        auxinfo_public.push(auxinfo_dup.clone());
-        auxinfo_public.push(auxinfo_dup);
-
-        // Make a keygen output with a duplicated pid (the public key material itself
-        // will be different)
-        pids.push(pids[4]); // take the last item to match the pop'd auxinfo pid.
+        // ...and simulate the outputs. The public material will be different for the
+        // two duplicated PIDs.
         let keygen_output = keygen::Output::simulate(&pids, rng);
+        let auxinfo_output = auxinfo::Output::simulate(&pids, rng);
 
-        let result = Input::new(auxinfo_public, auxinfo_private, keygen_output);
+        let result = Input::new(auxinfo_output, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
@@ -1448,47 +1406,19 @@ mod test {
         let auxinfo_pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
-        let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&auxinfo_pids, rng);
+        let auxinfo_output = auxinfo::Output::simulate(&auxinfo_pids, rng);
 
         let keygen_pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
             .take(5)
             .collect::<Vec<_>>();
         let keygen_output = keygen::Output::simulate(&keygen_pids, rng);
 
-        let result = Input::new(auxinfo_public, auxinfo_private, keygen_output);
+        let result = Input::new(auxinfo_output, keygen_output);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
             InternalError::CallingApplicationMistake(CallerError::BadInput)
         );
-    }
-
-    #[test]
-    fn inputs_must_have_a_public_private_pair() {
-        let rng = &mut init_testing();
-
-        let pids = std::iter::repeat_with(|| ParticipantIdentifier::random(rng))
-            .take(5)
-            .collect::<Vec<_>>();
-
-        let keygen_output = keygen::Output::simulate(&pids, rng);
-        let (_, auxinfo_public) = simulate_auxinfo_output(&pids, rng);
-
-        // Make a private auxinfo component with no relation to the public inputs.
-        let fake_auxinfo_private = AuxInfoPrivate::from(DecryptionKey::new(rng).unwrap().0);
-
-        // Auxinfo private key must correspond to one of the public inputs.
-        let result = Input::new(auxinfo_public, fake_auxinfo_private, keygen_output);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            InternalError::CallingApplicationMistake(CallerError::BadInput)
-        );
-
-        // Note: we can't test the same thing for keygen because the keygen
-        // output type doesn't let us muck around with its internal
-        // representation here. TODO #376: Add the equivalent test in
-        // the keygen module.
     }
 
     #[test]
@@ -1501,9 +1431,9 @@ mod test {
             .take(SIZE)
             .collect::<Vec<_>>();
         let keygen_output = keygen::Output::simulate(&input_pids, rng);
-        let (auxinfo_private, auxinfo_public) = simulate_auxinfo_output(&input_pids, rng);
+        let auxinfo_output = auxinfo::Output::simulate(&input_pids, rng);
 
-        let input = Input::new(auxinfo_public, auxinfo_private, keygen_output)?;
+        let input = Input::new(auxinfo_output, keygen_output)?;
 
         // Create valid config with PIDs independent of those used to make the input set
         let config = ParticipantConfig::random(SIZE, rng);

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -9,10 +9,7 @@
 // of this source tree.
 
 use crate::{
-    auxinfo::{
-        self,
-        info::{AuxInfoPrivate, AuxInfoPublic},
-    },
+    auxinfo::{self, AuxInfoPrivate, AuxInfoPublic},
     broadcast::participant::{BroadcastOutput, BroadcastParticipant, BroadcastTag},
     errors::{CallerError, InternalError, Result},
     keygen::{self, KeySharePrivate, KeySharePublic},
@@ -235,10 +232,9 @@ pub struct PresignParticipant {
 /// Input needed for [`PresignParticipant`] to run.
 #[derive(Debug, Clone)]
 pub struct Input {
-    /// The key share material for the key corresponding to the presign run.
+    /// The key share material for the key that will be used in the presign run.
     keygen_output: keygen::Output,
-    /// The private auxinfo of this participant.
-    /// The public auxinfo of all the participants (including this participant).
+    /// The auxiliary info for the key that will be used in the presign run.
     auxinfo_output: auxinfo::Output,
 }
 

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::{
-    auxinfo::info::AuxInfoPublic,
+    auxinfo::AuxInfoPublic,
     errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
     presign::{

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::{
-    auxinfo::info::AuxInfoPublic,
+    auxinfo::AuxInfoPublic,
     errors::{InternalError, Result},
     keygen::KeySharePublic,
     messages::{Message, MessageType, PresignMessageType},

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -82,8 +82,8 @@ pub enum ProtocolType {
 /// participant, and **these must be stored securely by the calling
 /// application**. Which outputs require secure storage is documented by each
 /// protocol type, under the "Storage requirements" heading:
-/// [`KeygenParticipant`](crate::KeygenParticipant),
-/// [`AuxInfoParticipant`](crate::AuxInfoParticipant), and
+/// [`KeygenParticipant`](crate::keygen::KeygenParticipant),
+/// [`AuxInfoParticipant`](crate::auxinfo::AuxInfoParticipant), and
 /// [`PresignParticipant`](crate::PresignParticipant). In addition, some outputs
 /// must only be used once and then discarded. These are documented as necessary
 /// under the "Lifetime requirements" heading in the aforementioned types.
@@ -646,8 +646,10 @@ impl std::fmt::Display for Identifier {
 mod tests {
     use super::*;
     use crate::{
-        auxinfo::participant::AuxInfoParticipant, keygen::KeygenParticipant,
-        presign::participant::Input as PresignInput, utils::testing::init_testing,
+        auxinfo::{self, AuxInfoParticipant},
+        keygen::KeygenParticipant,
+        presign::participant::Input as PresignInput,
+        utils::testing::init_testing,
         PresignParticipant,
     };
     use k256::ecdsa::signature::DigestVerifier;
@@ -893,7 +895,7 @@ mod tests {
         // And make sure all participants have successfully terminated.
         assert!(auxinfo_quorum
             .iter()
-            .all(|p| *p.status() == crate::auxinfo::participant::Status::TerminatedSuccessfully));
+            .all(|p| *p.status() == auxinfo::Status::TerminatedSuccessfully));
 
         // Set up keygen participants
         let keygen_sid = Identifier::random(&mut rng);
@@ -947,12 +949,12 @@ mod tests {
             .iter()
             .map(|config| {
                 (
-                    auxinfo_outputs.get(&config.id()).unwrap(),
-                    keygen_outputs.get(&config.id()).unwrap(),
+                    auxinfo_outputs.remove(&config.id()).unwrap(),
+                    keygen_outputs.remove(&config.id()).unwrap(),
                 )
             })
-            .map(|((aux_pub, aux_priv), keygen_output)| {
-                PresignInput::new(aux_pub.clone(), aux_priv.clone(), keygen_output.clone()).unwrap()
+            .map(|(auxinfo_output, keygen_output)| {
+                PresignInput::new(auxinfo_output, keygen_output).unwrap()
             })
             .collect::<Vec<_>>();
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -12,12 +12,11 @@
 
 use crate::{
     errors::{CallerError, InternalError, Result},
-    messages::MessageType,
+    messages::{Message, MessageType},
     participant::{InnerProtocolParticipant, ProtocolParticipant},
     protocol::participant_config::ParticipantConfig,
     utils::{k256_order, CurvePoint},
     zkp::ProofContext,
-    Message,
 };
 use k256::elliptic_curve::IsHigh;
 use libpaillier::unknown_order::BigNumber;


### PR DESCRIPTION
Closes #406.

This adds an `Output` type to auxinfo and also rejigs the public-facing module structure a bit (hence all the changes in the includes).

Looking for:
- general Rust review -- is this a good API?
- test ideas -- is there anything I missed about the structure of the auxinfo output that should be checked here?