### PR TITLE
Fix ignored tests to use latest rust version

### DIFF
--- a/.github/workflows/ignored_tests.yml
+++ b/.github/workflows/ignored_tests.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+  
+  # This is only here to test that the changes work. Should not be merged to main.
+  pull_request:
+    types: [opened]
 
 jobs:
   test:
@@ -12,15 +16,10 @@ jobs:
     name: ignored tests
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          # Set Rust version here!
-          toolchain: 1.69.0
-          override: true
+        uses: IronCoreLabs/rust-toolchain@v1
 
       # Caching for Rust files. Must be called after installing Rust toolchain.
       # See https://github.com/Swatinem/rust-cache for more information.

--- a/.github/workflows/ignored_tests.yml
+++ b/.github/workflows/ignored_tests.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches:
       - main
-  
-  # This is only here to test that the changes work. Should not be merged to main.
-  pull_request:
-    types: [opened]
 
 jobs:
   test:


### PR DESCRIPTION
It looks like our run-on-merge-to-main tests started failing because a dependency needs a higher minimum rust version. When we updated the other tests to pull the rust version from the `.toml` file, we didn't update these ones. Fixing now.

Please don't review until the tests run correctly, and note that we need to remove the line that runs these tests on PR before merging.