### PR TITLE
reduces passing of inputs in protocols

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -198,7 +198,6 @@ impl ProtocolParticipant for AuxInfoParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing auxinfo message.");
 
@@ -212,7 +211,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
                 // Handle the broadcasted message if all parties have agreed on it
-                broadcast_outcome.convert(self, Self::handle_round_one_msg, rng, input)
+                broadcast_outcome.convert(self, Self::handle_round_one_msg, rng)
             }
             MessageType::Auxinfo(AuxinfoMessageType::R2Decommit) => {
                 self.handle_round_two_msg(rng, message)
@@ -333,7 +332,6 @@ impl AuxInfoParticipant {
         &mut self,
         rng: &mut R,
         broadcast_message: BroadcastOutput,
-        _input: &(),
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling round one auxinfo message.");
 
@@ -720,10 +718,7 @@ mod tests {
             &message.message_type(),
             &message.from(),
         );
-        Some((
-            index,
-            participant.process_message(rng, &message, &()).unwrap(),
-        ))
+        Some((index, participant.process_message(rng, &message).unwrap()))
     }
 
     #[cfg_attr(feature = "flame_it", flame)]

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -153,7 +153,6 @@ impl ProtocolParticipant for BroadcastParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        _: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing broadcast message.");
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -250,7 +250,6 @@ impl ProtocolParticipant for KeygenParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>> {
         info!("Processing keygen message.");
 
@@ -264,7 +263,7 @@ impl ProtocolParticipant for KeygenParticipant {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
                 // Handle the broadcasted message if all parties have agreed on it
-                broadcast_outcome.convert(self, Self::handle_round_one_msg, rng, input)
+                broadcast_outcome.convert(self, Self::handle_round_one_msg, rng)
             }
             MessageType::Keygen(KeygenMessageType::R2Decommit) => {
                 self.handle_round_two_msg(message)
@@ -392,7 +391,6 @@ impl KeygenParticipant {
         &mut self,
         rng: &mut R,
         broadcast_message: BroadcastOutput,
-        _input: &(),
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling round one keygen message.");
 
@@ -748,10 +746,7 @@ mod tests {
             &message.message_type(),
             &message.from(),
         );
-        Some((
-            index,
-            participant.process_message(rng, &message, &()).unwrap(),
-        ))
+        Some((index, participant.process_message(rng, &message).unwrap()))
     }
 
     #[cfg_attr(feature = "flame_it", flame)]

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -84,16 +84,15 @@ where
         participant: &mut P,
         mut handle_output: F,
         rng: &mut R,
-        storage: &P::Input,
     ) -> Result<ProcessOutcome<P::Output>>
     where
         P: InnerProtocolParticipant,
-        F: FnMut(&mut P, &mut R, O, &P::Input) -> Result<ProcessOutcome<P::Output>>,
+        F: FnMut(&mut P, &mut R, O) -> Result<ProcessOutcome<P::Output>>,
         R: CryptoRng + RngCore,
     {
         let (output, messages) = self.into_parts();
         let outcome = match output {
-            Some(o) => handle_output(participant, rng, o, storage)?,
+            Some(o) => handle_output(participant, rng, o)?,
             None => ProcessOutcome::Incomplete,
         };
         Ok(outcome.with_messages(messages))
@@ -241,7 +240,6 @@ pub trait ProtocolParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &Self::Input,
     ) -> Result<ProcessOutcome<Self::Output>>;
 
     /// The status of the protocol execution.
@@ -413,7 +411,7 @@ pub(crate) trait Broadcast {
 
         let outcome = self
             .broadcast_participant()
-            .process_message(rng, &broadcast_input, &())?;
+            .process_message(rng, &broadcast_input)?;
 
         // ...and then re-wrap the output messages.
         let (output, mut messages) = outcome.into_parts();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -190,9 +190,7 @@ impl<P: ProtocolParticipant> Participant<P> {
         }
 
         // Handle it!
-        let outcome =
-            self.participant
-                .process_message(rng, message, &self.participant.input().clone())?;
+        let outcome = self.participant.process_message(rng, message)?;
         let (output, messages) = outcome.into_parts();
         Ok((output, messages))
     }


### PR DESCRIPTION
This handles part of #290 but does not complete it. 

The code landed in a weird intermediate state where the `ProtocolParticipant` types all held their inputs as a field, but the input was also passed around to all the methods. This PR removes that duplication (and in the process, removes the need to clone inputs for every new message received, reducing memory usage and the number of copies of secrets floating around).