### PR TITLE
add interactive signing public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,39 @@
 //! generated in this threshold manner are indistinguishable from signatures
 //! generated using a normal ECDSA signing method.
 //!
+//! # Usage
+//! The [`Participant`] type is the main driver for protocol execution. A given
+//! `Participant` is parameterized by the subprotocol that it runs:
+//! [`keygen`](`keygen::KeygenParticipant`),
+//! [`auxinfo`](auxinfo::AuxInfoParticipant),
+//! [`presign`](presign::PresignParticipant), or
+//! [`sign`](sign::InteractiveSignParticipant).
+//!
+//! The public API is not currently complete: we provide an interface to call
+//! interactive signing (e.g. running the presign and sign protocols from
+//! Canetti et al. in sequence), but not for non-interactive signing. You can
+//! run presigning alone and generate individual [`SignatureShare`]s, but you
+//! must then manually combine those shares to create the generated signature;
+//! this does not provide the same security guarantees as the protocol.
+//!
+//! A valid protocol run requires a lot of setup so we won't try to provide a
+//! code example here; please see the examples directory. At a high level,
+//! though, the user can run a protocol as follows:
+//! 1. Create a new [`Participant`], parameterized by the
+//!    [`ProtocolParticipant`] describing the protocol you want to run.
+//! 2. Initialize the `Participant` by calling
+//!    [`initialize_message()`](Participant::initialize_message()) and passing
+//!    the result to
+//!    [`process_single_message`](Participant::process_single_message()).
+//! 3. Processing a message returns an optional output and a (possibly empty)
+//!    set of messages. Send any messages to the other participants. If there's
+//!    an output, the protocol is complete for this party.
+//! 4. On receiving a message from another participant, call
+//!    `process_single_message`. Repeat 3 and 4.
+//!
+//! Note that a `Participant` can receive messages before it has been
+//! initialized. They will be stored and processed after initialization.
+//!
 //! # 🔒 Requirements of the calling application
 //! This library **does not** implement the complete protocol. There are several
 //! security-critical steps that must be handled by the calling application. We

--- a/src/sign/interactive_sign/participant.rs
+++ b/src/sign/interactive_sign/participant.rs
@@ -182,7 +182,7 @@ impl ProtocolParticipant for InteractiveSignParticipant {
     }
 
     fn protocol_type() -> ProtocolType {
-        todo!()
+        ProtocolType::InteractiveSign
     }
 
     fn new(


### PR DESCRIPTION
Closes #426

This adds interactive signing to the public API. The only thing that had to change to make this possible was to add a condition that allows you to run a participant with `ProtocolType = InteractiveSign`. 

The much larger change here is to add an interactive-sign end-to-end test. There's some duplicated code relative to the non-interactive-sign e2e test but I simplified some of the mechanics relative to the older test; I might try to consolidate that. There's a lot of duplication in general with running these protocols and it might be helpful to write a generic-over-protocol-type runner. But it also might be confusing.

Open to recommendations on simplifying the test, otherwise I can make an issue to clean up the end-to-end tests after also adding non-interactive sign to the public API (#494) and maybe when we pull out those tests to be actual integration tests (#428).