### PR TITLE
Add noninteractive signing to public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,15 +43,13 @@
 //! `Participant` is parameterized by the subprotocol that it runs:
 //! [`keygen`](`keygen::KeygenParticipant`),
 //! [`auxinfo`](auxinfo::AuxInfoParticipant),
-//! [`presign`](presign::PresignParticipant), or
-//! [`sign`](sign::InteractiveSignParticipant).
-//!
-//! The public API is not currently complete: we provide an interface to call
-//! interactive signing (e.g. running the presign and sign protocols from
-//! Canetti et al. in sequence), but not for non-interactive signing. You can
-//! run presigning alone and generate individual [`SignatureShare`]s, but you
-//! must then manually combine those shares to create the generated signature;
-//! this does not provide the same security guarantees as the protocol.
+//! [`presign`](presign::PresignParticipant),
+//! [`sign`](sign::SignParticipant) or
+//! [`interactive_sign`](sign::InteractiveSignParticipant).
+//! As in the paper, interactive signing is equivalent to running presign and
+//! sign back-to-back; you only have to generate one session ID and don't have
+//! to handle secure storage of presign records, but don't get the benefit of
+//! being able to "cache" message-independent records.
 //!
 //! A valid protocol run requires a lot of setup so we won't try to provide a
 //! code example here; please see the examples directory. At a high level,

--- a/src/sign/interactive_sign/participant.rs
+++ b/src/sign/interactive_sign/participant.rs
@@ -110,7 +110,7 @@ impl SigningMaterial {
                 digest,
                 public_keys,
             } => {
-                let signing_input = sign::Input::new(digest, record, public_keys);
+                let signing_input = sign::Input::new_from_digest(digest, record, public_keys);
                 // Note: this shouldn't throw an error because the only failure case should have
                 // also been checked by the presign constructor, and computation
                 // halted far before we reach this point.


### PR DESCRIPTION
Closes #494 

This adds non-interactive signing to the public API, and paves the way to removing the non-protocol-correct DIY-signing. As in #493, the code changes are minimal; the changes to the tests and docs are more significant.