### PR TITLE
Add storage utility methods for presign

### DIFF
--- a/src/auxinfo/info.rs
+++ b/src/auxinfo/info.rs
@@ -39,8 +39,6 @@ pub struct AuxInfoPrivate {
 }
 
 const AUXINFO_TAG: &[u8] = b"AuxInfoPrivate";
-// Length of the length field for auxinfo serialization.
-const AUXINFO_LEN: usize = 8;
 
 impl AuxInfoPrivate {
     pub(crate) fn encryption_key(&self) -> EncryptionKey {
@@ -93,15 +91,7 @@ impl AuxInfoPrivate {
             }
 
             // Extract the length of the key
-            let key_len_slice = parser.take_bytes(AUXINFO_LEN)?;
-            let len_bytes: [u8; AUXINFO_LEN] = key_len_slice.try_into().map_err(|_| {
-                error!(
-                    "Failed to convert byte array (should always work because we
-                        defined it to be exactly 8 bytes)"
-                );
-                InternalError::InternalInvariantFailed
-            })?;
-            let key_len = usize::from_le_bytes(len_bytes);
+            let key_len = parser.take_len()?;
 
             let key_bytes = parser.take_rest()?;
             if key_bytes.len() != key_len {

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -7,7 +7,7 @@
 // of this source tree.
 
 use crate::{
-    errors::{CallerError, InternalError, Result},
+    errors::{CallerError, Result},
     utils::{k256_order, CurvePoint, ParseBytes},
     ParticipantIdentifier,
 };
@@ -19,8 +19,6 @@ use tracing::error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const KEYSHARE_TAG: &[u8] = b"KeySharePrivate";
-/// Length of the field indicating the length of the key share.
-const KEYSHARE_LEN: usize = 8;
 
 /// Private key corresponding to a given [`Participant`](crate::Participant)'s
 /// [`KeySharePublic`].
@@ -92,15 +90,7 @@ impl KeySharePrivate {
             }
 
             // Extract the length of the key share
-            let share_len_slice = parser.take_bytes(KEYSHARE_LEN)?;
-            let share_len_bytes: [u8; KEYSHARE_LEN] = share_len_slice.try_into().map_err(|_| {
-                error!(
-                    "Failed to convert byte array (should always work because we
-                defined it to be exactly 8 bytes"
-                );
-                InternalError::InternalInvariantFailed
-            })?;
-            let share_len = usize::from_le_bytes(share_len_bytes);
+            let share_len = parser.take_len()?;
 
             let share_bytes = parser.take_rest()?;
             if share_bytes.len() != share_len {

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -449,14 +449,39 @@ mod tests {
         assert!(PresignRecord::try_from_bytes(bytes).is_err());
 
         // Length with no chi share following doesn't pass
-        let bytes = [RECORD_TAG, &point_len, &point, &random_share_len, &random_share, &chi_share_len].concat();
+        let bytes = [
+            RECORD_TAG,
+            &point_len,
+            &point,
+            &random_share_len,
+            &random_share,
+            &chi_share_len,
+        ]
+        .concat();
         assert!(PresignRecord::try_from_bytes(bytes).is_err());
 
-        let bytes = [RECORD_TAG, &point_len, &point, &random_share_len, &random_share, &zero_len].concat();
+        let bytes = [
+            RECORD_TAG,
+            &point_len,
+            &point,
+            &random_share_len,
+            &random_share,
+            &zero_len,
+        ]
+        .concat();
         assert!(PresignRecord::try_from_bytes(bytes).is_err());
 
         // Full thing works (e.g. the encoding scheme used above is correct)
-        let bytes = [RECORD_TAG, &point_len, &point, &random_share_len, &random_share, &chi_share_len, &chi_share].concat();
+        let bytes = [
+            RECORD_TAG,
+            &point_len,
+            &point,
+            &random_share_len,
+            &random_share,
+            &chi_share_len,
+            &chi_share,
+        ]
+        .concat();
         assert!(PresignRecord::try_from_bytes(bytes).is_ok());
     }
 }

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -209,10 +209,11 @@ impl PresignRecord {
             // Parse the random share `k`
             let random_share_len = parser.take_len()?;
             let random_share_slice = parser.take_bytes(random_share_len)?;
-            let random_share_bytes: [u8; 32] = random_share_slice
+            let mut random_share_bytes: [u8; 32] = random_share_slice
                 .try_into()
                 .map_err(|_| CallerError::DeserializationFailed)?;
             let random_share: Option<_> = Scalar::from_repr(random_share_bytes.into()).into();
+            random_share_bytes.zeroize();
 
             // Parse the chi share
             let chi_share_len = parser.take_len()?;
@@ -220,10 +221,11 @@ impl PresignRecord {
             if chi_share_slice.len() != chi_share_len {
                 Err(CallerError::DeserializationFailed)?
             }
-            let chi_share_bytes: [u8; 32] = chi_share_slice
+            let mut chi_share_bytes: [u8; 32] = chi_share_slice
                 .try_into()
                 .map_err(|_| CallerError::DeserializationFailed)?;
             let chi_share: Option<_> = Scalar::from_repr(chi_share_bytes.into()).into();
+            chi_share_bytes.zeroize();
 
             // The random and chi shares both need to be elements of `F_q`;
             // the k256::Scalar's parsing methods check this for us.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,7 +73,7 @@ impl CurvePoint {
         match point {
             Some(point) => Ok(Self(point.into())),
             None => {
-                error!("failed to encode bytes as a curve point");
+                error!("Failed to encode bytes as a curve point");
                 Err(CallerError::DeserializationFailed)?
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,11 @@
 use crate::errors::{CallerError, InternalError, Result};
 use generic_array::GenericArray;
 use k256::{
-    elliptic_curve::{bigint::Encoding, group::ff::PrimeField, AffinePoint, Curve},
+    elliptic_curve::{
+        bigint::Encoding,
+        group::{ff::PrimeField, GroupEncoding},
+        AffinePoint, Curve,
+    },
     Secp256k1,
 };
 use libpaillier::unknown_order::BigNumber;
@@ -47,6 +51,34 @@ impl CurvePoint {
     pub(crate) fn multiply_by_scalar(&self, point: &BigNumber) -> Result<Self> {
         Ok(Self(self.0 * crate::utils::bn_to_scalar(point)?))
     }
+
+    /// Serialize the `CurvePoint` as an affine-encoded secp256k1 byte array.
+    pub(crate) fn to_bytes(self) -> Vec<u8> {
+        let mut generic_array = AffinePoint::<Secp256k1>::from(self.0).to_bytes();
+        let bytes = generic_array.to_vec();
+        generic_array.zeroize();
+        bytes
+    }
+
+    #[allow(unused)]
+    pub(crate) fn try_from_bytes(bytes: Vec<u8>) -> Result<Self> {
+        let mut fixed_len_bytes: [u8; 33] = bytes.try_into().map_err(|_| {
+            error!("Failed to encode bytes as a curve point");
+            CallerError::DeserializationFailed
+        })?;
+
+        let point: Option<AffinePoint<Secp256k1>> =
+            AffinePoint::<Secp256k1>::from_bytes(&fixed_len_bytes.into()).into();
+        fixed_len_bytes.zeroize();
+
+        match point {
+            Some(point) => Ok(Self(point.into())),
+            None => {
+                error!("failed to encode bytes as a curve point");
+                Err(CallerError::DeserializationFailed)?
+            }
+        }
+    }
 }
 
 impl std::ops::Add for CurvePoint {
@@ -83,6 +115,21 @@ impl<'de> Deserialize<'de> for CurvePoint {
     }
 }
 
+#[cfg(test)]
+mod curve_point_tests {
+    use crate::utils::{testing::init_testing, CurvePoint};
+    use k256::elliptic_curve::Group;
+
+    #[test]
+    fn curve_point_byte_conversion_works() {
+        let rng = &mut init_testing();
+        let point = CurvePoint(k256::ProjectivePoint::random(rng));
+        let bytes = point.to_bytes();
+        let reconstructed = CurvePoint::try_from_bytes(bytes).unwrap();
+        assert_eq!(point, reconstructed);
+    }
+}
+
 /// Helper type for parsing byte array into slices.
 ///
 /// This type implements [`Zeroize`]. When parsing secret types, you should
@@ -107,6 +154,21 @@ impl ParseBytes {
             .ok_or(CallerError::DeserializationFailed)?;
         self.offset += n;
         Ok(slice)
+    }
+
+    /// Parse the next 8 bytes as a little-endian encoded usize.
+    pub(crate) fn take_len(&mut self) -> Result<usize> {
+        const LENGTH_BYTES: usize = 8;
+
+        let len_slice = self.take_bytes(LENGTH_BYTES)?;
+        let len_bytes: [u8; LENGTH_BYTES] = len_slice.try_into().map_err(|_| {
+            error!(
+                "Failed to convert byte array (should always work because we
+                   defined it to be exactly 8 bytes"
+            );
+            InternalError::InternalInvariantFailed
+        })?;
+        Ok(usize::from_le_bytes(len_bytes))
     }
 
     /// Take the rest of the bytes from the array.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,8 +60,7 @@ impl CurvePoint {
         bytes
     }
 
-    #[allow(unused)]
-    pub(crate) fn try_from_bytes(bytes: Vec<u8>) -> Result<Self> {
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         let mut fixed_len_bytes: [u8; 33] = bytes.try_into().map_err(|_| {
             error!("Failed to encode bytes as a curve point");
             CallerError::DeserializationFailed
@@ -125,7 +124,7 @@ mod curve_point_tests {
         let rng = &mut init_testing();
         let point = CurvePoint(k256::ProjectivePoint::random(rng));
         let bytes = point.to_bytes();
-        let reconstructed = CurvePoint::try_from_bytes(bytes).unwrap();
+        let reconstructed = CurvePoint::try_from_bytes(&bytes).unwrap();
         assert_eq!(point, reconstructed);
     }
 }


### PR DESCRIPTION
Closes #429

Adds serialization methods and equality checking for presign records. Also adds a utility method in the parse-bytes function to read an 8-byte length, since we use that everywhere.

