### PR TITLE
Add chain code to tshare and create subprotocol helpers

### DIFF
--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -36,6 +36,7 @@ pub(crate) struct KeygenDecommit {
     ///`sid` corresponds to a unique session identifier.
     pub sid: Identifier,
     pub sender: ParticipantIdentifier,
+    pub chain_code: [u8; 32],
     pub rid: [u8; 32],
     pub u_i: [u8; 32],
     pub pk: KeySharePublic,
@@ -51,13 +52,16 @@ impl KeygenDecommit {
         pk: &KeySharePublic,
         sch_precom: &PiSchPrecommit,
     ) -> Self {
+        let mut chain_code = [0u8; 32];
         let mut rid = [0u8; 32];
         let mut u_i = [0u8; 32];
+        rng.fill_bytes(chain_code.as_mut_slice());
         rng.fill_bytes(rid.as_mut_slice());
         rng.fill_bytes(u_i.as_mut_slice());
         Self {
             sid: *sid,
             sender: *sender,
+            chain_code,
             rid,
             u_i,
             pk: pk.clone(),

--- a/src/keygen/keygen_commit.rs
+++ b/src/keygen/keygen_commit.rs
@@ -36,7 +36,6 @@ pub(crate) struct KeygenDecommit {
     ///`sid` corresponds to a unique session identifier.
     pub sid: Identifier,
     pub sender: ParticipantIdentifier,
-    pub chain_code: [u8; 32],
     pub rid: [u8; 32],
     pub u_i: [u8; 32],
     pub pk: KeySharePublic,
@@ -52,16 +51,13 @@ impl KeygenDecommit {
         pk: &KeySharePublic,
         sch_precom: &PiSchPrecommit,
     ) -> Self {
-        let mut chain_code = [0u8; 32];
         let mut rid = [0u8; 32];
         let mut u_i = [0u8; 32];
-        rng.fill_bytes(chain_code.as_mut_slice());
         rng.fill_bytes(rid.as_mut_slice());
         rng.fill_bytes(u_i.as_mut_slice());
         Self {
             sid: *sid,
             sender: *sender,
-            chain_code,
             rid,
             u_i,
             pk: pk.clone(),

--- a/src/keygen/participant.rs
+++ b/src/keygen/participant.rs
@@ -47,10 +47,6 @@ mod storage {
     impl TypeTag for SchnorrPrecom {
         type Value = PiSchPrecommit;
     }
-    pub(super) struct ChainCode;
-    impl TypeTag for ChainCode {
-        type Value = [u8; 32];
-    }
     pub(super) struct GlobalRid;
     impl TypeTag for GlobalRid {
         type Value = [u8; 32];
@@ -480,24 +476,17 @@ impl KeygenParticipant {
 
         // Compute the global chain code and random identifier from individual
         // contributions
-        let mut global_chain_code = my_decom.chain_code;
         let mut global_rid = my_decom.rid;
         for &other_participant_id in self.other_participant_ids.iter() {
             let decom = self
                 .local_storage
                 .retrieve::<storage::Decommit>(other_participant_id)?;
-            global_chain_code = xor_256_bits!(global_chain_code, decom.chain_code);
             global_rid = xor_256_bits!(global_rid, decom.rid);
         }
 
-        // TODO: the global chain_code is determined by the HMAC function, remove from
-        // here
-        self.local_storage
-            .store::<storage::ChainCode>(self.id, global_chain_code);
         self.local_storage
             .store::<storage::GlobalRid>(self.id, global_rid);
-        let transcript =
-            schnorr_proof_transcript(self.sid(), &global_chain_code, &global_rid, self.id())?;
+        let transcript = schnorr_proof_transcript(self.sid(), &global_rid, self.id())?;
 
         let precom = self
             .local_storage
@@ -547,7 +536,6 @@ impl KeygenParticipant {
         }
         let proof = PiSchProof::from_message(message)?;
         let global_rid = *self.local_storage.retrieve::<storage::GlobalRid>(self.id)?;
-        let global_chain_code = *self.local_storage.retrieve::<storage::ChainCode>(self.id)?;
         let decom = self
             .local_storage
             .retrieve::<storage::Decommit>(message.from())?;
@@ -555,8 +543,7 @@ impl KeygenParticipant {
 
         let input = CommonInput::new(&decom.pk);
 
-        let mut transcript =
-            schnorr_proof_transcript(self.sid(), &global_chain_code, &global_rid, message.from())?;
+        let mut transcript = schnorr_proof_transcript(self.sid(), &global_rid, message.from())?;
         proof.verify_with_precommit(input, &self.retrieve_context(), &mut transcript, precommit)?;
 
         // Only if the proof verifies do we store the participant's public key
@@ -582,12 +569,7 @@ impl KeygenParticipant {
                 .remove::<storage::PrivateKeyshare>(self.id)?;
             self.status = Status::TerminatedSuccessfully;
 
-            let output = Output::from_parts(
-                public_key_shares,
-                private_key_share,
-                global_chain_code,
-                global_rid,
-            )?;
+            let output = Output::from_parts(public_key_shares, private_key_share, global_rid)?;
             Ok(ProcessOutcome::Terminated(output))
         } else {
             // Otherwise, we'll have to wait for more round three messages.
@@ -599,13 +581,11 @@ impl KeygenParticipant {
 /// Generate a [`Transcript`] for [`PiSchProof`].
 fn schnorr_proof_transcript(
     sid: Identifier,
-    global_chain_code: &[u8; 32],
     global_rid: &[u8; 32],
     sender_id: ParticipantIdentifier,
 ) -> Result<Transcript> {
     let mut transcript = Transcript::new(b"keygen schnorr");
     transcript.append_message(b"sid", &serialize!(&sid)?);
-    transcript.append_message(b"chain_code", &serialize!(global_chain_code)?);
     transcript.append_message(b"rid", &serialize!(global_rid)?);
     transcript.append_message(b"sender_id", &serialize!(&sender_id)?);
     Ok(transcript)

--- a/src/keyrefresh/participant.rs
+++ b/src/keyrefresh/participant.rs
@@ -796,14 +796,8 @@ impl KeyrefreshParticipant {
             let my_new_share = my_private_update.apply(self.input.private_key_share());
 
             // Return the output and stop.
-            let chain_code_before = *self.input.keygen_output().chain_code();
             let rid_before = *self.input.keygen_output().rid();
-            let output = Output::from_parts(
-                new_public_shares,
-                my_new_share,
-                chain_code_before,
-                rid_before,
-            )?;
+            let output = Output::from_parts(new_public_shares, my_new_share, rid_before)?;
 
             // Final validation that the public key of the quorum has not changed. This
             // should never fail because this is already verified in round 2 by

--- a/src/keyrefresh/participant.rs
+++ b/src/keyrefresh/participant.rs
@@ -797,7 +797,13 @@ impl KeyrefreshParticipant {
 
             // Return the output and stop.
             let rid_before = *self.input.keygen_output().rid();
-            let output = Output::from_parts(new_public_shares, my_new_share, rid_before)?;
+            let chain_code_before = *self.input.keygen_output().chain_code();
+            let output = Output::from_parts(
+                new_public_shares,
+                my_new_share,
+                rid_before,
+                chain_code_before,
+            )?;
 
             // Final validation that the public key of the quorum has not changed. This
             // should never fail because this is already verified in round 2 by

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -983,7 +983,7 @@ mod tests {
 
         // Tshare protocol
         // After the Tshare protocol, we will have a set of t-out-of-t shares
-        // Therefore we need to remove the some participants from the configs, and from
+        // Therefore we need to remove some participants from the configs, and from
         // keygen and auxinfo outputs
         let mut keygen_outputs_tshare = keygen_outputs.clone();
         let auxinfo_outputs_tshare = auxinfo_outputs.clone();
@@ -1064,13 +1064,11 @@ mod tests {
         let all_participants = configs.first().unwrap().all_participants();
 
         // t-out-of-t conversion
-        let chain_code = keygen_outputs[&configs[0].id()].chain_code();
         let rid = keygen_outputs[&configs[0].id()].rid();
         let (mut toft_keygen_outputs, _toft_public_keys) =
             TshareParticipant::convert_to_t_out_of_t_shares(
-                tshare_outputs,
+                tshare_outputs.clone(),
                 all_participants.clone(),
-                *chain_code,
                 *rid,
             )?;
 
@@ -1103,7 +1101,6 @@ mod tests {
             .get(&configs.first().unwrap().id())
             .unwrap()
             .public_key()?;
-        let keygen_outputs_clone = keygen_outputs.clone();
 
         // Set up presign participants
         let mut auxinfo_outputs_presign = HashMap::new();
@@ -1181,12 +1178,17 @@ mod tests {
         let sign_sid = Identifier::random(&mut rng);
 
         // Get first output
-        let first_output = keygen_outputs_clone
-            .values()
-            .next()
-            .expect("could not get the first output");
+        //let first_output = keygen_outputs_clone
+        //    .values()
+        //    .next()
+        //    .expect("could not get the first output");
 
-        let chain_code = first_output.chain_code();
+        //let chain_code = first_output.chain_code();
+        // read chain_code from first output from tshare protocol
+        let chain_code = tshare_outputs
+            .get(&configs.first().unwrap().id())
+            .unwrap()
+            .chain_code();
 
         let saved_public_key_bytes: Vec<u8> = saved_public_key.clone().to_sec1_bytes().to_vec();
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1269,56 +1269,6 @@ mod tests {
             }
         }
 
-        /*let presign_sid = Identifier::random(&mut rng);
-
-        // Prepare presign inputs: a pair of outputs from keygen and auxinfo.
-        let presign_inputs = configs
-            .iter()
-            .map(|config| {
-                (
-                    auxinfo_outputs_presign.remove(&config.id()).unwrap(),
-                    toft_keygen_outputs.remove(&config.id()).unwrap(),
-                )
-            })
-            .map(|(auxinfo_output, keygen_output)| {
-                presign::Input::new(auxinfo_output, keygen_output).unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        let mut presign_quorum = configs
-            .clone()
-            .into_iter()
-            .zip(presign_inputs)
-            .map(|(config, input)| {
-                Participant::<PresignParticipant>::from_config(config, presign_sid, input).unwrap()
-            })
-            .collect::<Vec<_>>();
-        let mut presign_outputs: HashMap<
-            ParticipantIdentifier,
-            <PresignParticipant as ProtocolParticipant>::Output,
-        > = HashMap::new();
-
-        for participant in &mut presign_quorum {
-            let inbox = inboxes.get_mut(&participant.id).unwrap();
-            inbox.push(participant.initialize_message()?);
-        }
-
-        while presign_outputs.len() < QUORUM_REAL {
-            let output = process_random_message(&mut presign_quorum, &mut inboxes, &mut rng)?;
-
-            if let Some((pid, output)) = output {
-                // Save the output, and make sure this participant didn't already return an
-                // output.
-                assert!(presign_outputs.insert(pid, output).is_none());
-            }
-        }
-
-        // Presigning is done! Make sure there are no more messages.
-        assert!(inboxes_are_empty(&inboxes));
-        // And make sure all participants have successfully terminated.
-        assert!(presign_quorum
-            .iter()
-            .all(|p| *p.status() == Status::TerminatedSuccessfully));*/
         let mut presign_outputs = presign_helper(
             configs.clone(),
             auxinfo_outputs_presign,
@@ -1326,10 +1276,6 @@ mod tests {
             &mut inboxes,
             rng.clone(),
         )?;
-
-        //let presign_outputs =
-        //    presign_helper(auxinfo_outputs_presign, toft_keygen_outputs,
-        // rng.clone())?;
 
         // Set the message and SID
         let message = b"Testing full protocol execution with non-interactive signing protocol";

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1023,12 +1023,17 @@ mod tests {
             .get(&configs.first().unwrap().id())
             .unwrap()
             .rid();
+        let chain_code = tshare_outputs
+            .get(&configs.first().unwrap().id())
+            .unwrap()
+            .chain_code();
 
         let (mut toft_keygen_outputs, _toft_public_keys) =
             TshareParticipant::convert_to_t_out_of_t_shares(
                 tshare_outputs.clone(),
                 all_participants.clone(),
                 *rid,
+                *chain_code,
             )?;
 
         if QUORUM_REAL >= QUORUM_THRESHOLD {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1136,13 +1136,6 @@ mod tests {
         let digest = Keccak256::new_with_prefix(message);
         let sign_sid = Identifier::random(&mut rng);
 
-        // Get first output
-        //let first_output = keygen_outputs_clone
-        //    .values()
-        //    .next()
-        //    .expect("could not get the first output");
-
-        //let chain_code = first_output.chain_code();
         // read chain_code from first output from tshare protocol
         let chain_code = tshare_outputs
             .get(&configs.first().unwrap().id())

--- a/src/tshare/commit.rs
+++ b/src/tshare/commit.rs
@@ -37,6 +37,7 @@ pub(crate) struct TshareDecommit {
     sid: Identifier,
     sender: ParticipantIdentifier,
     u_i: [u8; 32], // The blinding factor is never read but it is included in the commitment.
+    pub chain_code: [u8; 32],
     pub rid: [u8; 32],
     pub coeff_publics: Vec<CoeffPublic>,
     pub precom: CurvePoint,
@@ -51,13 +52,16 @@ impl TshareDecommit {
         coeff_publics: &[CoeffPublic],
         sch_precom: CurvePoint,
     ) -> Self {
+        let mut chain_code = [0u8; 32];
         let mut rid = [0u8; 32];
         let mut u_i = [0u8; 32];
+        rng.fill_bytes(chain_code.as_mut_slice());
         rng.fill_bytes(rid.as_mut_slice());
         rng.fill_bytes(u_i.as_mut_slice());
         Self {
             sid: *sid,
             sender: *sender,
+            chain_code,
             rid,
             u_i,
             coeff_publics: coeff_publics.to_vec(),

--- a/src/tshare/output.rs
+++ b/src/tshare/output.rs
@@ -32,6 +32,8 @@ pub struct Output {
     private_key_share: Scalar,
     // The chain code for the HD wallet
     chain_code: [u8; 32],
+    // The chain code for the HD wallet
+    rid: [u8; 32],
 }
 
 impl Output {
@@ -69,6 +71,11 @@ impl Output {
         &self.chain_code
     }
 
+    /// Get the rid.
+    pub fn rid(&self) -> &[u8; 32] {
+        &self.rid
+    }
+
     /// Create a new `Output` from its constitutent parts.
     ///
     /// This method should only be used with components that were previously
@@ -83,6 +90,7 @@ impl Output {
         public_keys: Vec<KeySharePublic>,
         private_key_share: Scalar,
         chain_code: [u8; 32],
+        rid: [u8; 32],
     ) -> Result<Self> {
         let pids = public_keys
             .iter()
@@ -102,6 +110,7 @@ impl Output {
             public_key_shares: public_keys,
             private_key_share,
             chain_code,
+            rid,
         })
     }
 
@@ -114,12 +123,21 @@ impl Output {
     ///
     /// The public components (including the byte array and the public key
     /// shares) can be stored in the clear.
-    pub fn into_parts(self) -> (Vec<CoeffPublic>, Vec<KeySharePublic>, Scalar, [u8; 32]) {
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<CoeffPublic>,
+        Vec<KeySharePublic>,
+        Scalar,
+        [u8; 32],
+        [u8; 32],
+    ) {
         (
             self.public_coeffs,
             self.public_key_shares,
             self.private_key_share,
             self.chain_code,
+            self.rid,
         )
     }
 }
@@ -158,6 +176,7 @@ mod tests {
 
             let rng = &mut init_testing();
             let chain_code = rng.gen();
+            let rid = rng.gen();
 
             // simulate a random evaluation
             let converted_publics = public_key_shares
@@ -180,6 +199,7 @@ mod tests {
                 public_key_shares,
                 eval_private_at_first_pid.x,
                 chain_code,
+                rid,
             )
             .unwrap();
 
@@ -197,8 +217,10 @@ mod tests {
             .collect::<Vec<_>>();
         let output = Output::simulate(&pids);
 
-        let (public_coeffs, public_keys, private_key, chain_code) = output.into_parts();
-        assert!(Output::from_parts(public_coeffs, public_keys, private_key, chain_code).is_ok());
+        let (public_coeffs, public_keys, private_key, chain_code, rid) = output.into_parts();
+        assert!(
+            Output::from_parts(public_coeffs, public_keys, private_key, chain_code, rid).is_ok()
+        );
     }
 
     #[test]
@@ -228,12 +250,14 @@ mod tests {
 
         let rng = &mut init_testing();
         let chain_code = rng.gen();
+        let rid = rng.gen();
 
         assert!(Output::from_parts(
             public_coeffs,
             public_key_shares,
             private_key_shares.pop().unwrap(),
             chain_code,
+            rid,
         )
         .is_err());
     }

--- a/src/tshare/participant.rs
+++ b/src/tshare/participant.rs
@@ -295,6 +295,8 @@ impl TshareParticipant {
             if let Some(private) = self.input.share() {
                 privates[0] = private.clone();
                 publics[0] = private.to_public();
+            } else {
+                dbg!("ENTROU NO ELSE MESMO");
             }
 
             (privates, publics)
@@ -605,29 +607,6 @@ impl TshareParticipant {
     #[instrument(skip_all, err(Debug))]
     fn gen_round_three_msgs(&mut self) -> Result<Vec<Message>> {
         info!("Generating round three tshare messages.");
-
-        // Construct `global rid` out of each participant's `rid`s.
-        /*let my_rid = self
-            .local_storage
-            .retrieve::<storage::Decommit>(self.id())?
-            .rid;
-        let rids: Vec<[u8; 32]> = self
-            .other_ids()
-            .iter()
-            .map(|&other_participant_id| {
-                let decom = self
-                    .local_storage
-                    .retrieve::<storage::Decommit>(other_participant_id)?;
-                Ok(decom.rid)
-            })
-            .collect::<Result<Vec<[u8; 32]>>>()?;
-        let mut global_rid = my_rid;
-        // xor all the rids together.
-        for rid in rids.iter() {
-            for i in 0..32 {
-                global_rid[i] ^= rid[i];
-            }
-        }*/
 
         // Auxiliary macro to xor two 256-bit arrays given as Vectors of 32 bytes
         macro_rules! xor_256_bits {
@@ -949,12 +928,14 @@ impl TshareParticipant {
             let global_chain_code = *self
                 .local_storage
                 .retrieve::<storage::GlobalChainCode>(self.id)?;
+            let global_rid = *self.local_storage.retrieve::<storage::GlobalRid>(self.id)?;
 
             let output = Output::from_parts(
                 all_public_coeffs.clone(),
                 all_public_keys,
                 my_private_share.x,
                 global_chain_code,
+                global_rid,
             )?;
 
             self.status = Status::TerminatedSuccessfully;

--- a/src/tshare/participant.rs
+++ b/src/tshare/participant.rs
@@ -757,6 +757,7 @@ impl TshareParticipant {
         tshares: HashMap<ParticipantIdentifier, Output>,
         all_participants: Vec<ParticipantIdentifier>,
         rid: [u8; 32],
+        chain_code: [u8; 32],
     ) -> Result<(
         HashMap<ParticipantIdentifier, <KeygenParticipant as ProtocolParticipant>::Output>,
         Vec<KeySharePublic>,
@@ -788,8 +789,12 @@ impl TshareParticipant {
             <KeygenParticipant as ProtocolParticipant>::Output,
         > = HashMap::new();
         for (pid, private_key_share) in new_private_shares {
-            let output =
-                crate::keygen::Output::from_parts(public_keys.clone(), private_key_share, rid)?;
+            let output = crate::keygen::Output::from_parts(
+                public_keys.clone(),
+                private_key_share,
+                rid,
+                chain_code,
+            )?;
             assert!(keygen_outputs.insert(pid, output).is_none());
         }
         Ok((keygen_outputs, public_keys))

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -138,6 +138,7 @@ impl Proof for PiSchProof {
         // Verifier samples e in F_q
         let challenge = positive_challenge_from_transcript(transcript, &k256_order())?;
         if challenge != self.challenge {
+            dbg!("xoiiiiiinicht");
             error!("Fiat-Shamir consistency check failed");
             return Err(InternalError::ProtocolError(None));
         }
@@ -150,6 +151,7 @@ impl Proof for PiSchProof {
             lhs == rhs
         };
         if !response_matches_commitment {
+            dbg!("xoiiiiii");
             error!("verification equation checked failed");
             return Err(InternalError::ProtocolError(None));
         }

--- a/src/zkp/pisch.rs
+++ b/src/zkp/pisch.rs
@@ -138,7 +138,6 @@ impl Proof for PiSchProof {
         // Verifier samples e in F_q
         let challenge = positive_challenge_from_transcript(transcript, &k256_order())?;
         if challenge != self.challenge {
-            dbg!("xoiiiiiinicht");
             error!("Fiat-Shamir consistency check failed");
             return Err(InternalError::ProtocolError(None));
         }


### PR DESCRIPTION
This PR adds a chain code field to the Tshare subprotocol. This way we can use the library in 4 different manners:
* Basic keygen
* Threshold keygen
* Basic HD wallet
* Threshold HD wallet

A unit test is added for each case. 
