### PR TITLE
Debug ProtocolAlreadyTerminated tests failure

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -138,7 +138,7 @@ pub struct AuxInfoParticipant {
     /// The status of the protocol execution
     status: Status,
     /// Whether or not the participant is Ready
-    ready: bool
+    ready: bool,
 }
 
 impl ProtocolParticipant for AuxInfoParticipant {
@@ -167,7 +167,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
                 input,
             )?,
             status: Status::Initialized,
-            ready: false
+            ready: false,
         })
     }
 
@@ -209,7 +209,9 @@ impl ProtocolParticipant for AuxInfoParticipant {
         }
 
         match message.message_type() {
-            MessageType::Auxinfo(AuxinfoMessageType::Ready) => self.handle_ready_msg(rng, message, input),
+            MessageType::Auxinfo(AuxinfoMessageType::Ready) => {
+                self.handle_ready_msg(rng, message, input)
+            }
             MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -282,7 +284,8 @@ impl AuxInfoParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling auxinfo ready message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+        let (ready_outcome, is_ready) =
+            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -209,9 +209,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
         }
 
         match message.message_type() {
-            MessageType::Auxinfo(AuxinfoMessageType::Ready) => {
-                self.handle_ready_msg(rng, message, input)
-            }
+            MessageType::Auxinfo(AuxinfoMessageType::Ready) => self.handle_ready_msg(rng, message),
             MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -280,12 +278,11 @@ impl AuxInfoParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &<AuxInfoParticipant as crate::participant::ProtocolParticipant>::Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling auxinfo ready message.");
 
         let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+            self.process_ready_message::<R, storage::Ready>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -137,6 +137,8 @@ pub struct AuxInfoParticipant {
     broadcast_participant: BroadcastParticipant,
     /// The status of the protocol execution
     status: Status,
+    /// Whether or not the participant is Ready
+    ready: bool
 }
 
 impl ProtocolParticipant for AuxInfoParticipant {
@@ -165,6 +167,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
                 input,
             )?,
             status: Status::Initialized,
+            ready: false
         })
     }
 
@@ -206,7 +209,7 @@ impl ProtocolParticipant for AuxInfoParticipant {
         }
 
         match message.message_type() {
-            MessageType::Auxinfo(AuxinfoMessageType::Ready) => self.handle_ready_msg(rng, message),
+            MessageType::Auxinfo(AuxinfoMessageType::Ready) => self.handle_ready_msg(rng, message, input),
             MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -232,6 +235,10 @@ impl ProtocolParticipant for AuxInfoParticipant {
     fn status(&self) -> &Self::Status {
         &self.status
     }
+
+    fn is_ready(&self) -> bool {
+        self.ready
+    }
 }
 
 impl InnerProtocolParticipant for AuxInfoParticipant {
@@ -247,6 +254,10 @@ impl InnerProtocolParticipant for AuxInfoParticipant {
 
     fn local_storage_mut(&mut self) -> &mut LocalStorage {
         &mut self.local_storage
+    }
+
+    fn set_ready(&mut self) {
+        self.ready = true;
     }
 }
 
@@ -267,10 +278,11 @@ impl AuxInfoParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
+        input: &<AuxInfoParticipant as crate::participant::ProtocolParticipant>::Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling auxinfo ready message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<storage::Ready>(message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -281,8 +281,7 @@ impl AuxInfoParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling auxinfo ready message.");
 
-        let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -208,6 +208,11 @@ impl ProtocolParticipant for AuxInfoParticipant {
             Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
+        if !self.is_ready() && message.message_type() != Self::ready_type() {
+            self.stash_message(message)?;
+            return Ok(ProcessOutcome::Incomplete);
+        }
+
         match message.message_type() {
             MessageType::Auxinfo(AuxinfoMessageType::Ready) => self.handle_ready_msg(rng, message),
             MessageType::Auxinfo(AuxinfoMessageType::R1CommitHash) => {
@@ -281,14 +286,10 @@ impl AuxInfoParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling auxinfo ready message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<R>(rng, message)?;
-
-        if is_ready {
-            let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;
-            Ok(ready_outcome.with_messages(round_one_messages))
-        } else {
-            Ok(ready_outcome)
-        }
+        let ready_outcome = self.process_ready_message(rng, message)?;
+        let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;
+        // extend the output with r1 messages (if they hadn't already been generated)
+        Ok(ready_outcome.with_messages(round_one_messages))
     }
 
     /// Generate the participant's round one message.

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -154,7 +154,12 @@ impl ProtocolParticipant for BroadcastParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<ProcessOutcome<Self::Output>> {
-        info!("BROADCAST: Player {}: received {:?} from {}", self.id(), message.message_type(), message.from());
+        info!(
+            "BROADCAST: Player {}: received {:?} from {}",
+            self.id(),
+            message.message_type(),
+            message.from()
+        );
 
         if let Status::ParticipantCompletedBroadcast(participants) = self.status() {
             // The protocol has terminated if the number of participants who
@@ -186,8 +191,8 @@ impl ProtocolParticipant for BroadcastParticipant {
         &self.status
     }
 
-    // As a subprotocol, Broadcast doesn't need to be activated with a Ready message.
-    // However, it's part of the trait and needs to be implemented.
+    // As a subprotocol, Broadcast doesn't need to be activated with a Ready
+    // message. However, it's part of the trait and needs to be implemented.
     fn is_ready(&self) -> bool {
         true
     }

--- a/src/broadcast/participant.rs
+++ b/src/broadcast/participant.rs
@@ -154,7 +154,7 @@ impl ProtocolParticipant for BroadcastParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<ProcessOutcome<Self::Output>> {
-        info!("Processing broadcast message.");
+        info!("BROADCAST: Player {}: received {:?} from {}", self.id(), message.message_type(), message.from());
 
         if let Status::ParticipantCompletedBroadcast(participants) = self.status() {
             // The protocol has terminated if the number of participants who
@@ -185,6 +185,12 @@ impl ProtocolParticipant for BroadcastParticipant {
     fn status(&self) -> &Self::Status {
         &self.status
     }
+
+    // As a subprotocol, Broadcast doesn't need to be activated with a Ready message.
+    // However, it's part of the trait and needs to be implemented.
+    fn is_ready(&self) -> bool {
+        true
+    }
 }
 
 impl InnerProtocolParticipant for BroadcastParticipant {
@@ -202,6 +208,8 @@ impl InnerProtocolParticipant for BroadcastParticipant {
     fn local_storage_mut(&mut self) -> &mut LocalStorage {
         &mut self.local_storage
     }
+
+    fn set_ready(&mut self) {}
 }
 
 impl BroadcastParticipant {

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -129,6 +129,8 @@ pub struct KeygenParticipant {
     broadcast_participant: BroadcastParticipant,
     /// Status of the protocol execution.
     status: Status,
+    /// Whether or not the participant is Ready
+    ready: bool
 }
 
 /// Output type from key generation, including all parties' public key shares,
@@ -217,6 +219,7 @@ impl ProtocolParticipant for KeygenParticipant {
                 input,
             )?,
             status: Status::Initialized,
+            ready: false
         })
     }
 
@@ -251,14 +254,19 @@ impl ProtocolParticipant for KeygenParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<ProcessOutcome<Self::Output>> {
-        info!("Processing keygen message.");
+        info!("KEYGEN: Player {}: received {:?} from {}", self.id(), message.message_type(), message.from());
 
         if *self.status() == Status::TerminatedSuccessfully {
             Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
+        if !self.is_ready() && message.message_type() != MessageType::Keygen(KeygenMessageType::Ready){
+            self.stash_message(message)?;
+            return Ok(ProcessOutcome::Incomplete);
+        }
+
         match message.message_type() {
-            MessageType::Keygen(KeygenMessageType::Ready) => self.handle_ready_msg(rng, message),
+            MessageType::Keygen(KeygenMessageType::Ready) => self.handle_ready_msg(rng, message, input),
             MessageType::Keygen(KeygenMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -282,6 +290,10 @@ impl ProtocolParticipant for KeygenParticipant {
     fn status(&self) -> &Self::Status {
         &self.status
     }
+
+    fn is_ready(&self) -> bool{
+        self.ready
+    }
 }
 
 impl InnerProtocolParticipant for KeygenParticipant {
@@ -297,6 +309,10 @@ impl InnerProtocolParticipant for KeygenParticipant {
 
     fn local_storage_mut(&mut self) -> &mut LocalStorage {
         &mut self.local_storage
+    }
+
+    fn set_ready(&mut self) {
+        self.ready = true;
     }
 }
 
@@ -317,13 +333,15 @@ impl KeygenParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
+        input: &<KeygenParticipant as crate::participant::ProtocolParticipant>::Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready keygen message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<storage::Ready>(message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;
+            // extend the output with r1 messages (if they hadn't already been generated)
             Ok(ready_outcome.with_messages(round_one_messages))
         } else {
             Ok(ready_outcome)
@@ -662,7 +680,7 @@ fn schnorr_proof_transcript(global_rid: &[u8; 32]) -> Result<Transcript> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{utils::testing::init_testing, Identifier, ParticipantConfig};
+    use crate::{utils::testing::{init_testing, init_testing_with_seed}, Identifier, ParticipantConfig};
     use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
     use tracing::debug;
@@ -747,7 +765,8 @@ mod tests {
     fn keygen_always_produces_valid_outputs() -> Result<()> {
         let _rng = init_testing();
 
-        for _ in 0..20 {
+        for i in 0..20000 {
+            println!("{}", i);
             keygen_produces_valid_outputs()?;
         }
         Ok(())
@@ -757,6 +776,8 @@ mod tests {
     fn keygen_produces_valid_outputs() -> Result<()> {
         let QUORUM_SIZE = 3;
         let mut rng = init_testing();
+        //let seed = [96, 40, 124, 150, 39, 16, 10, 93, 146, 79, 137, 119, 66, 234, 89, 188, 248, 190, 156, 60, 111, 146, 252, 23, 77, 194, 70, 59, 226, 151, 162, 242];
+        //let mut rng = init_testing_with_seed(seed);
         let sid = Identifier::random(&mut rng);
         let mut quorum = KeygenParticipant::new_quorum(sid, QUORUM_SIZE, &mut rng)?;
         let mut inboxes = HashMap::new();

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -343,8 +343,7 @@ impl KeygenParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready keygen message.");
 
-        let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -130,7 +130,7 @@ pub struct KeygenParticipant {
     /// Status of the protocol execution.
     status: Status,
     /// Whether or not the participant is Ready
-    ready: bool
+    ready: bool,
 }
 
 /// Output type from key generation, including all parties' public key shares,
@@ -219,7 +219,7 @@ impl ProtocolParticipant for KeygenParticipant {
                 input,
             )?,
             status: Status::Initialized,
-            ready: false
+            ready: false,
         })
     }
 
@@ -254,19 +254,28 @@ impl ProtocolParticipant for KeygenParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<ProcessOutcome<Self::Output>> {
-        info!("KEYGEN: Player {}: received {:?} from {}", self.id(), message.message_type(), message.from());
+        info!(
+            "KEYGEN: Player {}: received {:?} from {}",
+            self.id(),
+            message.message_type(),
+            message.from()
+        );
 
         if *self.status() == Status::TerminatedSuccessfully {
             Err(CallerError::ProtocolAlreadyTerminated)?;
         }
 
-        if !self.is_ready() && message.message_type() != MessageType::Keygen(KeygenMessageType::Ready){
+        if !self.is_ready()
+            && message.message_type() != MessageType::Keygen(KeygenMessageType::Ready)
+        {
             self.stash_message(message)?;
             return Ok(ProcessOutcome::Incomplete);
         }
 
         match message.message_type() {
-            MessageType::Keygen(KeygenMessageType::Ready) => self.handle_ready_msg(rng, message, input),
+            MessageType::Keygen(KeygenMessageType::Ready) => {
+                self.handle_ready_msg(rng, message, input)
+            }
             MessageType::Keygen(KeygenMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -291,7 +300,7 @@ impl ProtocolParticipant for KeygenParticipant {
         &self.status
     }
 
-    fn is_ready(&self) -> bool{
+    fn is_ready(&self) -> bool {
         self.ready
     }
 }
@@ -337,7 +346,8 @@ impl KeygenParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready keygen message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+        let (ready_outcome, is_ready) =
+            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;
@@ -680,7 +690,7 @@ fn schnorr_proof_transcript(global_rid: &[u8; 32]) -> Result<Transcript> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{utils::testing::{init_testing, init_testing_with_seed}, Identifier, ParticipantConfig};
+    use crate::{utils::testing::init_testing, Identifier, ParticipantConfig};
     use rand::{CryptoRng, Rng, RngCore};
     use std::collections::HashMap;
     use tracing::debug;
@@ -764,9 +774,7 @@ mod tests {
     // likelihood
     fn keygen_always_produces_valid_outputs() -> Result<()> {
         let _rng = init_testing();
-
-        for i in 0..20000 {
-            println!("{}", i);
+        for _ in 0..30 {
             keygen_produces_valid_outputs()?;
         }
         Ok(())
@@ -776,8 +784,6 @@ mod tests {
     fn keygen_produces_valid_outputs() -> Result<()> {
         let QUORUM_SIZE = 3;
         let mut rng = init_testing();
-        //let seed = [96, 40, 124, 150, 39, 16, 10, 93, 146, 79, 137, 119, 66, 234, 89, 188, 248, 190, 156, 60, 111, 146, 252, 23, 77, 194, 70, 59, 226, 151, 162, 242];
-        //let mut rng = init_testing_with_seed(seed);
         let sid = Identifier::random(&mut rng);
         let mut quorum = KeygenParticipant::new_quorum(sid, QUORUM_SIZE, &mut rng)?;
         let mut inboxes = HashMap::new();

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -273,9 +273,7 @@ impl ProtocolParticipant for KeygenParticipant {
         }
 
         match message.message_type() {
-            MessageType::Keygen(KeygenMessageType::Ready) => {
-                self.handle_ready_msg(rng, message, input)
-            }
+            MessageType::Keygen(KeygenMessageType::Ready) => self.handle_ready_msg(rng, message),
             MessageType::Keygen(KeygenMessageType::R1CommitHash) => {
                 let broadcast_outcome = self.handle_broadcast(rng, message)?;
 
@@ -342,12 +340,11 @@ impl KeygenParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &<KeygenParticipant as crate::participant::ProtocolParticipant>::Input,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready keygen message.");
 
         let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+            self.process_ready_message::<R, storage::Ready>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -34,14 +34,21 @@ impl MessageQueue {
         Ok(())
     }
 
-    /// Retrieve (and remove) all messages of a given [`MessageType`].
+    /// Retrieve (and remove) all [`Message`]s of a given [`MessageType`].
     ///
     /// If the given [`MessageType`] is not found, an empty [`Vec`] is returned.
-    pub(crate) fn retrieve_all(&mut self, message_type: MessageType) -> Vec<Message> {
+    pub(crate) fn retrieve_all_of_type(&mut self, message_type: MessageType) -> Vec<Message> {
         self.do_retrieve(message_type, None)
     }
 
-    /// Retrieve (and remove) all messages of a given [`MessageType`] associated
+    /// Retrieve (and remove) all [`Message`]s from the [`MessageQueue`].
+    ///
+    /// If no messages are found, an empty [`Vec`] is returned.
+    pub(crate) fn retrieve_all(&mut self) -> Vec<Message> {
+        self.0.drain().flat_map(|(_key, value)| value).collect()
+    }
+
+    /// Retrieve (and remove) all [`Message`]s of a given [`MessageType`] associated
     /// with the given [`ParticipantIdentifier`].
     ///
     /// If the given [`MessageType`] is not found, an empty [`Vec`] is returned.

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -48,8 +48,8 @@ impl MessageQueue {
         self.0.drain().flat_map(|(_key, value)| value).collect()
     }
 
-    /// Retrieve (and remove) all [`Message`]s of a given [`MessageType`] associated
-    /// with the given [`ParticipantIdentifier`].
+    /// Retrieve (and remove) all [`Message`]s of a given [`MessageType`]
+    /// associated with the given [`ParticipantIdentifier`].
     ///
     /// If the given [`MessageType`] is not found, an empty [`Vec`] is returned.
     pub(crate) fn retrieve(

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -292,7 +292,6 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
         &mut self,
         rng: &mut R,
         message: &Message,
-        input: &Self::Input,
     ) -> Result<(ProcessOutcome<Self::Output>, bool)> {
         // If message came from self, then we should start the protocol
         if message.from() == self.id() {
@@ -301,7 +300,7 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
             self.set_ready();
             let outcomes = banked_messages
                 .iter()
-                .map(|m| self.process_message(rng, m, input))
+                .map(|m| self.process_message(rng, m))
                 .collect::<Result<Vec<ProcessOutcome<Self::Output>>>>()?;
 
             Ok((ProcessOutcome::collect(outcomes)?, true))

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -303,7 +303,6 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
                 .iter()
                 .map(|m| self.process_message(rng, m, input))
                 .collect::<Result<Vec<ProcessOutcome<Self::Output>>>>()?;
-            //Ok((ProcessOutcome::Processed(vec![]), true))
 
             Ok((ProcessOutcome::collect(outcomes)?, true))
         } else {

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -250,6 +250,9 @@ pub trait ProtocolParticipant {
 
     /// The input of the current session
     fn input(&self) -> &Self::Input;
+
+    /// Returns whether or not the Participant is Ready
+    fn is_ready(&self) -> bool;
 }
 
 pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
@@ -285,38 +288,25 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
 
     /// Process a `ready` message: tell other participants that we're ready and
     /// see if all others have also reported that they are ready.
-    fn process_ready_message<T: TypeTag<Value = ()>>(
+    fn process_ready_message<R: RngCore + CryptoRng, T: TypeTag<Value = ()>>(
         &mut self,
+        rng: &mut R,
         message: &Message,
+        input: &Self::Input,
     ) -> Result<(ProcessOutcome<Self::Output>, bool)> {
-        self.local_storage_mut().store::<T>(message.from(), ());
-        let empty: [u8; 0] = [];
-        // If message came from self, then tell the other participants that we are ready
-        let self_initiated_outcome = if message.from() == self.id() {
-            let messages = self
-                .other_ids()
-                .iter()
-                .map(|other_id| {
-                    Message::new(
-                        message.message_type(),
-                        message.id(),
-                        self.id(),
-                        *other_id,
-                        &empty,
-                    )
-                })
-                .collect::<Result<Vec<Message>>>()?;
-            ProcessOutcome::Processed(messages)
+        // If message came from self, then we should start the protocol
+        if message.from() == self.id() {
+            // First, process any messages that had been received before the Ready signal
+            let banked_messages = self.fetch_all_messages()?;
+            self.set_ready();
+            let outcomes = banked_messages.iter().map(|m| self.process_message(rng, m, input)).collect::<Result<Vec<ProcessOutcome<Self::Output>>>>()?;
+            //Ok((ProcessOutcome::Processed(vec![]), true))
+            
+            Ok((ProcessOutcome::collect(outcomes)?, true))
         } else {
-            ProcessOutcome::Incomplete
-        };
-
-        // Make sure that all parties are ready before proceeding
-        let is_ready = self
-            .local_storage()
-            .contains_for_all_ids::<T>(&self.all_participants());
-
-        Ok((self_initiated_outcome, is_ready))
+            error!("Received a Ready message from the wrong sender!");
+            Err(InternalError::ProtocolError)
+        }
     }
 
     /// Retrieves an item from [`LocalStorage`] associated with the given
@@ -351,8 +341,16 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
     /// If no messages are found, return an empty [`Vec`].
     fn fetch_messages(&mut self, message_type: MessageType) -> Result<Vec<Message>> {
         let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
-        Ok(message_storage.retrieve_all(message_type))
+        Ok(message_storage.retrieve_all_of_type(message_type))
     }
+
+    /// Fetch (and remove) all [`Message`]s of any [`MessageType`].
+    /// If no messages are found, return an empty [`Vec`].
+    fn fetch_all_messages(&mut self) -> Result<Vec<Message>> {
+        let message_storage = self.get_from_storage::<local_storage::MessageQueue>()?;
+        Ok(message_storage.retrieve_all())
+    }
+
     /// Fetch (and remove) all [`Message`]s matching the given [`MessageType`]
     /// and [`ParticipantIdentifier`]. If no messages are found, return an empty
     /// [`Vec`].
@@ -375,6 +373,8 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
         let progress_storage = self.get_from_storage::<local_storage::ProgressStore>()?;
         Ok(progress_storage.get(&func_name).is_some())
     }
+
+    fn set_ready(&mut self);
 }
 
 pub(crate) trait Broadcast {

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -299,9 +299,12 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
             // First, process any messages that had been received before the Ready signal
             let banked_messages = self.fetch_all_messages()?;
             self.set_ready();
-            let outcomes = banked_messages.iter().map(|m| self.process_message(rng, m, input)).collect::<Result<Vec<ProcessOutcome<Self::Output>>>>()?;
+            let outcomes = banked_messages
+                .iter()
+                .map(|m| self.process_message(rng, m, input))
+                .collect::<Result<Vec<ProcessOutcome<Self::Output>>>>()?;
             //Ok((ProcessOutcome::Processed(vec![]), true))
-            
+
             Ok((ProcessOutcome::collect(outcomes)?, true))
         } else {
             error!("Received a Ready message from the wrong sender!");

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -288,7 +288,7 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
 
     /// Process a `ready` message: tell other participants that we're ready and
     /// see if all others have also reported that they are ready.
-    fn process_ready_message<R: RngCore + CryptoRng, T: TypeTag<Value = ()>>(
+    fn process_ready_message<R: RngCore + CryptoRng>(
         &mut self,
         rng: &mut R,
         message: &Message,

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -286,7 +286,7 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
             .collect()
     }
 
-    /// Process a `ready` message: If it came from another Participant, ignore
+    /// Process a `ready` message: If it came from another Participant, reject
     /// it. Once ready, process all messages that were received before
     /// ready.
     fn process_ready_message<R: RngCore + CryptoRng>(

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -227,6 +227,8 @@ pub struct PresignParticipant {
     broadcast_participant: BroadcastParticipant,
     /// Status of the protocol execution.
     status: Status,
+    /// Whether or not the participant is Ready
+    ready: bool
 }
 
 /// Input needed for [`PresignParticipant`] to run.
@@ -389,6 +391,7 @@ impl ProtocolParticipant for PresignParticipant {
             local_storage: Default::default(),
             broadcast_participant: BroadcastParticipant::new(sid, id, other_participant_ids, ())?,
             status: Status::Initialized,
+            ready: false
         })
     }
 
@@ -462,6 +465,10 @@ impl ProtocolParticipant for PresignParticipant {
     fn status(&self) -> &Self::Status {
         &self.status
     }
+
+    fn is_ready(&self) -> bool {
+        self.ready
+    }
 }
 
 impl InnerProtocolParticipant for PresignParticipant {
@@ -477,6 +484,10 @@ impl InnerProtocolParticipant for PresignParticipant {
 
     fn local_storage_mut(&mut self) -> &mut LocalStorage {
         &mut self.local_storage
+    }
+
+    fn set_ready(&mut self) {
+        self.ready = true;
     }
 }
 
@@ -500,7 +511,7 @@ impl PresignParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready presign message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<storage::Ready>(message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -228,7 +228,7 @@ pub struct PresignParticipant {
     /// Status of the protocol execution.
     status: Status,
     /// Whether or not the participant is Ready
-    ready: bool
+    ready: bool,
 }
 
 /// Input needed for [`PresignParticipant`] to run.
@@ -391,7 +391,7 @@ impl ProtocolParticipant for PresignParticipant {
             local_storage: Default::default(),
             broadcast_participant: BroadcastParticipant::new(sid, id, other_participant_ids, ())?,
             status: Status::Initialized,
-            ready: false
+            ready: false,
         })
     }
 
@@ -511,7 +511,8 @@ impl PresignParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready presign message.");
 
-        let (ready_outcome, is_ready) = self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+        let (ready_outcome, is_ready) =
+            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -511,8 +511,7 @@ impl PresignParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         info!("Handling ready presign message.");
 
-        let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message)?;
+        let (ready_outcome, is_ready) = self.process_ready_message::<R>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -512,7 +512,7 @@ impl PresignParticipant {
         info!("Handling ready presign message.");
 
         let (ready_outcome, is_ready) =
-            self.process_ready_message::<R, storage::Ready>(rng, message, input)?;
+            self.process_ready_message::<R, storage::Ready>(rng, message)?;
 
         if is_ready {
             let round_one_messages = run_only_once!(self.gen_round_one_msgs(rng, message.id()))?;


### PR DESCRIPTION
This PR addresses issue #304, in which a possible unfavorable message ordering causes errors. Specifically, it was possible for a protocol to terminate locally before receiving a Ready message from yourself, causing the receipt of such message to trigger an error. To address this, the purpose of Ready messages was changed: instead of needing to receive a Ready from all players prior to starting a protocol instance (which is not required in the paper), we instead become "Ready" after receiving a Ready message from ourselves (so in practice, whoever is controlling the Participant can make them ready to run a protocol by sending a message). 

This by itself doesn't fully fix the issue, so the other change is to not process any messages before receiving this initial Ready. Code was added to bank all messages received prior to Ready, and to play them back afterwards. To facilitate this, some functions were added to the Participant and MessageQueue API's. 

To test that this change is effective, it was first implemented in KeyGen, which was tested for 20,000 consecutive runs without any issues. After that, the same changes were applied to Auxinfo and Presign. The end-to-end protocol test was run 200 times locally without issue.