### PR TITLE
add storage methods for auxinfo

### DIFF
--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -10,6 +10,7 @@ use crate::{
     errors::{CallerError, InternalError, Result},
     paillier::{DecryptionKey, EncryptionKey},
     ring_pedersen::VerifiedRingPedersen,
+    utils::ParseBytes,
     zkp::ProofContext,
     ParticipantIdentifier,
 };
@@ -74,41 +75,41 @@ impl AuxInfoPrivate {
         // AUXINFO_TAG | key_len in bytes | key
         //             | ---8 bytes------ | --key_len bytes---
 
-        // Check the tag.
-        if bytes.len() < AUXINFO_TAG.len() {
-            error!("Failed to deserialize `AuxInfoPrivate` due to invalid tag");
-            Err(CallerError::DeserializationFailed)?
-        }
-        // `split_at` panics if the parameter is larger than the length, but we check
-        // above so it's okay.
-        let (actual_tag, bytes) = bytes.split_at(AUXINFO_TAG.len());
-        if actual_tag != AUXINFO_TAG {
-            error!("Failed to deserialize `AuxInfoPrivate` due to invalid tag");
-            Err(CallerError::DeserializationFailed)?
-        }
+        // Make sure the AUXINFO_TAG is correct
+        let result = {
+            let mut parser = ParseBytes::new(bytes);
 
-        // Check the key len
-        if bytes.len() < AUXINFO_LEN {
-            error!("Failed to deserialize `AuxInfoPrivate` due to invalid length field");
-            Err(CallerError::DeserializationFailed)?
-        }
-        let (key_len, key_bytes) = bytes.split_at(AUXINFO_LEN);
-        let fixed_size_len: [u8; 8] = key_len.try_into().map_err(|_| {
-            error!("Failed to convert byte array (should always work because we defined it to be exactly 8 bytes)");
-            InternalError::InternalInvariantFailed
-        })?;
-        if usize::from_le_bytes(fixed_size_len) != key_bytes.len() {
-            error!("Failed to deserialize `AuxInfoPrivate` due to invalid length field");
-            Err(CallerError::DeserializationFailed)?
-        }
+            let actual_tag = parser.take_bytes(AUXINFO_TAG.len())?;
+            if actual_tag != AUXINFO_TAG {
+                Err(CallerError::DeserializationFailed)?
+            }
 
-        // Check the key
-        let decryption_key = DecryptionKey::try_from_bytes(key_bytes.to_vec()).map_err(|_| {
-            error!("Failed to deserialize `AuxInfoPrivate` due to invalid decryption key");
-            CallerError::DeserializationFailed
-        })?;
+            // Extract the length of the key
+            let key_len_slice = parser.take_bytes(AUXINFO_LEN)?;
+            let len_bytes: [u8; AUXINFO_LEN] = key_len_slice.try_into().map_err(|_| {
+                    error!("Failed to convert byte array (should always work because we defined it to be exactly 8 bytes)");
+                    InternalError::InternalInvariantFailed
+                })?;
+            let key_len = usize::from_le_bytes(len_bytes);
 
-        Ok(Self { decryption_key })
+            let key_bytes = parser.take_rest()?;
+            if key_bytes.len() != key_len {
+                Err(CallerError::DeserializationFailed)?
+            }
+
+            // Check the key
+            let decryption_key = DecryptionKey::try_from_bytes(key_bytes).map_err(|_| {
+                error!("Failed to deserialize `AuxInfoPrivate` due to invalid decryption key");
+                CallerError::DeserializationFailed
+            })?;
+
+            Ok(Self { decryption_key })
+        };
+
+        if result.is_err() {
+            error!("Failed to deserialize `AuxInfoPrivate`");
+        }
+        result
     }
 }
 

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -80,7 +80,7 @@ impl AuxInfoPrivate {
 
         let mut parser = ParseBytes::new(bytes);
 
-        // This little method ensures that
+        // This little closure ensures that
         // 1. We can zeroize out the potentially-sensitive input bytes regardless of
         //    whether parsing succeeded; and
         // 2. We can log the error message once at the end, rather than duplicating it

--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -30,7 +30,7 @@ use tracing::{error, instrument};
 ///
 /// Note: this doesn't implement [`ZeroizeOnDrop`] but all of its internal types
 /// do.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AuxInfoPrivate {
     /// The participant's Paillier private key.
     decryption_key: DecryptionKey,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,7 +50,7 @@ pub enum CallerError {
     RetryFailed,
     #[error("Tried to create an invalid `ParticipantConfig` (the protocol requires at least 2 uniquely identified parties)")]
     ParticipantConfigError,
-    #[error("The provided input did not satisfy the requirements on the input type. See logs for details.")]
+    #[error("The provided input did not satisfy the requirements on the input type; see logs for details")]
     BadInput,
     #[error("Failed to deserialize bytes into the expected type")]
     DeserializationFailed,

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -225,6 +225,16 @@ impl Debug for DecryptionKey {
     }
 }
 
+impl PartialEq for DecryptionKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.n() == other.0.n()
+          && self.0.totient() == other.0.totient()
+          && self.0.lambda() == other.0.lambda()
+          && self.0.u() == other.0.u()
+    }
+}
+impl Eq for DecryptionKey {}
+
 impl DecryptionKey {
     /// Compute the floor of `n/2` for the modulus `n`.
     ///

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -307,6 +307,21 @@ impl DecryptionKey {
         }
     }
 
+    pub(crate) fn into_bytes(&self) -> Vec<u8> {
+        // Note: the libpaillier crate just serializes the four fields; it doesn't
+        // do any length prepending or other misuse-resistant things.
+        self.0.to_bytes()
+    }
+
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        libpaillier::DecryptionKey::from_bytes(bytes);
+
+        // Validate: make sure the total length is correct.
+        // Can we check the factor length to make sure they're both large?
+
+        todo!()
+    }
+
     /// Retrieve the public [`EncryptionKey`] corresponding to this secret
     /// [`DecryptionKey`].
     pub(crate) fn encryption_key(&self) -> EncryptionKey {

--- a/src/paillier.rs
+++ b/src/paillier.rs
@@ -324,7 +324,7 @@ impl DecryptionKey {
         self.0.to_bytes()
     }
 
-    pub(crate) fn try_from_bytes(bytes: Vec<u8>) -> Result<Self> {
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         // Convert bytes to libpaillier::DecryptionKey
         // This method does not validate the key for consistency
         let decryption_key = libpaillier::DecryptionKey::from_bytes(bytes).map_err(|err| {
@@ -658,7 +658,7 @@ mod test {
         let (decryption_key, _, _) = DecryptionKey::new(rng).unwrap();
 
         let bytes = decryption_key.clone().into_bytes();
-        let reconstructed = DecryptionKey::try_from_bytes(bytes);
+        let reconstructed = DecryptionKey::try_from_bytes(&bytes);
 
         assert!(reconstructed.is_ok());
         assert_eq!(reconstructed.unwrap(), decryption_key);
@@ -677,7 +677,7 @@ mod test {
             DecryptionKey(libpaillier::DecryptionKey::with_primes(&p, &q).unwrap());
 
         let bytes = small_decryption_key.into_bytes();
-        assert!(DecryptionKey::try_from_bytes(bytes).is_err());
+        assert!(DecryptionKey::try_from_bytes(&bytes).is_err());
 
         // Generate too-large primes (this is sometimes slow)
         let p = BigNumber::safe_prime_from_rng(PRIME_BITS + 1, rng);
@@ -686,6 +686,6 @@ mod test {
             DecryptionKey(libpaillier::DecryptionKey::with_primes(&p, &q).unwrap());
         assert!(large_decryption_key.modulus().bit_length() > 2 * PRIME_BITS);
         let bytes = large_decryption_key.into_bytes();
-        assert!(DecryptionKey::try_from_bytes(bytes).is_err());
+        assert!(DecryptionKey::try_from_bytes(&bytes).is_err());
     }
 }


### PR DESCRIPTION
This addresses part of #429 but does not complete it.

I decided to break 429 into pieces because this is already fairly large.

It adds equality checking and manual serialization / deserialization method to `AuxInfoPrivate` and its underlying `DecryptionKey`.

This change flags again the unsuitability of the `libpaillier` dependency we're using; it doesn't do any validation of the correctness of a deserialized decryption key. I added a check but I only came up with one property that we can check without having the factors handy. Maybe there are other things related lengths of the fields?
