### PR TITLE
288-remove

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -591,17 +591,14 @@ impl AuxInfoParticipant {
             let auxinfo_public = self
                 .all_participants()
                 .iter()
-                .map(|pid| {
-                    let value = self.local_storage.retrieve::<storage::Public>(*pid)?;
-                    Ok(value.clone())
-                })
+                .map(|pid| self.local_storage.remove::<storage::Public>(*pid))
                 .collect::<Result<Vec<_>>>()?;
-            let auxinfo_private = self.local_storage.retrieve::<storage::Private>(self.id)?;
+            let auxinfo_private = self.local_storage.remove::<storage::Private>(self.id)?;
 
             self.status = Status::TerminatedSuccessfully;
             Ok(ProcessOutcome::Terminated((
                 auxinfo_public,
-                auxinfo_private.clone(),
+                auxinfo_private,
             )))
         } else {
             // Otherwise, we'll have to wait for more round three messages.

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -93,6 +93,36 @@ impl LocalStorage {
             })
     }
 
+    /// Deletes a storage value via its [`TypeTag`] and
+    /// [`ParticipantIdentifier`]. This function returns the deleted value
+    /// if it existed and should be used instead of retrieve if the value is
+    /// being accessed for the last time.
+    pub(crate) fn remove<T: TypeTag>(
+        &mut self,
+        participant_id: ParticipantIdentifier,
+    ) -> Result<T::Value> {
+        self.storage
+            .remove(&(participant_id, TypeId::of::<T>()))
+            .ok_or_else(|| {
+                error!(
+                    "Could not locate storage entry. Type: {:?}, participant_id: {}",
+                    std::any::type_name::<T::Value>(),
+                    participant_id
+                );
+                InternalError::InternalInvariantFailed
+            })?
+            .downcast::<T::Value>()
+            .map_err(|_| {
+                error!(
+                    "Could not downcast storage entry. Type: {:?}, participant_id: {}",
+                    std::any::type_name::<T::Value>(),
+                    participant_id
+                );
+                InternalError::InternalInvariantFailed
+            })
+            .map(|any| *any)
+    }
+
     /// Retrieves a mutable reference to a value via its [`TypeTag`]
     /// and [`ParticipantIdentifier`].
     pub(crate) fn retrieve_mut<T: TypeTag>(

--- a/src/local_storage.rs
+++ b/src/local_storage.rs
@@ -94,9 +94,10 @@ impl LocalStorage {
     }
 
     /// Deletes a storage value via its [`TypeTag`] and
-    /// [`ParticipantIdentifier`]. This function returns the deleted value
-    /// if it existed and should be used instead of retrieve if the value is
-    /// being accessed for the last time.
+    /// [`ParticipantIdentifier`]. This function returns the deleted value if it
+    /// existed and should be used instead of
+    /// [`retrieve()`](LocalStorage::retrieve()) if the value is being
+    /// accessed for the last time.
     pub(crate) fn remove<T: TypeTag>(
         &mut self,
         participant_id: ParticipantIdentifier,


### PR DESCRIPTION
Adds a new `remove()` function to the Storage API, which removes an item from storage and returns it to the call. Replaces a few end-of-protocol calls to `retrieve` with `remove`, but only where there is no chance that the item will be needed again. Replacing other instances of `retrieve` with `remove` will require more care, especially when considering the possibility of `ProtocolError`s

Closes #288 