### PR TITLE
424 presign testing

### DIFF
--- a/benches/e2e_benchmark.rs
+++ b/benches/e2e_benchmark.rs
@@ -12,19 +12,13 @@ use tss_ecdsa::{
 };
 
 /// Delivers all messages into their respective participant's inboxes
-fn deliver_all(
-    messages: &[Message],
-    inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
-) -> Result<()> {
+fn deliver_all(messages: &[Message], inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>) {
     for message in messages {
-        for (id, inbox) in inboxes.iter_mut() {
-            if *id == message.to() {
-                inbox.push(message.clone());
-                break;
-            }
-        }
+        inboxes
+            .get_mut(&message.to())
+            .unwrap()
+            .push(message.clone());
     }
-    Ok(())
 }
 
 /// Process a single message for a single participant, randomly chosen. If that
@@ -48,7 +42,7 @@ fn process_messages<R: RngCore + CryptoRng, P: ProtocolParticipant>(
     let index = rng.gen_range(0..inbox.len());
     let message = inbox.remove(index);
     let (output, messages) = participant.process_single_message(&message, rng)?;
-    deliver_all(&messages, inboxes)?;
+    deliver_all(&messages, inboxes);
 
     Ok(output)
 }

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -679,16 +679,13 @@ mod tests {
     fn deliver_all(
         messages: &[Message],
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
-    ) -> Result<()> {
+    ) {
         for message in messages {
-            for (&id, inbox) in &mut *inboxes {
-                if id == message.to() {
-                    inbox.push(message.clone());
-                    break;
-                }
-            }
+            inboxes
+                .get_mut(&message.to())
+                .unwrap()
+                .push(message.clone());
         }
-        Ok(())
     }
 
     fn is_auxinfo_done(quorum: &[AuxInfoParticipant]) -> bool {
@@ -774,10 +771,10 @@ mod tests {
             // Deliver messages and save outputs
             match outcome {
                 ProcessOutcome::Incomplete => {}
-                ProcessOutcome::Processed(messages) => deliver_all(&messages, &mut inboxes)?,
+                ProcessOutcome::Processed(messages) => deliver_all(&messages, &mut inboxes),
                 ProcessOutcome::Terminated(output) => outputs[index] = Some(output),
                 ProcessOutcome::TerminatedForThisParticipant(output, messages) => {
-                    deliver_all(&messages, &mut inboxes)?;
+                    deliver_all(&messages, &mut inboxes);
                     outputs[index] = Some(output);
                 }
             }

--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -785,7 +785,7 @@ mod tests {
 
         // Make sure every player got an output
         let outputs: Vec<_> = outputs.into_iter().flatten().collect();
-        assert!(outputs.len() == QUORUM_SIZE);
+        assert_eq!(outputs.len(), QUORUM_SIZE);
 
         let participant_ids = quorum[0].all_participants();
         let context = SharedContext::fill_context(participant_ids, sid);

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -45,7 +45,7 @@ impl KeySharePrivate {
 
     /// Computes the "raw" curve point corresponding to this private key.
     pub(crate) fn public_share(&self) -> Result<CurvePoint> {
-        CurvePoint::GENERATOR.multiply_by_scalar(&self.x)
+        CurvePoint::GENERATOR.multiply_by_bignum(&self.x)
     }
 
     /// Convert private material into bytes.

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -738,16 +738,13 @@ mod tests {
     fn deliver_all(
         messages: &[Message],
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
-    ) -> Result<()> {
+    ) {
         for message in messages {
-            for (&id, inbox) in &mut *inboxes {
-                if id == message.to() {
-                    inbox.push(message.clone());
-                    break;
-                }
-            }
+            inboxes
+                .get_mut(&message.to())
+                .unwrap()
+                .push(message.clone());
         }
-        Ok(())
     }
 
     fn is_keygen_done(quorum: &[KeygenParticipant]) -> bool {
@@ -826,10 +823,10 @@ mod tests {
             // Deliver messages and save outputs
             match outcome {
                 ProcessOutcome::Incomplete => {}
-                ProcessOutcome::Processed(messages) => deliver_all(&messages, &mut inboxes)?,
+                ProcessOutcome::Processed(messages) => deliver_all(&messages, &mut inboxes),
                 ProcessOutcome::Terminated(output) => outputs[index] = Some(output),
                 ProcessOutcome::TerminatedForThisParticipant(output, messages) => {
-                    deliver_all(&messages, &mut inboxes)?;
+                    deliver_all(&messages, &mut inboxes);
                     outputs[index] = Some(output);
                 }
             }

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -837,7 +837,7 @@ mod tests {
 
         // Make sure every player got an output
         let outputs: Vec<_> = outputs.into_iter().flatten().collect();
-        assert!(outputs.len() == QUORUM_SIZE);
+        assert_eq!(outputs.len(), QUORUM_SIZE);
 
         // Check returned outputs
         //
@@ -886,7 +886,7 @@ mod tests {
             assert!(public_share.is_some());
 
             let expected_public_share =
-                CurvePoint::GENERATOR.multiply_by_scalar(output.private_key_share.as_ref())?;
+                CurvePoint::GENERATOR.multiply_by_bignum(output.private_key_share.as_ref())?;
             assert_eq!(public_share.unwrap().as_ref(), &expected_public_share);
         }
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -161,35 +161,6 @@ impl Output {
     pub(crate) fn private_key_share(&self) -> &KeySharePrivate {
         &self.private_key_share
     }
-
-    /// Simulate the output of a keygen run with the given participants.
-    ///
-    /// This should __never__ be called outside of tests!
-    #[cfg(test)]
-    pub(crate) fn simulate(
-        pids: &[ParticipantIdentifier],
-        rng: &mut (impl CryptoRng + RngCore),
-    ) -> Self {
-        use rand::Rng;
-
-        let (mut private_key_shares, public_key_shares): (Vec<_>, Vec<_>) = pids
-            .iter()
-            .map(|&pid| {
-                // TODO #340: Replace with KeyShare methods once they exist.
-                let secret = KeySharePrivate::random(rng);
-                let public = secret.public_share().unwrap();
-                (secret, KeySharePublic::new(pid, public))
-            })
-            .unzip();
-
-        let rid = rng.gen();
-
-        Self {
-            private_key_share: private_key_shares.pop().unwrap(),
-            public_key_shares,
-            rid,
-        }
-    }
 }
 
 impl ProtocolParticipant for KeygenParticipant {
@@ -680,6 +651,65 @@ mod tests {
     use std::collections::HashMap;
     use tracing::debug;
 
+    impl Output {
+        /// Simulate the output of a keygen run with the given participants.
+        ///
+        /// This should __never__ be called outside of tests!
+        pub(crate) fn simulate(
+            pids: &[ParticipantIdentifier],
+            rng: &mut (impl CryptoRng + RngCore),
+        ) -> Self {
+            let (mut private_key_shares, public_key_shares): (Vec<_>, Vec<_>) = pids
+                .iter()
+                .map(|&pid| {
+                    // TODO #340: Replace with KeyShare methods once they exist.
+                    let secret = KeySharePrivate::random(rng);
+                    let public = secret.public_share().unwrap();
+                    (secret, KeySharePublic::new(pid, public))
+                })
+                .unzip();
+
+            let rid = rng.gen();
+
+            Self {
+                private_key_share: private_key_shares.pop().unwrap(),
+                public_key_shares,
+                rid,
+            }
+        }
+
+        /// Simulate a consistent output of a keygen run with the given
+        /// participants.
+        ///
+        /// This produces output for every config in the provided set. The
+        /// config must have a non-zero length.
+        pub(crate) fn simulate_set(
+            configs: &[ParticipantConfig],
+            rng: &mut (impl CryptoRng + RngCore),
+        ) -> Vec<Self> {
+            let (private_key_shares, public_key_shares): (Vec<_>, Vec<_>) = configs
+                .iter()
+                .map(|config| {
+                    // TODO #340: Replace with KeyShare methods once they exist.
+                    let secret = KeySharePrivate::random(rng);
+                    let public = secret.public_share().unwrap();
+                    (secret, KeySharePublic::new(config.id(), public))
+                })
+                .unzip();
+
+            let rid = rng.gen();
+
+            private_key_shares
+                .into_iter()
+                .map(|private_key_share| Self {
+                    private_key_share,
+                    public_key_shares: public_key_shares.clone(),
+                    rid,
+                })
+                .collect()
+        }
+    }
+
     impl KeygenParticipant {
         pub fn new_quorum<R: RngCore + CryptoRng>(
             sid: Identifier,
@@ -691,6 +721,7 @@ mod tests {
                 .map(|config| Self::new(sid, config.id(), config.other_ids().to_vec(), ()))
                 .collect::<Result<Vec<_>>>()
         }
+
         pub fn initialize_keygen_message(&self, keygen_identifier: Identifier) -> Result<Message> {
             let empty: [u8; 0] = [];
             Message::new(

--- a/src/presign/participant.rs
+++ b/src/presign/participant.rs
@@ -1216,12 +1216,10 @@ mod test {
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
     ) {
         for message in messages {
-            for (&id, inbox) in &mut *inboxes {
-                if id == message.to() {
-                    inbox.push(message.clone());
-                    break;
-                }
-            }
+            inboxes
+                .get_mut(&message.to())
+                .unwrap()
+                .push(message.clone());
         }
     }
 

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -280,6 +280,20 @@ mod tests {
         PresignRecord,
     };
 
+    impl PresignRecord {
+        pub(crate) fn mask_point(&self) -> &CurvePoint {
+            &self.R
+        }
+
+        pub(crate) fn mask_share(&self) -> &Scalar {
+            &self.k
+        }
+
+        pub(crate) fn masked_key_share(&self) -> &Scalar {
+            &self.chi
+        }
+    }
+
     fn random_record(rng: &mut StdRng) -> PresignRecord {
         let point = CurvePoint(ProjectivePoint::random(StdRng::from_seed(rng.gen())));
         let random_share = Scalar::random(StdRng::from_seed(rng.gen()));

--- a/src/presign/record.rs
+++ b/src/presign/record.rs
@@ -272,12 +272,14 @@ mod tests {
         elliptic_curve::{Field, Group},
         ProjectivePoint, Scalar,
     };
-    use rand::{rngs::StdRng, Rng, SeedableRng};
+    use libpaillier::unknown_order::BigNumber;
+    use rand::{rngs::StdRng, CryptoRng, Rng, RngCore, SeedableRng};
 
     use crate::{
-        presign::record::RECORD_TAG,
-        utils::{testing::init_testing, CurvePoint},
-        PresignRecord,
+        keygen,
+        presign::{participant::presign_record_set_is_valid, record::RECORD_TAG},
+        utils::{bn_to_scalar, testing::init_testing, CurvePoint},
+        ParticipantConfig, PresignRecord,
     };
 
     impl PresignRecord {
@@ -292,24 +294,88 @@ mod tests {
         pub(crate) fn masked_key_share(&self) -> &Scalar {
             &self.chi
         }
+
+        /// Simulate creation of a random presign record. Do not use outside of
+        /// testing.
+        fn simulate(rng: &mut StdRng) -> PresignRecord {
+            let mask_point = CurvePoint(ProjectivePoint::random(StdRng::from_seed(rng.gen())));
+            let mask_share = Scalar::random(StdRng::from_seed(rng.gen()));
+            let masked_key_share = Scalar::random(rng);
+
+            PresignRecord {
+                R: mask_point,
+                k: mask_share,
+                chi: masked_key_share,
+            }
+        }
+
+        /// Simulate generation of a valid set of presign records to correspond
+        /// with the provided keygen outputs.
+        ///
+        /// For testing only; this does not check that the keygen output set is
+        /// consistent or complete.
+        pub(crate) fn simulate_set(
+            keygen_outputs: &[keygen::Output],
+            rng: &mut (impl CryptoRng + RngCore),
+        ) -> Vec<Self> {
+            // Note: using slightly-biased generation for faster tests
+            let mask_shares =
+                std::iter::repeat_with(|| Scalar::generate_biased(StdRng::from_seed(rng.gen())))
+                    .take(keygen_outputs.len())
+                    .collect::<Vec<_>>();
+            let mask = mask_shares
+                .iter()
+                .fold(Scalar::ZERO, |sum, mask_share| sum + mask_share);
+            let mask_inversion = Option::<Scalar>::from(mask.invert()).unwrap();
+            // `R` in the paper.
+            let mask_point = CurvePoint::GENERATOR.multiply_by_scalar(&mask_inversion);
+
+            let secret_key = keygen_outputs
+                .iter()
+                .map(|output| output.private_key_share())
+                .fold(BigNumber::zero(), |sum, key_share| sum + key_share.as_ref());
+
+            // Make all but one of the masked key shares randomly
+            let mut masked_key_shares =
+                std::iter::repeat_with(|| Scalar::random(StdRng::from_seed(rng.gen())))
+                    .take(keygen_outputs.len() - 1)
+                    .collect::<Vec<_>>();
+            let almost_masked_key = masked_key_shares
+                .iter()
+                .fold(Scalar::ZERO, |sum, masked_share| sum + masked_share);
+
+            // Compute the last key share to force correctness. We need to enforce that
+            // sum(masked_key_shares) = secret_key * mask (mod q)
+            masked_key_shares.push(bn_to_scalar(&secret_key).unwrap() * mask - almost_masked_key);
+
+            assert_eq!(masked_key_shares.len(), keygen_outputs.len());
+            assert_eq!(mask_shares.len(), keygen_outputs.len());
+
+            std::iter::zip(masked_key_shares, mask_shares)
+                .map(|(masked_key_share, mask_share)| Self {
+                    R: mask_point,
+                    k: mask_share,
+                    chi: masked_key_share,
+                })
+                .collect()
+        }
     }
 
-    fn random_record(rng: &mut StdRng) -> PresignRecord {
-        let point = CurvePoint(ProjectivePoint::random(StdRng::from_seed(rng.gen())));
-        let random_share = Scalar::random(StdRng::from_seed(rng.gen()));
-        let chi_share = Scalar::random(rng);
+    #[test]
+    fn simulated_presign_output_is_valid() {
+        let rng = &mut init_testing();
+        let configs = ParticipantConfig::random_quorum(5, rng).unwrap();
+        let keygen_outputs = keygen::Output::simulate_set(&configs, rng);
+        let records = PresignRecord::simulate_set(&keygen_outputs, rng);
 
-        PresignRecord {
-            R: point,
-            k: random_share,
-            chi: chi_share,
-        }
+        // Check validity of set; this will panic if anything is wrong
+        presign_record_set_is_valid(records, keygen_outputs);
     }
 
     #[test]
     fn record_bytes_conversion_works() {
         let rng = &mut init_testing();
-        let record = random_record(rng);
+        let record = PresignRecord::simulate(rng);
         let clone = PresignRecord { ..record };
 
         let bytes = record.into_bytes();
@@ -322,7 +388,7 @@ mod tests {
     #[test]
     fn deserialized_record_tag_must_be_correct() {
         let rng = &mut init_testing();
-        let record = random_record(rng);
+        let record = PresignRecord::simulate(rng);
 
         // Cut out the tag from the serialized bytes for convenience.
         let share_bytes = &record.into_bytes()[RECORD_TAG.len()..];
@@ -372,7 +438,7 @@ mod tests {
     #[test]
     fn point_field_must_have_length_prepended() {
         let rng = &mut init_testing();
-        let PresignRecord { R, k, chi } = random_record(rng);
+        let PresignRecord { R, k, chi } = PresignRecord::simulate(rng);
 
         let point = R.to_bytes();
 
@@ -397,7 +463,7 @@ mod tests {
     #[test]
     fn k_field_must_have_length_prepended() {
         let rng = &mut init_testing();
-        let PresignRecord { R, k, chi } = random_record(rng);
+        let PresignRecord { R, k, chi } = PresignRecord::simulate(rng);
 
         let point = R.to_bytes();
         let point_len = point.len().to_le_bytes();
@@ -416,7 +482,7 @@ mod tests {
     #[test]
     fn chi_field_must_have_length_prepended() {
         let rng = &mut init_testing();
-        let PresignRecord { R, k, chi } = random_record(rng);
+        let PresignRecord { R, k, chi } = PresignRecord::simulate(rng);
 
         let point = R.to_bytes();
         let point_len = point.len().to_le_bytes();
@@ -446,7 +512,7 @@ mod tests {
         assert!(PresignRecord::try_from_bytes(bytes.to_vec()).is_err());
         assert!(PresignRecord::try_from_bytes(RECORD_TAG.to_vec()).is_err());
 
-        let PresignRecord { R, k, chi } = random_record(rng);
+        let PresignRecord { R, k, chi } = PresignRecord::simulate(rng);
 
         let point = R.to_bytes();
         let point_len = point.len().to_le_bytes();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -797,17 +797,15 @@ mod tests {
     fn deliver_all(
         messages: &[Message],
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
-    ) -> Result<()> {
+    ) {
         for message in messages {
-            for (&id, inbox) in &mut *inboxes {
-                if id == message.to() {
-                    inbox.push(message.clone());
-                    break;
-                }
-            }
+            inboxes
+                .get_mut(&message.to())
+                .unwrap()
+                .push(message.clone());
         }
-        Ok(())
     }
+
     fn process_messages<R: RngCore + CryptoRng, P: ProtocolParticipant>(
         quorum: &mut [Participant<P>],
         inboxes: &mut HashMap<ParticipantIdentifier, Vec<Message>>,
@@ -833,7 +831,7 @@ mod tests {
             &message.message_type(),
         );
         let (output, messages) = participant.process_single_message(&message, rng)?;
-        deliver_all(&messages, inboxes)?;
+        deliver_all(&messages, inboxes);
 
         // Return the (id, output) pair, so the calling application knows _who_
         // finished.

--- a/src/zkp/piaffg.rs
+++ b/src/zkp/piaffg.rs
@@ -284,7 +284,7 @@ impl Proof2 for PiAffgProof {
             .map_err(|_| InternalError::InternalInvariantFailed)?;
         // Compute the exponentiation of the random multiplicative coefficient
         // (producing `B_x` in the paper)
-        let random_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_scalar(&random_mult_coeff)?;
+        let random_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_bignum(&random_mult_coeff)?;
         // Encrypt the random additive coefficient using the 1st encryption key
         // (producing `B_y` in the paper).
         let (random_add_coeff_ciphertext_prover, random_add_coeff_nonce_prover) = input
@@ -424,9 +424,9 @@ impl Proof2 for PiAffgProof {
         }
         // Check that the masked group exponentiation is valid.
         let masked_group_exponentiation_is_valid = {
-            let lhs = CurvePoint::GENERATOR.multiply_by_scalar(&self.masked_mult_coeff)?;
+            let lhs = CurvePoint::GENERATOR.multiply_by_bignum(&self.masked_mult_coeff)?;
             let rhs = self.random_mult_coeff_exp
-                + input.mult_coeff_exp.multiply_by_scalar(&self.challenge)?;
+                + input.mult_coeff_exp.multiply_by_bignum(&self.challenge)?;
             lhs == rhs
         };
         if !masked_group_exponentiation_is_valid {
@@ -576,7 +576,7 @@ mod tests {
         let (decryption_key_1, _, _) = DecryptionKey::new(rng).unwrap();
         let pk1 = decryption_key_1.encryption_key();
 
-        let mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_scalar(x)?;
+        let mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_bignum(x)?;
         let (add_coeff_ciphertext_prover, rho_y) = pk1
             .encrypt(rng, y)
             .map_err(|_| InternalError::InternalInvariantFailed)?;
@@ -783,7 +783,7 @@ mod tests {
 
             // Swap multi coefficient exponent with a random [`CurvePoint`]
             let mask = random_plusminus_by_size(&mut rng, ELL);
-            let bad_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_scalar(&mask)?;
+            let bad_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_bignum(&mask)?;
             assert_ne!(bad_mult_coeff_exp, input.mult_coeff_exp.clone());
             let bad_input = PiAffgInput::new(
                 input.verifier_setup_params,
@@ -813,7 +813,7 @@ mod tests {
         let (decryption_key_1, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let pk1 = decryption_key_1.encryption_key();
 
-        let mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_scalar(&x)?;
+        let mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_bignum(&x)?;
         let (add_coeff_ciphertext_prover, rho_y) = pk1
             .encrypt(&mut rng, &y)
             .map_err(|_| InternalError::InternalInvariantFailed)?;
@@ -969,7 +969,7 @@ mod tests {
             // Swap random_mult_coeff_exp with a random [`CurvePoint`]
             let mut bad_proof = proof.clone();
             let mask = random_plusminus_by_size(&mut rng, ELL);
-            bad_proof.random_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_scalar(&mask)?;
+            bad_proof.random_mult_coeff_exp = CurvePoint::GENERATOR.multiply_by_bignum(&mask)?;
             assert_ne!(bad_proof.random_mult_coeff_exp, proof.random_mult_coeff_exp);
             assert!(bad_proof.verify(input, &(), &mut transcript()).is_err());
 

--- a/src/zkp/pilog.rs
+++ b/src/zkp/pilog.rs
@@ -226,7 +226,7 @@ impl Proof2 for PiLogProof {
             .encrypt(rng, &mask)
             .map_err(|_| InternalError::InternalInvariantFailed)?;
         // Commit to the random plaintext using discrete log (`Y` in the paper).
-        let mask_dlog_commit = input.generator.multiply_by_scalar(&mask)?;
+        let mask_dlog_commit = input.generator.multiply_by_bignum(&mask)?;
         // Commit to the random plaintext using ring-Pedersen (producing variables `D`
         // and `ɣ` in the paper).
         let (mask_commit, mask_commit_randomness) =
@@ -310,9 +310,9 @@ impl Proof2 for PiLogProof {
         let group_exponentiation_is_valid = {
             let lhs = input
                 .generator
-                .multiply_by_scalar(&self.plaintext_response)?;
+                .multiply_by_bignum(&self.plaintext_response)?;
             let rhs =
-                self.mask_dlog_commit + input.dlog_commit.multiply_by_scalar(&self.challenge)?;
+                self.mask_dlog_commit + input.dlog_commit.multiply_by_bignum(&self.challenge)?;
             lhs == rhs
         };
         if !group_exponentiation_is_valid {
@@ -437,7 +437,7 @@ mod tests {
         let (decryption_key, _, _) = DecryptionKey::new(&mut rng).unwrap();
         let pk = decryption_key.encryption_key();
         let g = CurvePoint::GENERATOR;
-        let dlog_commit = g.multiply_by_scalar(&x)?;
+        let dlog_commit = g.multiply_by_bignum(&x)?;
         let (ciphertext, rho) = pk.encrypt(&mut rng, &x).unwrap();
         let setup_params = VerifiedRingPedersen::gen(&mut rng, &())?;
 
@@ -464,7 +464,7 @@ mod tests {
 
         // Generate a random generator
         let random_mask = random_plusminus_by_size(&mut rng, ELL);
-        let bad_g = input.generator.multiply_by_scalar(&random_mask)?;
+        let bad_g = input.generator.multiply_by_bignum(&random_mask)?;
         let bad_input = CommonInput::new(
             &ciphertext,
             &dlog_commit,
@@ -523,7 +523,7 @@ mod tests {
 
         // Swap dlog_commit with a random [`CurvePoint`]
         let mask = random_plusminus_by_size(&mut rng, ELL);
-        let bad_dlog_commit = input.generator.multiply_by_scalar(&mask)?;
+        let bad_dlog_commit = input.generator.multiply_by_bignum(&mask)?;
         assert_ne!(&bad_dlog_commit, input.dlog_commit);
         let bad_input = CommonInput::new(
             &ciphertext,
@@ -554,7 +554,7 @@ mod tests {
         let g = CurvePoint::GENERATOR;
 
         // Make a valid common input
-        let dlog_commit = g.multiply_by_scalar(&x)?;
+        let dlog_commit = g.multiply_by_bignum(&x)?;
         let (ciphertext, rho) = pk.encrypt(&mut rng, &x).unwrap();
         let setup_params = VerifiedRingPedersen::gen(&mut rng, &())?;
         let input = CommonInput::new(&ciphertext, &dlog_commit, setup_params.scheme(), &pk, &g);
@@ -641,7 +641,7 @@ mod tests {
             // Swap mask_dlog_commit with a random [`CurvePoint`]
             let mut bad_proof = proof.clone();
             let mask = random_plusminus_by_size(&mut rng, ELL);
-            bad_proof.mask_dlog_commit = input.generator.multiply_by_scalar(&mask)?;
+            bad_proof.mask_dlog_commit = input.generator.multiply_by_bignum(&mask)?;
             assert_ne!(bad_proof.mask_dlog_commit, proof.mask_dlog_commit);
             assert!(bad_proof.verify(input, &(), &mut transcript()).is_err());
 

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -145,8 +145,8 @@ impl Proof2 for PiSchProof {
         // Do equality checks
 
         let response_matches_commitment = {
-            let lhs = CurvePoint::GENERATOR.multiply_by_scalar(&self.response)?;
-            let rhs = self.commitment + input.x_commitment.multiply_by_scalar(&self.challenge)?;
+            let lhs = CurvePoint::GENERATOR.multiply_by_bignum(&self.response)?;
+            let rhs = self.commitment + input.x_commitment.multiply_by_bignum(&self.challenge)?;
             lhs == rhs
         };
         if !response_matches_commitment {
@@ -164,7 +164,7 @@ impl PiSchProof {
         // Sample alpha from F_q
         let randomness_for_commitment = random_positive_bn(rng, &k256_order());
         // Form a commitment to the mask
-        let precommitment = CurvePoint::GENERATOR.multiply_by_scalar(&randomness_for_commitment)?;
+        let precommitment = CurvePoint::GENERATOR.multiply_by_bignum(&randomness_for_commitment)?;
         Ok(PiSchPrecommit {
             precommitment,
             randomness_for_commitment,
@@ -244,7 +244,7 @@ mod tests {
         let g = CurvePoint::GENERATOR;
 
         let mut x = random_positive_bn(rng, &q);
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
         if additive {
             x += random_positive_bn(rng, &q);
         }
@@ -267,11 +267,11 @@ mod tests {
 
         let x = random_positive_bn(&mut rng, &q);
 
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
 
         // Generating random commitment
         let y = random_positive_bn(&mut rng, &q);
-        let y_commit = g.multiply_by_scalar(&y)?;
+        let y_commit = g.multiply_by_bignum(&y)?;
 
         let input = CommonInput::new(&x_commit);
         let com = PiSchProof::precommit(&mut rng)?;
@@ -296,7 +296,7 @@ mod tests {
 
         let x = random_positive_bn(&mut rng, &q);
 
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
 
         let input = CommonInput::new(&x_commit);
         let com = PiSchProof::precommit(&mut rng)?;
@@ -321,8 +321,8 @@ mod tests {
 
         let x = random_positive_bn(&mut rng, &q);
 
-        let x_commit = g.multiply_by_scalar(&x)?;
-        let bad_generator = x_commit.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
+        let bad_generator = x_commit.multiply_by_bignum(&x)?;
 
         let input = CommonInput::new(&bad_generator);
         let com = PiSchProof::precommit(&mut rng)?;
@@ -346,7 +346,7 @@ mod tests {
 
         let x = random_positive_bn(&mut rng, &q);
 
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
 
         // Generating random `y` for bad secret input
         let y = random_positive_bn(&mut rng, &q);
@@ -375,12 +375,12 @@ mod tests {
 
         let x = random_positive_bn(&mut rng, &q);
 
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
 
         // Generating random commitment to `y` for generating random input for verifying
         // the proof than which was used to create it
         let y = random_positive_bn(&mut rng, &q);
-        let y_commit = g.multiply_by_scalar(&y)?;
+        let y_commit = g.multiply_by_bignum(&y)?;
         assert_ne!(x_commit, y_commit);
 
         let input = CommonInput::new(&x_commit);
@@ -439,7 +439,7 @@ mod tests {
         let g = CurvePoint::GENERATOR;
 
         let x = random_positive_bn(&mut rng, &q);
-        let x_commit = g.multiply_by_scalar(&x)?;
+        let x_commit = g.multiply_by_bignum(&x)?;
 
         let input = CommonInput::new(&x_commit);
         let com = PiSchProof::precommit(&mut rng)?;


### PR DESCRIPTION
Closes #424

This adds a basic happy test for presigning, defines the characteristics that a valid set of `PresignRecord`s should satisfy, and adds a method to simulate a valid `presign` run.

There's lots of boilerplate to get the presign test running; this is mostly copied from the equivalent keygen and auxinfo tests. I think some of this could be extracted into a testing utility module because many of the functionalities (e.g. maintain an inbox to store and "send" messages) are the same across different participant types. I also think some of them could be simplified (e.g. we don't need separate inboxes for each party; we can just make one big inbox for all messages). But I refrain from addressing that here.

There's a bit of rearranging of code, like for the `simulate` methods on keygen and auxinfo, which I just moved into the test module so they're more obviously not-for-general-use. I'll mark the big chunks of moved code inline. I also had to add some functionality for simulating auxinfo and keygen output; before, we had methods to create a single valid instance; now we needed a method to create a valid set. The `simulate` and `simulate_set` methods have a lot of similar code, but they take slightly different inputs and I didn't figure out a nice way to consolidate them.

The most important cryptography component for @hridambasu to review is the tests on `PresignRecord`. The paper never explicitly defines what properties a record needs to hold. I generated the properties here by reading it and also reading @amaloz's excellent documentation on the `PresignParticipant` type. But I would like you read the same things and think about whether there seem to be any other conditions that should hold for correctly-generated records.

One other point of interest: in testing some of the presign stuff, I realized that the `CurvePoint::multiply_by_scalar` method is actually multiplying by a `BigNumber` which it converts to a `Scalar`. This raised a few code quality concerns:
1. The `bn_to_scalar` method it uses has some cloning of the input; we often call this method on secrets so this is a potential point of leakage we should address
2. In fact, there are a variety of secret and intermediate types across the protocols that are drawn from `𝔽_q`. The paper isn't explicit about what that means, but `𝔽_q` is (by definition) the scalar field of the elliptic curve. I think it's worth looking through these types to see if some of our `BigNumber`s can / should actually be `k256::Scalar`s.

For the purposes of this PR, I just changed the name to `multiply_by_bignumber` and made a separate, infallible `multiply_by_scalar` method to make the types line up more nicely. This is why there are so many changed files... sorry. But perhaps in the future we will find that `multiply_by_scalar` is the correct method to be using and we just have some types wrong.