### PR TITLE
Include dependency to `rug` to fix compilation error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,13 @@ generic-array = "0.14"
 hex = "0.4"
 k256 = { version = "0.13", features = ["arithmetic", "sha256", "ecdsa", "serde"] }
 lazy_static = "1"
+
+# libpaillier depends on `unknown_order` which in turn depends on `rug`.
 libpaillier = { version = "0.5", default-features = false, features = ["gmp"] }
+# We don't use `rug` directly, but compilation will fail unless we include it here. See Issue #513 for more
+# information.
+rug = { version = "1.24.0"}
+
 merlin = "3"
 num-bigint = "0.4"
 rand = "0.8"


### PR DESCRIPTION
See Issue #513 for more details.