### PR TITLE
add storage methods for keygen

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,6 +52,8 @@ pub enum CallerError {
     ParticipantConfigError,
     #[error("The provided input did not satisfy the requirements on the input type. See logs for details.")]
     BadInput,
+    #[error("Failed to deserialize bytes into the expected type")]
+    DeserializationFailed,
 }
 
 macro_rules! serialize {

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::{
-    errors::Result,
+    errors::{CallerError, InternalError, Result},
     utils::{k256_order, CurvePoint},
     ParticipantIdentifier,
 };
@@ -15,22 +15,29 @@ use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
+use tracing::error;
 use zeroize::ZeroizeOnDrop;
+
+const KEYSHARE_TAG: &[u8] = b"KeySharePrivate";
+/// Length of the field indicating the length of the key share.
+const KEYSHARE_LEN: usize = 8;
 
 /// Private key corresponding to a given [`Participant`](crate::Participant)'s
 /// [`KeySharePublic`].
 ///
 /// # 🔒 Storage requirements
 /// This type must be stored securely by the calling application.
-#[derive(Clone, ZeroizeOnDrop)]
+#[derive(Clone, ZeroizeOnDrop, PartialEq, Eq)]
 pub struct KeySharePrivate {
     x: BigNumber, // in the range [1, q)
 }
+
 impl Debug for KeySharePrivate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("KeySharePrivate([redacted])")
     }
 }
+
 impl KeySharePrivate {
     /// Sample a private key share uniformly at random.
     pub(crate) fn random(rng: &mut (impl CryptoRng + RngCore)) -> Self {
@@ -41,6 +48,68 @@ impl KeySharePrivate {
     /// Computes the "raw" curve point corresponding to this private key.
     pub(crate) fn public_share(&self) -> Result<CurvePoint> {
         CurvePoint::GENERATOR.multiply_by_scalar(&self.x)
+    }
+
+    /// Convert private material into bytes.
+    ///
+    /// 🔒 This is inteded for use by the calling application for secure
+    /// storage. The output of this function should be handled with care.
+    pub fn into_bytes(self) -> Vec<u8> {
+        // Format:
+        // KEYSHARE_TAG | key_len in bytes | key (big endian bytes)
+        //              | 8 bytes          | key_len bytes
+
+        let share = self.x.to_bytes();
+        let share_len = share.len().to_le_bytes();
+
+        [KEYSHARE_TAG, &share_len, &share].concat()
+    }
+
+    /// Convert bytes into private material.
+    ///
+    /// 🔒 This is intended for use by the calling application for secure
+    /// storage. Do not use this method to create arbitrary instances of
+    /// [`KeySharePrivate`].
+    pub fn try_from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        // Expected format:
+        // KEYSHARE_TAG | key_len in bytes | key (big endian bytes)
+        //              | 8 bytes          | key_len bytes
+
+        // Check the tag.
+        if bytes.len() < KEYSHARE_TAG.len() {
+            error!("Failed to deserialize `KeySharePrivate`: invalid tag");
+            Err(CallerError::DeserializationFailed)?
+        }
+        let (actual_tag, bytes) = bytes.split_at(KEYSHARE_TAG.len());
+        if actual_tag != KEYSHARE_TAG {
+            error!("Failed to deserialize `KeySharePrivate`: invalid tag");
+            Err(CallerError::DeserializationFailed)?
+        }
+
+        // Check the share len
+        if bytes.len() < KEYSHARE_LEN {
+            error!("Failed to deserialize `KeySharePrivate`: invalid length field");
+            Err(CallerError::DeserializationFailed)?
+        }
+        let (share_len, share_bytes) = bytes.split_at(KEYSHARE_LEN);
+        let fixed_size_len: [u8; KEYSHARE_LEN] = share_len.try_into().map_err(|_| {
+            error!("Failed to convert byte array even though we specified the size");
+            InternalError::InternalInvariantFailed
+        })?;
+
+        if usize::from_le_bytes(fixed_size_len) != share_bytes.len() {
+            error!("Failed to deserialize `KeySharePrivate`: invalid length field");
+            Err(CallerError::DeserializationFailed)?
+        }
+
+        // Check the key share
+        let share = BigNumber::from_slice(share_bytes);
+        if share > k256_order() || share < BigNumber::zero() {
+            error!("Failed to deserialize `KeySharePrivate`: share value out of range");
+            Err(CallerError::DeserializationFailed)?
+        }
+
+        Ok(Self { x: share })
     }
 }
 
@@ -74,7 +143,7 @@ impl KeySharePublic {
     }
 
     /// Generate a new [`KeySharePrivate`] and [`KeySharePublic`].
-    pub fn new_keyshare<R: RngCore + CryptoRng>(
+    pub(crate) fn new_keyshare<R: RngCore + CryptoRng>(
         participant: ParticipantIdentifier,
         rng: &mut R,
     ) -> Result<(KeySharePrivate, KeySharePublic)> {

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -79,7 +79,7 @@ impl KeySharePrivate {
 
         let mut parser = ParseBytes::new(bytes);
 
-        // This little method ensures that
+        // This little function ensures that
         // 1. We can zeroize out the potentially-sensitive input bytes regardless of
         //    whether parsing succeeded; and
         // 2. We can log the error message once at the end, rather than duplicating it

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,6 +77,40 @@ impl<'de> Deserialize<'de> for CurvePoint {
     }
 }
 
+/// Helper type for parsing byte array into slices.
+///
+/// This type implements [`Zeroize`]. When parsing secret types, you should
+/// manually call `zeroize()` after parsing is complete.
+#[derive(Zeroize)]
+pub(crate) struct ParseBytes {
+    bytes: Vec<u8>,
+    offset: usize,
+}
+
+impl ParseBytes {
+    /// Consume bytes for parsing.
+    pub(crate) fn new(bytes: Vec<u8>) -> ParseBytes {
+        ParseBytes { bytes, offset: 0 }
+    }
+
+    /// Take next `n` bytes from array.
+    pub(crate) fn take_bytes(&mut self, n: usize) -> Result<&[u8]> {
+        let slice = &self
+            .bytes
+            .get(self.offset..self.offset + n)
+            .ok_or(CallerError::DeserializationFailed)?;
+        self.offset += n;
+        Ok(slice)
+    }
+
+    /// Take the rest of the bytes from the array.
+    pub(crate) fn take_rest(&mut self) -> Result<&[u8]> {
+        self.bytes
+            .get(self.offset..)
+            .ok_or(CallerError::DeserializationFailed.into())
+    }
+}
+
 /// Returns `true` if `value ∊ [-2^n, 2^n]`.
 pub(crate) fn within_bound_by_size(value: &BigNumber, n: usize) -> bool {
     let bound = BigNumber::one() << n;


### PR DESCRIPTION
Addresses part of #429 but doesn't complete it.

This has some overlapping changes with #433, specifically the `ParseBytes` utility. It is smaller and plausibly easier to review than #433, so maybe do this one first.

