### PR TITLE
keygen: security fixes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum InternalError {
     Serialization,
     #[error("Some player sent a message which does not match the protocol specification: {0:?}")]
     ProtocolError(Option<ParticipantIdentifier>),
+    #[error("Some player sent more than one message of the same type: {0:?}")]
+    DuplicateMessage(ParticipantIdentifier),
     #[error("Represents some code assumption that was checked at runtime but failed to be true")]
     InternalInvariantFailed,
     #[error("Unexpected state: {0:?} for protocol participant's status")]

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -106,7 +106,7 @@ impl KeySharePrivate {
 
             // Check that the share itself is valid
             let share = BigNumber::from_slice(share_bytes);
-            if share > k256_order() || share < BigNumber::one() {
+            if share >= k256_order() || share < BigNumber::one() {
                 Err(CallerError::DeserializationFailed)?
             }
 
@@ -206,9 +206,7 @@ mod tests {
     #[test]
     fn keyshare_private_bytes_must_be_in_range() {
         // Share must be < k256_order()
-        let too_big = KeySharePrivate {
-            x: k256_order() + 1,
-        };
+        let too_big = KeySharePrivate { x: k256_order() };
         let bytes = too_big.into_bytes();
         assert!(KeySharePrivate::try_from_bytes(bytes).is_err());
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -23,10 +23,7 @@ use crate::{
     },
     protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once,
-    zkp::{
-        pisch::{CommonInput, PiSchPrecommit, PiSchProof, ProverSecret},
-        Proof,
-    },
+    zkp::pisch::{CommonInput, PiSchPrecommit, PiSchProof, ProverSecret},
     Identifier,
 };
 
@@ -317,15 +314,23 @@ impl KeygenParticipant {
         rng: &mut R,
         broadcast_message: BroadcastOutput,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
+        let message = broadcast_message.into_message(BroadcastTag::KeyGenR1CommitHash)?;
+
+        if self
+            .local_storage
+            .contains::<storage::Commit>(message.from())
+        {
+            warn!(
+                "Received duplicate round one keygen message from {:?}.",
+                message.from()
+            );
+            return Ok(ProcessOutcome::Incomplete);
+        }
         info!("Handling round one keygen message.");
 
-        // XXX should we have a check that we haven't recieved a round one
-        // message _after_ round one is complete? Likewise for all other rounds.
-
-        let message = broadcast_message.into_message(BroadcastTag::KeyGenR1CommitHash)?;
         let keygen_commit = KeygenCommit::from_message(&message)?;
         self.local_storage
-            .store::<storage::Commit>(message.from(), keygen_commit);
+            .store_once::<storage::Commit>(message.from(), keygen_commit)?;
 
         // Check if we've received all the commits, which signals an end to
         // round one.
@@ -411,7 +416,18 @@ impl KeygenParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
+        if self
+            .local_storage
+            .contains::<storage::Decommit>(message.from())
+        {
+            warn!(
+                "Received duplicate round two keygen message from {:?}.",
+                message.from()
+            );
+            return Ok(ProcessOutcome::Incomplete);
+        }
         info!("Handling round two keygen message.");
+
         // We must receive all commitments in round 1 before we start processing
         // decommits in round 2.
         let r1_done = self
@@ -424,13 +440,12 @@ impl KeygenParticipant {
         }
         // Check that the decommitment contained in the message is valid for the
         // previously received commitment.
-        let decom = KeygenDecommit::from_message(message)?;
         let com = self
             .local_storage
             .retrieve::<storage::Commit>(message.from())?;
-        decom.verify(&message.id(), &message.from(), com)?;
+        let decom = KeygenDecommit::from_message(message, com)?;
         self.local_storage
-            .store::<storage::Decommit>(message.from(), decom);
+            .store_once::<storage::Decommit>(message.from(), decom)?;
 
         // Check if we've received all the decommits
         let r2_done = self
@@ -486,7 +501,7 @@ impl KeygenParticipant {
         }
         self.local_storage
             .store::<storage::GlobalRid>(self.id, global_rid);
-        let transcript = schnorr_proof_transcript(&global_rid)?;
+        let transcript = schnorr_proof_transcript(self.sid(), &global_rid, self.id())?;
 
         let precom = self
             .local_storage
@@ -527,6 +542,16 @@ impl KeygenParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
+        if self
+            .local_storage
+            .contains::<storage::PublicKeyshare>(message.from())
+        {
+            warn!(
+                "Received duplicate round three keygen message from {:?}.",
+                message.from()
+            );
+            return Ok(ProcessOutcome::Incomplete);
+        }
         info!("Handling round three keygen message.");
 
         if !self.local_storage.contains::<storage::GlobalRid>(self.id) {
@@ -538,17 +563,18 @@ impl KeygenParticipant {
         let decom = self
             .local_storage
             .retrieve::<storage::Decommit>(message.from())?;
+        let precommit = &decom.A;
 
         let input = CommonInput::new(&decom.pk);
 
-        let mut transcript = schnorr_proof_transcript(&global_rid)?;
-        proof.verify(input, &self.retrieve_context(), &mut transcript)?;
+        let mut transcript = schnorr_proof_transcript(self.sid(), &global_rid, message.from())?;
+        proof.verify_with_precommit(input, &self.retrieve_context(), &mut transcript, precommit)?;
 
         // Only if the proof verifies do we store the participant's public key
         // share. This signals the end of the protocol for the participant.
         let keyshare = decom.get_keyshare();
         self.local_storage
-            .store::<storage::PublicKeyshare>(message.from(), keyshare.clone());
+            .store_once::<storage::PublicKeyshare>(message.from(), keyshare.clone())?;
 
         //check if we've stored all the public keyshares
         let keyshare_done = self
@@ -577,9 +603,15 @@ impl KeygenParticipant {
 }
 
 /// Generate a [`Transcript`] for [`PiSchProof`].
-fn schnorr_proof_transcript(global_rid: &[u8; 32]) -> Result<Transcript> {
+fn schnorr_proof_transcript(
+    sid: Identifier,
+    global_rid: &[u8; 32],
+    sender_id: ParticipantIdentifier,
+) -> Result<Transcript> {
     let mut transcript = Transcript::new(b"keygen schnorr");
+    transcript.append_message(b"sid", &serialize!(&sid)?);
     transcript.append_message(b"rid", &serialize!(global_rid)?);
+    transcript.append_message(b"sender_id", &serialize!(&sender_id)?);
     Ok(transcript)
 }
 

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -316,16 +316,7 @@ impl KeygenParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         let message = broadcast_message.into_message(BroadcastTag::KeyGenR1CommitHash)?;
 
-        if self
-            .local_storage
-            .contains::<storage::Commit>(message.from())
-        {
-            warn!(
-                "Received duplicate round one keygen message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::Commit>(message.from())?;
         info!("Handling round one keygen message.");
 
         let keygen_commit = KeygenCommit::from_message(&message)?;
@@ -416,16 +407,7 @@ impl KeygenParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
-        if self
-            .local_storage
-            .contains::<storage::Decommit>(message.from())
-        {
-            warn!(
-                "Received duplicate round two keygen message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::Decommit>(message.from())?;
         info!("Handling round two keygen message.");
 
         // We must receive all commitments in round 1 before we start processing
@@ -542,16 +524,7 @@ impl KeygenParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
-        if self
-            .local_storage
-            .contains::<storage::PublicKeyshare>(message.from())
-        {
-            warn!(
-                "Received duplicate round three keygen message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::PublicKeyshare>(message.from())?;
         info!("Handling round three keygen message.");
 
         if !self.local_storage.contains::<storage::GlobalRid>(self.id) {

--- a/src/keyrefresh/keyrefresh_commit.rs
+++ b/src/keyrefresh/keyrefresh_commit.rs
@@ -65,6 +65,7 @@ impl KeyrefreshDecommit {
         }
     }
 
+    /// Deserialize a KeyrefreshDecommit from a message and verify it.
     pub(crate) fn from_message(
         message: &Message,
         com: &KeyrefreshCommit,

--- a/src/keyrefresh/participant.rs
+++ b/src/keyrefresh/participant.rs
@@ -374,16 +374,7 @@ impl KeyrefreshParticipant {
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
         let message = broadcast_message.into_message(BroadcastTag::KeyRefreshR1CommitHash)?;
 
-        if self
-            .local_storage
-            .contains::<storage::Commit>(message.from())
-        {
-            warn!(
-                "Received duplicate round one keyrefresh message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::Commit>(message.from())?;
         info!("Handling round one keyrefresh message.");
 
         let keyrefresh_commit = KeyrefreshCommit::from_message(&message)?;
@@ -474,16 +465,7 @@ impl KeyrefreshParticipant {
         rng: &mut R,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
-        if self
-            .local_storage
-            .contains::<storage::Decommit>(message.from())
-        {
-            warn!(
-                "Received duplicate round two keyrefresh message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::Decommit>(message.from())?;
         info!("Handling round two keyrefresh message.");
 
         // We must receive all commitments in round 1 before we start processing
@@ -659,16 +641,8 @@ impl KeyrefreshParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
-        if self
-            .local_storage
-            .contains::<storage::ValidPublicUpdates>(message.from())
-        {
-            warn!(
-                "Received duplicate round three keyrefresh broadcast message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::ValidPublicUpdates>(message.from())?;
+
         if !self.can_handle_round_three_msg() {
             info!("Not yet ready to handle round three keyrefresh broadcast message.");
             self.stash_message(message)?;
@@ -724,16 +698,8 @@ impl KeyrefreshParticipant {
         &mut self,
         message: &Message,
     ) -> Result<ProcessOutcome<<Self as ProtocolParticipant>::Output>> {
-        if self
-            .local_storage
-            .contains::<storage::ValidPrivateUpdate>(message.from())
-        {
-            warn!(
-                "Received duplicate round three keyrefresh private message from {:?}.",
-                message.from()
-            );
-            return Ok(ProcessOutcome::Incomplete);
-        }
+        self.check_for_duplicate_msg::<storage::ValidPrivateUpdate>(message.from())?;
+
         if !self.can_handle_round_three_msg() {
             info!("Not yet ready to handle round three keyrefresh private message.");
             self.stash_message(message)?;

--- a/src/keyrefresh/participant.rs
+++ b/src/keyrefresh/participant.rs
@@ -388,7 +388,7 @@ impl KeyrefreshParticipant {
 
         let keyrefresh_commit = KeyrefreshCommit::from_message(&message)?;
         self.local_storage
-            .store::<storage::Commit>(message.from(), keyrefresh_commit);
+            .store_once::<storage::Commit>(message.from(), keyrefresh_commit)?;
 
         // Check if we've received all the commits, which signals an end to
         // round one.
@@ -503,7 +503,7 @@ impl KeyrefreshParticipant {
             .retrieve::<storage::Commit>(message.from())?;
         let decom = KeyrefreshDecommit::from_message(message, com, &self.all_participants())?;
         self.local_storage
-            .store::<storage::Decommit>(message.from(), decom);
+            .store_once::<storage::Decommit>(message.from(), decom)?;
 
         // Check if we've received all the decommits
         let r2_done = self
@@ -707,7 +707,10 @@ impl KeyrefreshParticipant {
 
         // Only if the proof verifies do we store the participant's updates.
         self.local_storage
-            .store::<storage::ValidPublicUpdates>(message.from(), decom.update_publics.clone());
+            .store_once::<storage::ValidPublicUpdates>(
+                message.from(),
+                decom.update_publics.clone(),
+            )?;
 
         self.maybe_finish()
     }


### PR DESCRIPTION
This PR fixes the following issues in KeyGen:

- *MAJOR -* Messages for past rounds overwrite the state.
    - [Issue #527](https://github.com/boltlabs-inc/tss-ecdsa/issues/527)

- *MAJOR -* Schnorr proofs are not verified against the commitment.
    - [Issue #515](https://github.com/boltlabs-inc/tss-ecdsa/issues/515).

- *MEDIUM -* Proofs can be replayed without knowledge of exponent.
    - [Issue #149](https://github.com/boltlabs-inc/tss-ecdsa/issues/149#issuecomment-2066617606).
    
- *UNKNOWN -* Function `KeygenDecommit::verify` sets the fields in a copy so it does not actually verify these fields.

- *INFO -* Inconsistent handling of edge cases of key shares (0 vs q).