### PR TITLE
Distinct proof contexts per participant

### DIFF
--- a/src/auxinfo/participant.rs
+++ b/src/auxinfo/participant.rs
@@ -503,7 +503,7 @@ impl AuxInfoParticipant {
                 let shared_context = &self.retrieve_context();
                 // ... and use its setup parameters in the proof.
                 let common_input =
-                    CommonInput::new(shared_context, sid, global_rid, params, &product);
+                    CommonInput::new(shared_context, sid, global_rid, self.id(), params, &product);
                 let proof = AuxInfoProof::prove(rng, &common_input, &witness.p, &witness.q)?;
                 Message::new(
                     MessageType::Auxinfo(AuxinfoMessageType::R3Proof),
@@ -552,6 +552,7 @@ impl AuxInfoParticipant {
             shared_context,
             message.id(),
             *global_rid,
+            message.from(),
             my_public.params(),
             auxinfo_pub.pk().modulus(),
         );

--- a/src/presign/round_one.rs
+++ b/src/presign/round_one.rs
@@ -6,6 +6,7 @@
 // License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 // of this source tree.
 
+use super::participant::ParticipantPresignContext;
 use crate::{
     errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
@@ -13,7 +14,7 @@ use crate::{
     ring_pedersen::VerifiedRingPedersen,
     zkp::{
         pienc::{PiEncInput, PiEncProof},
-        Proof, ProofContext,
+        Proof,
     },
 };
 use libpaillier::unknown_order::BigNumber;
@@ -80,7 +81,7 @@ impl Public {
     /// (i.e., the verifier).
     pub(crate) fn verify(
         self,
-        context: &impl ProofContext,
+        context: &ParticipantPresignContext,
         verifier_setup_params: &VerifiedRingPedersen,
         prover_pk: &EncryptionKey,
         prover_public_broadcast: &PublicBroadcast,

--- a/src/presign/round_three.rs
+++ b/src/presign/round_three.rs
@@ -11,13 +11,14 @@ use crate::{
     errors::{InternalError, Result},
     messages::{Message, MessageType, PresignMessageType},
     presign::{
+        participant::ParticipantPresignContext,
         round_one::PublicBroadcast as RoundOnePublicBroadcast,
         round_two::{Private as RoundTwoPrivate, Public as RoundTwoPublic},
     },
     utils::CurvePoint,
     zkp::{
         pilog::{CommonInput, PiLogProof},
-        Proof, ProofContext,
+        Proof,
     },
 };
 use k256::{elliptic_curve::PrimeField, Scalar};
@@ -75,7 +76,7 @@ impl Public {
     /// values.
     pub(crate) fn verify(
         self,
-        context: &impl ProofContext,
+        context: &ParticipantPresignContext,
         verifier_auxinfo_public: &AuxInfoPublic,
         prover_auxinfo_public: &AuxInfoPublic,
         prover_r1_public_broadcast: &RoundOnePublicBroadcast,

--- a/src/presign/round_two.rs
+++ b/src/presign/round_two.rs
@@ -12,12 +12,15 @@ use crate::{
     keygen::KeySharePublic,
     messages::{Message, MessageType, PresignMessageType},
     paillier::Ciphertext,
-    presign::round_one::{Private as RoundOnePrivate, PublicBroadcast as RoundOnePublicBroadcast},
+    presign::{
+        participant::ParticipantPresignContext,
+        round_one::{Private as RoundOnePrivate, PublicBroadcast as RoundOnePublicBroadcast},
+    },
     utils::CurvePoint,
     zkp::{
         piaffg::{PiAffgInput, PiAffgProof},
         pilog::{CommonInput, PiLogProof},
-        Proof, ProofContext,
+        Proof,
     },
 };
 use libpaillier::unknown_order::BigNumber;
@@ -65,7 +68,7 @@ impl Public {
     /// [`PublicBroadcast`](crate::presign::round_one::PublicBroadcast) values.
     pub(crate) fn verify(
         self,
-        context: &impl ProofContext,
+        context: &ParticipantPresignContext,
         verifier_auxinfo_public: &AuxInfoPublic,
         verifier_r1_private: &RoundOnePrivate,
         prover_auxinfo_public: &AuxInfoPublic,


### PR DESCRIPTION
This PR adds the participant ID to the context of each proof. This is as specified in the paper, such that there is no risk of someone replaying someone else’s proofs.

This applies to AuxInfo and PreSign. See https://github.com/boltlabs-inc/tss-ecdsa/pull/530 for the same in KeyGen and KeyRefresh.