### PR TITLE
implement InnerProtocolParticipant for signing

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -34,10 +34,6 @@ mod storage {
     use super::*;
     use crate::local_storage::TypeTag;
 
-    pub(super) struct Ready;
-    impl TypeTag for Ready {
-        type Value = ();
-    }
     pub(super) struct Private;
     impl TypeTag for Private {
         type Value = AuxInfoPrivate;

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -37,10 +37,6 @@ mod storage {
     use super::*;
     use crate::local_storage::TypeTag;
 
-    pub(super) struct Ready;
-    impl TypeTag for Ready {
-        type Value = ();
-    }
     pub(super) struct Commit;
     impl TypeTag for Commit {
         type Value = KeygenCommit;

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -379,6 +379,8 @@ pub(crate) trait InnerProtocolParticipant: ProtocolParticipant {
         Ok(progress_storage.get(&func_name).is_some())
     }
 
+    /// Each `InnerProtocolParticipant` must have some kind of indicator for
+    /// when it is ready to process messages. This method turns it on.
     fn set_ready(&mut self);
 }
 

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -47,10 +47,6 @@ use tracing::{error, info, instrument};
 mod storage {
     use crate::local_storage::TypeTag;
 
-    pub(super) struct Ready;
-    impl TypeTag for Ready {
-        type Value = ();
-    }
     pub(super) struct RoundOnePrivate;
     impl TypeTag for RoundOnePrivate {
         type Value = crate::presign::round_one::Private;


### PR DESCRIPTION
Closes #423 

This handles the checklist in the issue, basically just adding infrastructure that will need to be in place to implement the actual protocol. There are a few utility methods for interacting with the `PresignRecord` input. Some things will likely change in future iterations, like exactly which types we keep in storage.

I also removed the `Ready` types from all participant storage modules; these were made obsolete with the refactor in #440 but didn't get removed at that time.