### PR TITLE
remove old signing API and update examples 

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -2,7 +2,7 @@ The threshold ECDSA library breaks down the tss-ecdsa protocol by Canetti et. al
 
 # Benchmarks
 
-These benchmarks evaluate the keygen, aux-info, and pre-signing  protocols. We did not evaluate the signing step because it’s virtually instantaneous. Each protocol was run 100 times using the criterion Rust package.
+These benchmarks evaluate the keygen, aux-info, and pre-signing  protocols. We did not evaluate the signing protocol, in either its interactive or non-interactive form, because it’s usually fast. Each protocol was run 100 times using the criterion Rust package.
 
 The benchmarking software runs all parties serially; it randomly selects a party, processes any messages it has waiting, and repeats until the protocol is complete. The results reported try to capture per-party runtime: the total benchmark time divided by the number of parties.
 

--- a/src/keygen/output.rs
+++ b/src/keygen/output.rs
@@ -41,7 +41,8 @@ impl Output {
         })
     }
 
-    pub(crate) fn public_key_shares(&self) -> &[KeySharePublic] {
+    /// Get the individual shares of the public key.
+    pub fn public_key_shares(&self) -> &[KeySharePublic] {
         &self.public_key_shares
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,6 @@ mod zkstar;
 pub use participant::ProtocolParticipant;
 pub use protocol::{
     participant_config::ParticipantConfig, Identifier, Participant, ParticipantIdentifier,
-    SignatureShare,
 };
 
 use crate::presign::*;


### PR DESCRIPTION
Closes #427

This removes the outdated signing API (which didn't run the protocol as specified in the paper) and updates the examples that used it. 