### PR TITLE
key-export-abstract: Import/export with abstract encryption library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sha3 = "0.10.8"
 thiserror = "1"
 tracing = "0.1.37"
 zeroize = "1.5"
+sodiumoxide = "0.2.7"
 
 [dependencies.gmp-mpfr-sys]
 version = "~1.6"

--- a/src/keygen/keyshare.rs
+++ b/src/keygen/keyshare.rs
@@ -38,7 +38,7 @@ impl Debug for KeySharePrivate {
 
 impl KeySharePrivate {
     /// Sample a private key share uniformly at random.
-    pub(crate) fn random(rng: &mut (impl CryptoRng + RngCore)) -> Self {
+    pub fn random(rng: &mut (impl CryptoRng + RngCore)) -> Self {
         let random_bn = BigNumber::from_rng(&k256_order(), rng);
         KeySharePrivate { x: random_bn }
     }

--- a/src/keyshare_export.rs
+++ b/src/keyshare_export.rs
@@ -1,0 +1,162 @@
+//! Module to export and import key shares, with encryption in transit.
+
+use crate::{errors::Result, keygen::KeySharePrivate};
+use std::{marker::PhantomData, ops::Deref};
+
+mod pke;
+pub use pke::Pke;
+
+mod sodium;
+pub use sodium::SodiumPke;
+
+/// Struct for handling the export and import of KeySharePrivate
+#[derive(Clone, Debug)]
+pub struct KeyShareEncrypted<T: Pke>(Vec<u8>, PhantomData<T>);
+
+impl<T: Pke> From<Vec<u8>> for KeyShareEncrypted<T> {
+    fn from(data: Vec<u8>) -> Self {
+        Self(data, PhantomData)
+    }
+}
+
+impl<T: Pke> From<KeyShareEncrypted<T>> for Vec<u8> {
+    fn from(encrypted: KeyShareEncrypted<T>) -> Vec<u8> {
+        encrypted.0
+    }
+}
+
+impl<T: Pke> Deref for KeyShareEncrypted<T> {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Pke> KeyShareEncrypted<T> {
+    /// Export a `KeySharePrivate` structure by serializing and encrypting it.
+    ///
+    /// # Arguments
+    ///
+    /// * `key_share` - The private key share to export.
+    /// * `receiver_pk` - The public key of the receiver for encryption.
+    /// * `sender_sk` - The private key of the sender for encryption.
+    ///
+    /// # Returns
+    ///
+    /// An encrypted byte vector of the serialized KeySharePrivate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tss_ecdsa::keygen::KeySharePrivate;
+    /// use tss_ecdsa::keyshare_export::{KeyShareEncrypted, SodiumPke};
+    /// use sodiumoxide::crypto::box_;
+    ///
+    /// sodiumoxide::init().expect("Failed to initialize sodiumoxide");
+    /// let (sender_pk, sender_sk) = box_::gen_keypair();
+    /// let (receiver_pk, receiver_sk) = box_::gen_keypair();
+    /// let mut rng = rand::thread_rng();
+    /// let key_share = KeySharePrivate::random(&mut rng);
+    ///
+    /// let exported = KeyShareEncrypted::<SodiumPke>::export_keyshare(&key_share, &receiver_pk, &sender_sk)
+    ///     .expect("Failed to export keyshare");
+    /// let exported_bytes: Vec<u8> = exported.into();
+    ///
+    /// let to_import = KeyShareEncrypted::<SodiumPke>::from(exported_bytes);
+    /// let imported = to_import.import_keyshare(&sender_pk, &receiver_sk)
+    ///     .expect("Failed to import keyshare");
+    ///
+    /// assert_eq!(imported, key_share);
+    /// ```
+    pub fn export_keyshare(
+        key_share: &KeySharePrivate,
+        receiver_pk: &T::PublicKey,
+        sender_sk: &T::SecretKey,
+    ) -> Result<Self> {
+        let serialized = key_share.clone().into_bytes();
+        let encrypted_data = T::encrypt(&serialized, receiver_pk, sender_sk)?;
+        Ok(Self(encrypted_data, PhantomData))
+    }
+
+    /// Import a `KeySharePrivate` structure by decrypting and deserializing it.
+    ///
+    /// # Arguments
+    ///
+    /// * `encrypted_key_share` - The encrypted byte vector of the
+    ///   KeySharePrivate.
+    /// * `sender_pk` - The public key of the sender for decryption.
+    /// * `receiver_sk` - The private key of the receiver for decryption.
+    ///
+    /// # Returns
+    ///
+    /// A `KeySharePrivate` object.
+    pub fn import_keyshare(
+        &self,
+        sender_pk: &T::PublicKey,
+        receiver_sk: &T::SecretKey,
+    ) -> Result<KeySharePrivate> {
+        let decrypted_data = T::decrypt(&self.0, sender_pk, receiver_sk)?;
+        KeySharePrivate::try_from_bytes(decrypted_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sodiumoxide::crypto::box_;
+
+    #[test]
+    fn test_failed_import_invalid_nonce_with_libsodium() {
+        // Initialize sodiumoxide library
+        sodiumoxide::init().unwrap();
+
+        // Generate key pairs for the sender and receiver
+        let (sender_pk, sender_sk) = box_::gen_keypair();
+        let (receiver_pk, receiver_sk) = box_::gen_keypair();
+
+        // Create a random KeySharePrivate
+        let mut rng = rand::thread_rng();
+        let key_share = KeySharePrivate::random(&mut rng);
+
+        // Export the key share using the LibsodiumPke
+        let mut encrypted =
+            KeyShareEncrypted::<SodiumPke>::export_keyshare(&key_share, &receiver_pk, &sender_sk)
+                .expect("Failed to export key share");
+
+        // Tamper with the nonce to invalidate it
+        encrypted.0[0] ^= 0xff;
+
+        // Attempt to import the key share (should fail)
+        let result =
+            KeyShareEncrypted::<SodiumPke>::import_keyshare(&encrypted, &sender_pk, &receiver_sk);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_failed_import_invalid_ciphertext_with_libsodium() {
+        // Initialize sodiumoxide library
+        sodiumoxide::init().unwrap();
+
+        // Generate key pairs for the sender and receiver
+        let (sender_pk, sender_sk) = box_::gen_keypair();
+        let (receiver_pk, receiver_sk) = box_::gen_keypair();
+
+        // Create a random KeySharePrivate
+        let mut rng = rand::thread_rng();
+        let key_share = KeySharePrivate::random(&mut rng);
+
+        // Export the key share using the LibsodiumPke
+        let mut encrypted =
+            KeyShareEncrypted::<SodiumPke>::export_keyshare(&key_share, &receiver_pk, &sender_sk)
+                .expect("Failed to export key share");
+
+        // Tamper with the ciphertext to invalidate it
+        encrypted.0[box_::NONCEBYTES] ^= 0xff;
+
+        // Attempt to import the key share (should fail)
+        let result =
+            KeyShareEncrypted::<SodiumPke>::import_keyshare(&encrypted, &sender_pk, &receiver_sk);
+        assert!(result.is_err());
+    }
+}

--- a/src/keyshare_export/pke.rs
+++ b/src/keyshare_export/pke.rs
@@ -1,0 +1,25 @@
+use crate::errors::Result;
+
+/// Trait for public-key encryption of exported key shares.
+pub trait Pke {
+    /// Type for public keys
+    type PublicKey;
+    /// Type for secret keys
+    type SecretKey;
+
+    /// Encrypt a plaintext using the public key of the receiver and the secret
+    /// key of the sender
+    fn encrypt(
+        plaintext: &[u8],
+        receiver_pk: &Self::PublicKey,
+        sender_sk: &Self::SecretKey,
+    ) -> Result<Vec<u8>>;
+
+    /// Decrypt a ciphertext using the public key of the sender and the secret
+    /// key of the receiver
+    fn decrypt(
+        ciphertext: &[u8],
+        sender_pk: &Self::PublicKey,
+        receiver_sk: &Self::SecretKey,
+    ) -> Result<Vec<u8>>;
+}

--- a/src/keyshare_export/sodium.rs
+++ b/src/keyshare_export/sodium.rs
@@ -1,0 +1,50 @@
+use sodiumoxide::crypto::box_::{gen_nonce, open, seal, Nonce, PublicKey, SecretKey, NONCEBYTES};
+
+use crate::{
+    errors::{InternalError, Result},
+    keyshare_export::Pke,
+};
+
+/// Libsodium-based implementation of the Pke trait
+#[derive(Clone, Debug)]
+pub struct SodiumPke;
+
+impl Pke for SodiumPke {
+    type PublicKey = PublicKey;
+    type SecretKey = SecretKey;
+
+    fn encrypt(
+        plaintext: &[u8],
+        receiver_pk: &Self::PublicKey,
+        sender_sk: &Self::SecretKey,
+    ) -> Result<Vec<u8>> {
+        init()?;
+
+        let nonce = gen_nonce();
+        let ciphertext = seal(plaintext, &nonce, receiver_pk, sender_sk);
+
+        let mut encrypted_data = nonce.0.to_vec();
+        encrypted_data.extend(ciphertext);
+        Ok(encrypted_data)
+    }
+
+    fn decrypt(
+        ciphertext: &[u8],
+        sender_pk: &Self::PublicKey,
+        receiver_sk: &Self::SecretKey,
+    ) -> Result<Vec<u8>> {
+        init()?;
+
+        let (nonce_bytes, ciphertext) = ciphertext.split_at(NONCEBYTES);
+        let nonce = Nonce::from_slice(nonce_bytes).ok_or(InternalError::Serialization)?;
+
+        let decrypted = open(ciphertext, &nonce, sender_pk, receiver_sk)
+            .map_err(|_| InternalError::Serialization)?;
+
+        Ok(decrypted)
+    }
+}
+
+fn init() -> Result<()> {
+    sodiumoxide::init().map_err(|_| InternalError::InternalInvariantFailed)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@ mod broadcast;
 mod gmp_zeroize;
 pub mod keygen;
 pub mod keyrefresh;
+pub mod keyshare_export;
 mod local_storage;
 mod message_queue;
 pub mod messages;


### PR DESCRIPTION
Issue #537.

This is a variant with an abstraction over encryption libraries.