### PR TITLE
Reject repeated messages in the auxinfo and signing protocols

### DIFF
--- a/src/sign/non_interactive_sign/participant.rs
+++ b/src/sign/non_interactive_sign/participant.rs
@@ -375,9 +375,12 @@ impl SignParticipant {
             return Ok(ProcessOutcome::Incomplete);
         }
 
+        self.check_for_duplicate_msg::<storage::Share>(message.from())?;
+
         // Save this signature share
         let share = SignatureShare::try_from(message)?;
-        self.storage.store::<storage::Share>(message.from(), share);
+        self.storage
+            .store_once::<storage::Share>(message.from(), share)?;
 
         // If we haven't received shares from all parties, stop here
         if !self


### PR DESCRIPTION
The policy is to never accept duplicate or conflicting messages, and to never overwrite existing values in storage.

See also https://github.com/boltlabs-inc/tss-ecdsa/pull/530 for the same in keygen and keyrefresh.