### PR TITLE
update k256, sha2 versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ flame = { version = "0.2", optional = true }
 flamer = { version = "0.3", optional = true }
 generic-array = "0.14"
 hex = "0.4"
-k256 = { version = "0.10", features = ["arithmetic", "digest", "sha256", "ecdsa", "serde"] }
+k256 = { version = "0.13", features = ["arithmetic", "sha256", "ecdsa", "serde"] }
 lazy_static = "1"
 libpaillier = { version = "0.5", default-features = false, features = ["gmp"] }
 merlin = "3"
 num-bigint = "0.4"
 rand = "0.8"
 serde = "1"
-sha2 = "0.9"
+sha2 = "0.10"
 thiserror = "1"
 tracing = "0.1.37"
 zeroize = "1.5"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -656,7 +656,7 @@ mod tests {
         utils::testing::init_testing,
         PresignParticipant,
     };
-    use k256::ecdsa::signature::Verifier;
+    use k256::ecdsa::signature::{DigestVerifier, Verifier};
     use rand::seq::IteratorRandom;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
@@ -1007,7 +1007,7 @@ mod tests {
         let signature = SignatureShare::into_signature(shares)?;
 
         // Moment of truth, does the signature verify?
-        //assert!(saved_public_key.verify_digest(hasher, &signature).is_ok());
+        assert!(saved_public_key.verify_digest(hasher, &signature).is_ok());
         assert!(saved_public_key
             .verify(b"some test message", &signature)
             .is_ok());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -18,7 +18,7 @@ use crate::{
     utils::{k256_order, CurvePoint},
     zkp::ProofContext,
 };
-use k256::elliptic_curve::IsHigh;
+use k256::elliptic_curve::scalar::IsHigh;
 use libpaillier::unknown_order::BigNumber;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -656,7 +656,7 @@ mod tests {
         utils::testing::init_testing,
         PresignParticipant,
     };
-    use k256::ecdsa::signature::DigestVerifier;
+    use k256::ecdsa::signature::Verifier;
     use rand::seq::IteratorRandom;
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
@@ -1007,7 +1007,10 @@ mod tests {
         let signature = SignatureShare::into_signature(shares)?;
 
         // Moment of truth, does the signature verify?
-        assert!(saved_public_key.verify_digest(hasher, &signature).is_ok());
+        //assert!(saved_public_key.verify_digest(hasher, &signature).is_ok());
+        assert!(saved_public_key
+            .verify(b"some test message", &signature)
+            .is_ok());
 
         #[cfg(feature = "flame_it")]
         flame::dump_html(&mut std::fs::File::create("dev/flame-graph.html").unwrap()).unwrap();

--- a/src/sign/non_interactive_sign/participant.rs
+++ b/src/sign/non_interactive_sign/participant.rs
@@ -109,7 +109,6 @@ impl Input {
         self.message_digest.clone().finalize()
     }
 
-    #[allow(unused)]
     pub(crate) fn public_key(&self) -> Result<k256::ecdsa::VerifyingKey> {
         // Add up all the key shares
         let public_key_point = self

--- a/src/sign/non_interactive_sign/participant.rs
+++ b/src/sign/non_interactive_sign/participant.rs
@@ -10,7 +10,7 @@ use std::collections::HashSet;
 use generic_array::{typenum::U32, GenericArray};
 use k256::{
     ecdsa::{signature::DigestVerifier, VerifyingKey},
-    elliptic_curve::{ops::Reduce, subtle::ConditionallySelectable, IsHigh},
+    elliptic_curve::{ops::Reduce, scalar::IsHigh, subtle::ConditionallySelectable},
     Scalar, U256,
 };
 use rand::{CryptoRng, RngCore};
@@ -109,6 +109,7 @@ impl Input {
         self.message_digest.clone().finalize()
     }
 
+    #[allow(unused)]
     pub(crate) fn public_key(&self) -> Result<k256::ecdsa::VerifyingKey> {
         // Add up all the key shares
         let public_key_point = self
@@ -351,7 +352,7 @@ impl SignParticipant {
 
         // Interpret the message digest as an integer mod `q`. This matches the way that
         // the k256 library converts a digest to a scalar.
-        let digest = <Scalar as Reduce<U256>>::from_be_bytes_reduced(self.input.digest());
+        let digest = <Scalar as Reduce<U256>>::reduce_bytes(&self.input.digest());
 
         // Compute the x-projection of `R` from the `PresignRecord`
         let x_projection = record.x_projection()?;
@@ -444,7 +445,7 @@ mod test {
 
     use k256::{
         ecdsa::signature::{DigestVerifier, Verifier},
-        elliptic_curve::{ops::Reduce, subtle::ConditionallySelectable, IsHigh},
+        elliptic_curve::{ops::Reduce, scalar::IsHigh, subtle::ConditionallySelectable},
         Scalar, U256,
     };
     use rand::{CryptoRng, Rng, RngCore};
@@ -520,7 +521,7 @@ mod test {
 
         let r = records[0].x_projection().unwrap();
 
-        let m = <Scalar as Reduce<U256>>::from_be_bytes_reduced(Sha256::digest(message));
+        let m = <Scalar as Reduce<U256>>::reduce_bytes(&Sha256::digest(message));
 
         let mut s = k * (m + r * secret_key);
         s.conditional_assign(&s.negate(), s.is_high());
@@ -532,7 +533,7 @@ mod test {
 
         assert!(public_key.verify(message, &signature).is_ok());
         assert!(public_key
-            .verify_digest(Sha256::new().chain(message), &signature)
+            .verify_digest(Sha256::new().chain_update(message), &signature)
             .is_ok());
         signature
     }
@@ -550,7 +551,7 @@ mod test {
         let presign_records = PresignRecord::simulate_set(&keygen_outputs, rng);
 
         let message = b"the quick brown fox jumped over the lazy dog";
-        let message_digest = sha2::Sha256::new().chain(message);
+        let message_digest = sha2::Sha256::new().chain_update(message);
 
         // Save some things for later -- a signature constructucted from the records and
         // the public key
@@ -638,9 +639,11 @@ mod test {
         // Verify that we have a valid signature under the public key for the `message`
         assert!(public_key.verify(message, distributed_sig.as_ref()).is_ok());
         assert!(public_key
-            .verify_digest(Sha256::new().chain(message), distributed_sig.as_ref())
+            .verify_digest(
+                Sha256::new().chain_update(message),
+                distributed_sig.as_ref()
+            )
             .is_ok());
-
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #444

Some of our core cryptography libraries were way out of date. Now they aren't. Most changes are just to method names and module organization.