### PR TITLE
Add support recoverable signatures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,32 @@ This library also includes a Makefile with our full set of continuous integratio
 ## Benchmarks
 
 The benchmarks are found in the benches folder. Please refer to the benches/README.md file for information on how to run and obtain the benchmarks, as well as how to generate a flame graph showing relative costs of some function calls.
+
+## Examples
+
+This library contains a CLI example you can use to test out the complete tss-ecdsa workflow: key generation, aux-info generation, pre-sign record generation, and signing.
+From the root directory, you can run: `cargo run --example threaded_example -- --help`. This command will print the CLI interface:
+```
+Multi-party ECDSA signing
+
+Usage: threaded_example --number-of-workers <NUMBER_OF_WORKERS> --protocol-executions <PROTOCOL_EXECUTIONS>
+
+Options:
+-n, --number-of-workers <NUMBER_OF_WORKERS>
+Number of participant worker threads to use
+-p, --protocol-executions <PROTOCOL_EXECUTIONS>
+Number of times to perform each sub-protocol of tss-ecdsa. protocol_executions > 1 useful for computing meaningful average execution times
+-h, --help
+Print help
+-V, --version
+Print version
+```
+For example, `cargo run --example threaded_example -- --number-of-workers 3 --protocol-executions 1` will execute this example using three workers (participants).
+**Note** please pay attention to the `--` in the middle of the command. This is necessary to separate arguments to the `cargo run` command from arguments to this
+CLI example.
+
+This CLI example supports logging via the tracing crate. You can set the env var `RUST_LOG` to a verbosity level to execute with logging turned on:
+For example:
+```shell
+RUST_LOG=info cargo run --example threaded_example -- --number-of-workers 2 --protocol-executions 1
+```

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -35,7 +35,7 @@ pub enum InternalError {
 /// These are triggered when the calling application incorrectly
 /// routes a message to the
 /// [`process_single_message()`](crate::Participant::process_single_message())
-/// method.
+/// method OR some other caller error.
 #[derive(Clone, Eq, PartialEq, Error, Debug)]
 #[allow(missing_docs)]
 pub enum CallerError {
@@ -57,6 +57,8 @@ pub enum CallerError {
     BadInput,
     #[error("Failed to deserialize bytes into the expected type")]
     DeserializationFailed,
+    #[error("Failed to compute recovery ID for signature")]
+    SignatureTrialRecoveryFailed,
 }
 
 macro_rules! serialize {

--- a/src/sign/non_interactive_sign/participant.rs
+++ b/src/sign/non_interactive_sign/participant.rs
@@ -431,7 +431,10 @@ mod test {
     use std::collections::HashMap;
 
     use k256::{
-        ecdsa::signature::{DigestVerifier, Verifier},
+        ecdsa::{
+            signature::{DigestVerifier, Verifier},
+            VerifyingKey,
+        },
         elliptic_curve::{ops::Reduce, scalar::IsHigh, subtle::ConditionallySelectable},
         Scalar, U256,
     };
@@ -626,6 +629,22 @@ mod test {
                 distributed_sig.as_ref()
             )
             .is_ok());
+
+        // Check we are able to create a recoverable signature.
+        let recovery_id = distributed_sig
+            .recovery_id(message, public_key)
+            .expect("Recovery ID failed");
+
+        // Re-derive the public key from the recoverable ID and ensure it matches the
+        // original public key.
+        let recovered_pk =
+            VerifyingKey::recover_from_msg(message, distributed_sig.as_ref(), recovery_id).unwrap();
+
+        assert_eq!(
+            recovered_pk, *public_key,
+            "Recovered public key does not match original one."
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
Implements method to compute recoverable signatures. Closes Issue #508.

Tested by adding recoverable signature function call to sign unit tests.
Adds documentation for the threaded example CLI.