### PR TITLE
Fix Accidental Logging in Unit Tests

### DIFF
--- a/src/tshare/participant.rs
+++ b/src/tshare/participant.rs
@@ -1023,7 +1023,7 @@ fn schnorr_proof_transcript(
 #[cfg(test)]
 mod tests {
     use super::{super::input::Input, *};
-    use crate::{auxinfo, utils::testing::init_testing_with_seed, Identifier, ParticipantConfig};
+    use crate::{auxinfo, utils::testing::init_testing, Identifier, ParticipantConfig};
     use k256::elliptic_curve::{Field, PrimeField};
     use rand::{thread_rng, CryptoRng, Rng, RngCore};
     use std::{collections::HashMap, iter::zip};
@@ -1119,7 +1119,7 @@ mod tests {
     }
 
     fn tshare_produces_valid_outputs(quorum_size: usize) -> Result<()> {
-        let mut rng = init_testing_with_seed(Default::default());
+        let mut rng = init_testing();
         let sid = Identifier::random(&mut rng);
         let test_share = Some(CoeffPrivate {
             x: Scalar::from_u128(42),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -452,8 +452,29 @@ pub(crate) mod testing {
         StdRng::from_seed(seed)
     }
 
-    /// A seeded version of init_testing. Additionally, turns on logging by
-    /// default.
+    /// A seeded version of [`init_testing`]. This function can be used when a
+    /// test fails unexpectedly, and you want to reproduce the run using a
+    /// specific RNG seed.
+    ///
+    /// **Additionally, turns on logging by default.**
+    ///
+    /// This function should only be called when debugging. Avoid calling as
+    /// part of a normal unit test execution. Otherwise, it will turn on
+    /// logging for all tests. This will be confusing as some tests
+    /// purposely give bad input to functions, which triggers an error and a
+    /// logging event. This is then confusing to developers as they will see:
+    /// ```
+    /// test paillier::test::paillier_encryption_works ... ok
+    ///   2024-11-15T23:16:21.753194Z ERROR tss_ecdsa::tshare::share: EvalEncrypted decryption failed, plaintext out of range (x=0)
+    ///     at src/tshare/share.rs:52
+    ///
+    ///   2024-11-15T23:16:21.822124Z ERROR tss_ecdsa::tshare::share: EvalEncrypted decryption failed, plaintext out of range (x=0)
+    ///     at src/tshare/share.rs:52
+    ///
+    /// test tshare::share::tests::coeff_decrypt_unexpected ... ok
+    /// ```
+    /// Which looks like something went wrong with the test but the test also
+    /// reported `ok`.
     #[allow(unused)]
     pub(crate) fn init_testing_with_seed(seed: [u8; 32]) -> StdRng {
         let logging_level = EnvFilter::from_default_env()


### PR DESCRIPTION
This led to confusing output when running unit tests!