### PR TITLE
Update `Display` instance for `ParticipantIdentifier`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1"
 libpaillier = { version = "0.5", default-features = false, features = ["gmp"] }
 # We don't use `rug` directly, but compilation will fail unless we include it here. See Issue #513 for more
 # information.
-rug = { version = "1.24.0"}
+rug = { version = "1.24.0" }
 
 merlin = "3"
 num-bigint = "0.4"
@@ -54,13 +54,13 @@ glass_pumpkin = "1"
 indicatif = "0.16"
 openssl = "0.10"
 reqwest = { version = "0.11", features = ["json"] }
-rocket = { version = "0.5.0-rc", default-features = false, features = ["json"] }
+
 rug = { version = "1.16", default-features = false, features = ["integer", "rand"] }
-tracing = {version = "0.1", default-features = false}
+tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tokio = { version = "1", features = ["full"] }
 # Generate UUID for threaded example.
-uuid = { version = "1.3.3", features =  ["v4", "fast-rng" ]}
+uuid = { version = "1.3.3", features = ["v4", "fast-rng"] }
 
 [[bench]]
 name = "e2e_benchmark"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -409,8 +409,9 @@ impl ParticipantIdentifier {
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         // Sample random 32 bytes and convert to hex
         let random_bytes = rng.gen::<u128>();
-        trace!("Created new Participant Identifier({random_bytes})");
-        Self(random_bytes)
+        let pid = Self(random_bytes);
+        trace!("Created new {}", pid);
+        pid
     }
 
     /// Note: This method is for convenience only. The `id` value is still
@@ -490,12 +491,10 @@ impl SharedContext {
 }
 
 impl std::fmt::Display for ParticipantIdentifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "ParticipantId({})",
-            hex::encode(&self.0.to_be_bytes()[..4])
-        )
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        // 16 byte number. Take last five bytes for display purposes.
+        let last_bytes = &self.0.to_be_bytes()[11..];
+        write!(f, "ParticipantId(0x{})", hex::encode(last_bytes))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -421,6 +421,7 @@ mod tests {
 /// and used for debugging.
 #[cfg(test)]
 pub(crate) mod testing {
+    use crate::enable_zeroize;
     use rand::{
         rngs::{OsRng, StdRng},
         Rng, SeedableRng,
@@ -435,6 +436,7 @@ pub(crate) mod testing {
     /// This will print the rng seed to stderr so that if a test fails, the
     /// failing seed can be recovered and used for debugging.
     pub(crate) fn init_testing() -> StdRng {
+        enable_zeroize();
         let mut seeder = OsRng;
         let seed = seeder.gen();
         eprintln!(


### PR DESCRIPTION
Smol PR for cleaning up a few things.

The `Display` change uses the last 4 bytes instead of the first 4 bytes for pretty display purposes. As it is more likely that the underlying u128 will have these least significant digits vs the most significant digits. Printed, it now looks like `ParticipantId(0x77d6b86ab8)`.

This fixes an issue in our MPC Demo where IDs look like: `ParticipantId(00000000)` since they are seeded from u32 values (which are always zero in those most significant digits :face_exhaling: )

- Use our zeroizing in all unit tests.
- Remove unneeded Rocket dev dependency.