### PR TITLE
419 err pimod

### DIFF
--- a/src/zkp/pimod.rs
+++ b/src/zkp/pimod.rs
@@ -568,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fourth_roots_mod_composite() {
+    fn test_fourth_roots_mod_composite() -> Result<Option<()>> {
         let mut rng = init_testing();
         let (p, q) = prime_gen::get_prime_pair_from_pool_insecure(&mut rng).unwrap();
         let N = &p * &q;
@@ -577,21 +577,21 @@ mod tests {
         let mut success = 0;
         loop {
             if success == 10 {
-                return;
+                return Ok(Some(()));
             }
             let a = BigNumber::from_rng(&N, &mut rng);
             let a_n = jacobi(&a, &N);
 
             let roots = fourth_roots_mod_composite(&a, &p, &q);
-            match roots {
-                Ok(xs) => {
+            match roots? {
+                Some(xs) => {
                     assert_eq!(a_n, 1);
                     for x in xs {
                         assert_eq!(modpow(&x, &BigNumber::from(4), &N), a);
                     }
                     success += 1;
                 }
-                Err(_) => {
+                None => {
                     continue;
                 }
             }


### PR DESCRIPTION
Closes #419 
Draft of one change in error PiMod. 
When I change the match pattern as mentioned in the issue, and change the return type of the test function to  Result<Option<()>>, I get the error: 
the trait bound `std::option::Option<()>: Termination` is not satisfied
required for `std::result::Result<std::option::Option<()>, errors::InternalError>` to implement `Termination`rustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B3%5D?3#file%3A%2F%2F%2FUsers%2Fhridambasu%2FDocuments%2Fcode%2Fbolt%2Ftss-ecdsa%2Fsrc%2Fzkp%2Fpimod.rs)
pimod.rs(574, 5): Error originated from macro call here
lib.rs(208, 30): required by a bound in `assert_test_result`. 