### PR TITLE
tshare-example: Use threshold signature in the example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,22 @@ From the root directory, you can run: `cargo run --example threaded_example -- -
 ```
 Multi-party ECDSA signing
 
-Usage: threaded_example --number-of-workers <NUMBER_OF_WORKERS> --protocol-executions <PROTOCOL_EXECUTIONS>
+Usage: threaded_example --number-of-workers <NUMBER_OF_WORKERS>
 
 Options:
 -n, --number-of-workers <NUMBER_OF_WORKERS>
-Number of participant worker threads to use
--p, --protocol-executions <PROTOCOL_EXECUTIONS>
-Number of times to perform each sub-protocol of tss-ecdsa. protocol_executions > 1 useful for computing meaningful average execution times
+Number of participant worker threads to use. Default: 3.
 -h, --help
 Print help
 -V, --version
 Print version
 ```
-For example, `cargo run --example threaded_example -- --number-of-workers 3 --protocol-executions 1` will execute this example using three workers (participants).
+For example, `cargo run --example threaded_example -- --number-of-workers 3` will execute this example using three workers (participants).
 **Note** please pay attention to the `--` in the middle of the command. This is necessary to separate arguments to the `cargo run` command from arguments to this
 CLI example.
 
 This CLI example supports logging via the tracing crate. You can set the env var `RUST_LOG` to a verbosity level to execute with logging turned on:
 For example:
 ```shell
-RUST_LOG=info cargo run --example threaded_example -- --number-of-workers 2 --protocol-executions 1
+RUST_LOG=info cargo run --example threaded_example -- --number-of-workers 2
 ```

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -36,15 +36,18 @@ use std::{
 use tracing::{debug, info, instrument, span, trace, Level};
 use tracing_subscriber::{self, EnvFilter};
 use tss_ecdsa::{
-    auxinfo::AuxInfoParticipant,
-    keygen::{KeygenParticipant, Output},
+    auxinfo::{self, AuxInfoParticipant},
+    keygen::{self, KeygenParticipant, Output},
     messages::Message,
     presign::{self, PresignParticipant},
     sign::{self, SignParticipant},
+    tshare::{self, TshareParticipant},
     Identifier, Participant, ParticipantConfig, ParticipantIdentifier, ProtocolParticipant,
 };
 use utils::{MessageFromWorker, SubProtocol};
 use uuid::Uuid;
+
+const THRESHOLD: usize = 2;
 
 /// A shared session ID must be agreed up on by workers. We use a central
 /// coordinator to assign this session ID to workers.
@@ -59,12 +62,12 @@ struct KeyId(Uuid);
 #[command(author, version, about, long_about = None)]
 struct Cli {
     /// Number of participant worker threads to use.
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = 3)]
     number_of_workers: usize,
     /// Number of times to perform each sub-protocol of tss-ecdsa.
     /// protocol_executions > 1 useful for computing meaningful average
     /// execution times.
-    #[arg(short, long)]
+    #[arg(short, long, default_value_t = 1)]
     protocol_executions: usize,
 }
 
@@ -84,7 +87,7 @@ impl<P: ProtocolParticipant> StoredOutput<P> {
         self.stored_output.insert(id, store);
     }
 
-    fn retrieve(&mut self, id: &KeyId) -> &P::Output {
+    fn retrieve(&self, id: &KeyId) -> &P::Output {
         self.stored_output.get(id).unwrap()
     }
 
@@ -163,6 +166,10 @@ fn main() -> anyhow::Result<()> {
     let _enter = span.entered();
 
     let num_workers = cli.number_of_workers;
+    assert!(
+        num_workers >= THRESHOLD,
+        "Number of workers must be >= threshold {THRESHOLD}."
+    );
 
     // Channel from workers to main thread (workers use MPSC).
     let (outgoing_tx, workers_rx) = channel::<MessageFromWorker>();
@@ -224,6 +231,7 @@ impl Coordinator {
         let key_id = KeyId(Uuid::new_v4());
         self.initiate_sub_protocol(SubProtocol::KeyGeneration, key_id)?;
         self.initiate_sub_protocol(SubProtocol::AuxInfo, key_id)?;
+        self.initiate_sub_protocol(SubProtocol::Tshare, key_id)?;
         self.initiate_sub_protocol(SubProtocol::Presign, key_id)?;
         self.initiate_sub_protocol(SubProtocol::Sign, key_id)?;
 
@@ -323,6 +331,8 @@ struct Worker {
     key_gen_material: StoredOutput<KeygenParticipant>,
     /// Outputs of successful aux info.
     aux_info: StoredOutput<AuxInfoParticipant>,
+    /// Outputs of successful tshare.
+    tshares: StoredOutput<TshareParticipant>,
     /// Outputs of successful presign.
     presign_records: StoredOutput<PresignParticipant>,
     /// Signatures generated from successful signing runs.
@@ -339,6 +349,7 @@ impl Worker {
             participants: ParticipantStorage::new(),
             key_gen_material: StoredOutput::new(),
             aux_info: StoredOutput::new(),
+            tshares: StoredOutput::new(),
             presign_records: StoredOutput::new(),
             signatures: StoredOutput::new(),
             outgoing,
@@ -350,14 +361,14 @@ impl Worker {
     #[instrument(skip_all)]
     fn new_sub_protocol<P: ProtocolParticipant + 'static>(
         &mut self,
+        config: ParticipantConfig,
         sid: SessionId,
         inputs: P::Input,
         key_id: KeyId,
     ) -> anyhow::Result<()> {
         let rng = &mut thread_rng();
 
-        let mut participant: Participant<P> =
-            Participant::from_config(self.config.clone(), sid.0, inputs)?;
+        let mut participant: Participant<P> = Participant::from_config(config, sid.0, inputs)?;
         let init_message = participant.initialize_message()?;
 
         // Output will be None.
@@ -405,31 +416,75 @@ impl Worker {
 /// These functions fetch the required inputs from storage.
 impl Worker {
     fn new_keygen(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
-        self.new_sub_protocol::<KeygenParticipant>(sid, (), key_id)
+        self.new_sub_protocol::<KeygenParticipant>(self.config.clone(), sid, (), key_id)
     }
 
     fn new_auxinfo(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
         // Note: Missing inputs to aux-info see issues
         // #242 and #243.
         let _output: &Output = self.key_gen_material.retrieve(&key_id);
-        self.new_sub_protocol::<AuxInfoParticipant>(sid, (), key_id)
+        self.new_sub_protocol::<AuxInfoParticipant>(self.config.clone(), sid, (), key_id)
+    }
+
+    fn new_tshare(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
+        let private_share = self
+            .key_gen_material
+            .retrieve(&key_id)
+            .private_key_share()
+            .try_into()?;
+        let auxinfo_output = self.aux_info.retrieve(&key_id);
+
+        let inputs = tshare::Input::new(auxinfo_output.clone(), Some(private_share), THRESHOLD)?;
+        self.new_sub_protocol::<TshareParticipant>(self.config.clone(), sid, inputs, key_id)
+    }
+
+    /// Pick a quorum of participants. Return the corresponding additive shares.
+    fn make_quorum(&self, key_id: KeyId) -> anyhow::Result<(keygen::Output, auxinfo::Output)> {
+        let participants = {
+            let mut pids = self.config.other_ids()[..THRESHOLD - 1].to_vec();
+            pids.push(self.config.id());
+            pids
+        };
+
+        let keygen_output = self.key_gen_material.retrieve(&key_id);
+        let tshare_output = self.tshares.retrieve(&key_id);
+
+        let keygen_quorum = TshareParticipant::convert_to_t_out_of_t_share(
+            self.config.id(),
+            tshare_output,
+            &participants,
+            *keygen_output.rid(),
+            *keygen_output.chain_code(),
+        )?;
+
+        let auxinfo_quorum = self
+            .aux_info
+            .retrieve(&key_id)
+            .filter_participants(&participants);
+
+        Ok((keygen_quorum, auxinfo_quorum))
     }
 
     fn new_presign(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
-        let key_shares = self.key_gen_material.retrieve(&key_id);
-        let auxinfo_output = self.aux_info.retrieve(&key_id);
+        let (keygen_quorum, auxinfo_quorum) = self.make_quorum(key_id)?;
 
-        let inputs = presign::Input::new(auxinfo_output.clone(), key_shares.clone())?;
-        self.new_sub_protocol::<PresignParticipant>(sid, inputs, key_id)
+        let config = self
+            .config
+            .filter_participants(&keygen_quorum.participants());
+        let inputs = presign::Input::new(auxinfo_quorum, keygen_quorum)?;
+        self.new_sub_protocol::<PresignParticipant>(config, sid, inputs, key_id)
     }
 
     fn new_sign(&mut self, sid: SessionId, key_id: KeyId) -> anyhow::Result<()> {
-        let key_shares = self.key_gen_material.retrieve(&key_id).public_key_shares();
+        let (keygen_quorum, _) = self.make_quorum(key_id)?;
+        let key_shares = keygen_quorum.public_key_shares();
         let record = self.presign_records.take(&key_id);
 
-        let threshold = key_shares.len();
-        let inputs = sign::Input::new(b"hello world", record, key_shares.to_vec(), threshold, None);
-        self.new_sub_protocol::<SignParticipant>(sid, inputs, key_id)
+        let config = self
+            .config
+            .filter_participants(&keygen_quorum.participants());
+        let inputs = sign::Input::new(b"hello world", record, key_shares.to_vec(), THRESHOLD, None);
+        self.new_sub_protocol::<SignParticipant>(config, sid, inputs, key_id)
     }
 }
 
@@ -449,6 +504,11 @@ impl Worker {
     fn process_auxinfo(&mut self, sid: SessionId, incoming: Message) -> anyhow::Result<()> {
         let (p, key_id) = self.participants.get_mut::<AuxInfoParticipant>(&sid);
         Self::process_message(p, key_id, incoming, &mut self.aux_info, &self.outgoing)
+    }
+
+    fn process_tshare(&mut self, sid: SessionId, incoming: Message) -> anyhow::Result<()> {
+        let (p, key_id) = self.participants.get_mut::<TshareParticipant>(&sid);
+        Self::process_message(p, key_id, incoming, &mut self.tshares, &self.outgoing)
     }
 
     fn process_presign(&mut self, sid: SessionId, incoming: Message) -> anyhow::Result<()> {
@@ -494,6 +554,9 @@ fn participant_worker(
                     SubProtocol::AuxInfo => {
                         worker.process_auxinfo(sid, message)?;
                     }
+                    SubProtocol::Tshare => {
+                        worker.process_tshare(sid, message)?;
+                    }
                     SubProtocol::Presign => worker.process_presign(sid, message)?,
                     SubProtocol::Sign => worker.process_sign(sid, message)?,
                 }
@@ -508,6 +571,9 @@ fn participant_worker(
                     }
                     SubProtocol::AuxInfo => {
                         worker.new_auxinfo(sid, key_id)?;
+                    }
+                    SubProtocol::Tshare => {
+                        worker.new_tshare(sid, key_id)?;
                     }
                     SubProtocol::Presign => {
                         worker.new_presign(sid, key_id)?;

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -65,11 +65,6 @@ struct Cli {
     /// Number of participant worker threads to use.
     #[arg(short, long, default_value_t = 3)]
     number_of_workers: usize,
-    /// Number of times to perform each sub-protocol of tss-ecdsa.
-    /// protocol_executions > 1 useful for computing meaningful average
-    /// execution times.
-    #[arg(short, long, default_value_t = 1)]
-    protocol_executions: usize,
 }
 
 /// Generic Storage for outputs of specific sub-protocols. Indexed by a `KeyId`

--- a/examples/threaded_example/utils.rs
+++ b/examples/threaded_example/utils.rs
@@ -6,6 +6,7 @@ use tss_ecdsa::messages::Message;
 pub enum SubProtocol {
     KeyGeneration,
     AuxInfo,
+    Tshare,
     Presign,
     Sign,
 }

--- a/src/auxinfo/output.rs
+++ b/src/auxinfo/output.rs
@@ -97,6 +97,21 @@ impl Output {
     pub(crate) fn private_auxinfo(&self) -> &AuxInfoPrivate {
         &self.private_auxinfo
     }
+
+    /// Filter the output to only include the auxinfo for the given participants.
+    pub fn filter_participants(&self, pids: &[ParticipantIdentifier]) -> Self {
+        let public_auxinfo = self
+            .public_auxinfo
+            .iter()
+            .filter(|auxinfo| pids.contains(&auxinfo.participant()))
+            .cloned()
+            .collect();
+
+        Self {
+            public_auxinfo,
+            private_auxinfo: self.private_auxinfo.clone(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/auxinfo/output.rs
+++ b/src/auxinfo/output.rs
@@ -98,7 +98,8 @@ impl Output {
         &self.private_auxinfo
     }
 
-    /// Filter the output to only include the auxinfo for the given participants.
+    /// Filter the output to only include the auxinfo for the given
+    /// participants.
     pub fn filter_participants(&self, pids: &[ParticipantIdentifier]) -> Self {
         let public_auxinfo = self
             .public_auxinfo

--- a/src/keygen/output.rs
+++ b/src/keygen/output.rs
@@ -47,7 +47,8 @@ impl Output {
         &self.public_key_shares
     }
 
-    pub(crate) fn private_key_share(&self) -> &KeySharePrivate {
+    /// Get the private key share.
+    pub fn private_key_share(&self) -> &KeySharePrivate {
         &self.private_key_share
     }
 
@@ -69,13 +70,21 @@ impl Output {
     }
 
     /// Get the shared randomness generated during key generation.
-    pub(crate) fn rid(&self) -> &[u8; 32] {
+    pub fn rid(&self) -> &[u8; 32] {
         &self.rid
     }
 
     /// Get the chain code generated during key generation.
-    pub(crate) fn chain_code(&self) -> &[u8; 32] {
+    pub fn chain_code(&self) -> &[u8; 32] {
         &self.chain_code
+    }
+
+    /// Get the set of participants involved in this key.
+    pub fn participants(&self) -> Vec<ParticipantIdentifier> {
+        self.public_key_shares
+            .iter()
+            .map(KeySharePublic::participant)
+            .collect()
     }
 
     /// Create a new `Output` from its constitutent parts.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -291,6 +291,17 @@ pub(crate) mod participant_config {
             })
         }
 
+        /// Returns a new [`ParticipantConfig`] including only the given participants.
+        pub fn filter_participants(&self, pids: &[ParticipantIdentifier]) -> Self {
+            let other_ids = self
+                .other_ids()
+                .iter()
+                .filter(|pid| pids.contains(pid))
+                .cloned()
+                .collect();
+            Self { id: self.id, other_ids }
+        }
+
         /// Get a list of `size` consistent [`ParticipantConfig`]s.
         ///
         /// Each config contains a different permutation of a single overall set

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -660,7 +660,7 @@ mod tests {
         presign,
         sign::{self, InteractiveSignParticipant, SignParticipant},
         slip0010,
-        tshare::{self, CoeffPrivate, TshareParticipant},
+        tshare::{self, tests::convert_to_t_out_of_t_shares, CoeffPrivate, TshareParticipant},
         utils::testing::init_testing,
         PresignParticipant,
     };
@@ -1464,7 +1464,7 @@ mod tests {
             .fold(Scalar::ZERO, |acc, x| acc + x);
 
         // t-out-of-t conversion
-        let toft_outputs = TshareParticipant::convert_to_t_out_of_t_shares(
+        let toft_keygen_outputs = convert_to_t_out_of_t_shares(
             tshare_outputs.clone(),
             all_participants.clone(),
             *rid,
@@ -1472,7 +1472,6 @@ mod tests {
             sum_tshare_input,
             t,
         )?;
-        let toft_keygen_outputs = toft_outputs.keygen_outputs;
 
         let first_keygen_output = toft_keygen_outputs
             .get(&configs.first().unwrap().id())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -291,7 +291,8 @@ pub(crate) mod participant_config {
             })
         }
 
-        /// Returns a new [`ParticipantConfig`] including only the given participants.
+        /// Returns a new [`ParticipantConfig`] including only the given
+        /// participants.
         pub fn filter_participants(&self, pids: &[ParticipantIdentifier]) -> Self {
             let other_ids = self
                 .other_ids()
@@ -299,7 +300,10 @@ pub(crate) mod participant_config {
                 .filter(|pid| pids.contains(pid))
                 .cloned()
                 .collect();
-            Self { id: self.id, other_ids }
+            Self {
+                id: self.id,
+                other_ids,
+            }
         }
 
         /// Get a list of `size` consistent [`ParticipantConfig`]s.

--- a/src/tshare/mod.rs
+++ b/src/tshare/mod.rs
@@ -54,3 +54,6 @@ pub use input::Input;
 pub use output::Output;
 pub use participant::TshareParticipant;
 pub use share::{CoeffPrivate, CoeffPublic};
+
+#[cfg(test)]
+pub(crate) use participant::tests;

--- a/src/tshare/participant.rs
+++ b/src/tshare/participant.rs
@@ -26,13 +26,12 @@ use crate::{
     protocol::{ParticipantIdentifier, ProtocolType, SharedContext},
     run_only_once,
     tshare::share::EvalPublic,
-    utils::{bn_to_scalar, k256_order, scalar_to_bn, CurvePoint},
+    utils::{bn_to_scalar, scalar_to_bn, CurvePoint},
     zkp::pisch::{CommonInput, PiSchPrecommit, PiSchProof, ProverSecret},
     Identifier, ParticipantConfig,
 };
 
 use k256::{elliptic_curve::PrimeField, Scalar};
-use libpaillier::unknown_order::BigNumber;
 use merlin::Transcript;
 use rand::{CryptoRng, RngCore};
 use tracing::{error, info, instrument, warn};
@@ -117,16 +116,6 @@ pub struct TshareParticipant {
     broadcast_participant: BroadcastParticipant,
     /// Status of the protocol execution.
     status: Status,
-}
-
-#[derive(Debug)]
-pub struct ToutofTHelper {
-    pub keygen_outputs:
-        HashMap<ParticipantIdentifier, <KeygenParticipant as ProtocolParticipant>::Output>,
-    pub public_keys: Vec<KeySharePublic>,
-    pub all_participants: Vec<ParticipantIdentifier>,
-    pub rid: [u8; 32],
-    pub chain_code: [u8; 32],
 }
 
 impl ProtocolParticipant for TshareParticipant {
@@ -791,92 +780,7 @@ impl TshareParticipant {
             KeySharePrivate::from_bigint(&scalar_to_bn(&private_t_of_t))
         };
 
-        Ok(crate::keygen::Output::from_parts(
-            public_key_shares,
-            private_key_share,
-            rid,
-            chain_code,
-        )?)
-    }
-
-    /// Convert the tshares to t-out-of-t shares.
-    /// This is done by multiplying the shares by the Lagrange coefficients.
-    /// Since the constant term is the secret, we need to multiply by the
-    /// Lagrange coefficient at zero. This is done by the function
-    /// `lagrange_coefficient_at_zero`.
-    /// Also convert the public tshares in the same way as the private shares.
-    /// Finally a vector of all public keys is returned. This needs to be run
-    /// before presign when using a threshold generated key.
-    #[allow(clippy::type_complexity)]
-    pub fn convert_to_t_out_of_t_shares(
-        tshares: HashMap<ParticipantIdentifier, Output>,
-        all_participants: Vec<ParticipantIdentifier>,
-        rid: [u8; 32],
-        chain_code: [u8; 32],
-        sum_tshare_input: Scalar,
-        threshold: usize,
-    ) -> Result<ToutofTHelper> {
-        let real = all_participants.len();
-        let mut new_private_shares = HashMap::new();
-        let mut public_keys = vec![];
-
-        // Compute the new private shares and public keys.
-        for pid in tshares.keys() {
-            if all_participants.contains(pid) {
-                let output = tshares.get(pid).unwrap();
-                let private_key = output.private_key_share();
-                let private_share = KeySharePrivate::from_bigint(&scalar_to_bn(private_key));
-                let public_share = CurvePoint::GENERATOR.multiply_by_scalar(private_key);
-                let lagrange = Self::lagrange_coefficient_at_zero(pid, &all_participants);
-                let new_private_share: BigNumber =
-                    private_share.clone().as_ref() * BigNumber::from_slice(lagrange.to_bytes());
-                let new_public_share = public_share.as_ref().multiply_by_scalar(&lagrange);
-                assert!(new_private_shares
-                    .insert(*pid, KeySharePrivate::from_bigint(&new_private_share))
-                    .is_none());
-                public_keys.push(KeySharePublic::new(*pid, new_public_share));
-            }
-        }
-
-        // Compute the new outputs
-        let mut keygen_outputs: HashMap<
-            ParticipantIdentifier,
-            <KeygenParticipant as ProtocolParticipant>::Output,
-        > = HashMap::new();
-        for (pid, private_key_share) in new_private_shares {
-            let output = crate::keygen::Output::from_parts(
-                public_keys.clone(),
-                private_key_share,
-                rid,
-                chain_code,
-            )?;
-            assert!(keygen_outputs.insert(pid, output).is_none());
-        }
-
-        let mut sum_toft_private_shares = keygen_outputs
-            .values()
-            .map(|output| output.private_key_share().as_ref().clone())
-            .fold(BigNumber::zero(), |acc, x| acc + x);
-        sum_toft_private_shares %= k256_order();
-
-        // Check the sum is indeed the sum of original private keys used as input of
-        // tshare reduced mod the order
-        dbg!(real);
-        dbg!(threshold);
-        if real >= threshold {
-            assert_eq!(
-                bn_to_scalar(&sum_toft_private_shares).unwrap(),
-                sum_tshare_input
-            );
-        }
-
-        Ok(ToutofTHelper {
-            keygen_outputs,
-            public_keys,
-            all_participants,
-            rid,
-            chain_code,
-        })
+        crate::keygen::Output::from_parts(public_key_shares, private_key_share, rid, chain_code)
     }
 
     /// Reconstruct the secret from the shares.
@@ -1066,13 +970,110 @@ fn schnorr_proof_transcript(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::{super::input::Input, *};
-    use crate::{auxinfo, utils::testing::init_testing, Identifier, ParticipantConfig};
+    use crate::{
+        auxinfo,
+        utils::{k256_order, testing::init_testing},
+        Identifier, ParticipantConfig,
+    };
+    use itertools::Itertools;
     use k256::elliptic_curve::{Field, PrimeField};
+    use libpaillier::unknown_order::BigNumber;
     use rand::{thread_rng, CryptoRng, Rng, RngCore};
     use std::{collections::HashMap, iter::zip};
     use tracing::debug;
+
+    /// Test utility to convert the tshares to t-out-of-t shares of all
+    /// participants.
+    #[cfg(test)]
+    #[allow(clippy::type_complexity)]
+    pub fn convert_to_t_out_of_t_shares(
+        tshares: HashMap<ParticipantIdentifier, Output>,
+        all_participants: Vec<ParticipantIdentifier>,
+        rid: [u8; 32],
+        chain_code: [u8; 32],
+        sum_tshare_input: Scalar,
+        threshold: usize,
+    ) -> Result<HashMap<ParticipantIdentifier, <KeygenParticipant as ProtocolParticipant>::Output>>
+    {
+        let real = all_participants.len();
+        let mut new_private_shares = HashMap::new();
+        let mut public_keys = vec![];
+
+        // Compute the new private shares and public keys.
+        for pid in tshares.keys() {
+            if all_participants.contains(pid) {
+                let output = tshares.get(pid).unwrap();
+                let private_key = output.private_key_share();
+                let private_share = KeySharePrivate::from_bigint(&scalar_to_bn(private_key));
+                let public_share = CurvePoint::GENERATOR.multiply_by_scalar(private_key);
+                let lagrange =
+                    TshareParticipant::lagrange_coefficient_at_zero(pid, &all_participants);
+                let new_private_share: BigNumber =
+                    private_share.clone().as_ref() * BigNumber::from_slice(lagrange.to_bytes());
+                let new_public_share = public_share.as_ref().multiply_by_scalar(&lagrange);
+                assert!(new_private_shares
+                    .insert(*pid, KeySharePrivate::from_bigint(&new_private_share))
+                    .is_none());
+                public_keys.push(KeySharePublic::new(*pid, new_public_share));
+            }
+        }
+        public_keys.sort_by_key(|k| k.participant());
+
+        // Compute the new outputs
+        let mut keygen_outputs: HashMap<
+            ParticipantIdentifier,
+            <KeygenParticipant as ProtocolParticipant>::Output,
+        > = HashMap::new();
+        for (pid, private_key_share) in new_private_shares {
+            let other_pids = all_participants
+                .iter()
+                .filter(|x| x != &&pid)
+                .copied()
+                .collect_vec();
+            let config = ParticipantConfig::new(pid, &other_pids)?;
+            let tshare = tshares.get(&pid).unwrap();
+
+            let output =
+                TshareParticipant::convert_to_t_out_of_t_share(&config, tshare, rid, chain_code)?;
+
+            // Test the function `convert_to_t_out_of_t_share`.
+            // Compare its output with `new_private_shares` and `public_keys`, which were
+            // computed with a different method above.
+            assert_eq!(output.private_key_share(), &private_key_share);
+            assert_eq!(
+                output
+                    .public_key_shares()
+                    .iter()
+                    .sorted_by_key(|k| k.participant())
+                    .cloned()
+                    .collect_vec(),
+                public_keys,
+            );
+
+            assert!(keygen_outputs.insert(pid, output).is_none());
+        }
+
+        let mut sum_toft_private_shares = keygen_outputs
+            .values()
+            .map(|output| output.private_key_share().as_ref().clone())
+            .fold(BigNumber::zero(), |acc, x| acc + x);
+        sum_toft_private_shares %= k256_order();
+
+        // Check the sum is indeed the sum of original private keys used as input of
+        // tshare reduced mod the order
+        dbg!(real);
+        dbg!(threshold);
+        if real >= threshold {
+            assert_eq!(
+                bn_to_scalar(&sum_toft_private_shares).unwrap(),
+                sum_tshare_input
+            );
+        }
+
+        Ok(keygen_outputs)
+    }
 
     impl TshareParticipant {
         pub fn new_quorum<R: RngCore + CryptoRng>(

--- a/src/tshare/share.rs
+++ b/src/tshare/share.rs
@@ -8,6 +8,7 @@
 
 use crate::{
     errors::{CallerError, InternalError, Result},
+    keygen::KeySharePrivate,
     paillier::{Ciphertext, DecryptionKey, EncryptionKey},
     utils::{bn_to_scalar, k256_order, scalar_to_bn, CurvePoint},
 };
@@ -95,6 +96,15 @@ impl Debug for CoeffPrivate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("CoeffPrivate([redacted])")
     }
+}
+
+impl TryFrom<&KeySharePrivate> for CoeffPrivate {
+    fn try_from(share: &KeySharePrivate) -> Result<Self> {
+        let x = bn_to_scalar(share.as_ref())?;
+        Ok(CoeffPrivate { x })
+    }
+
+    type Error = InternalError;
 }
 
 /// Represents a coefficient of a polynomial.


### PR DESCRIPTION
Content:

- Insert the `tshare` conversion protocol in the example scenario.
- Refactor the coordinator to support subsets of participant workers.
- For presign and sign protocols, use a subset: the first 2 participants as an example.
- Add conversion functions between `keygen` and `tshare` outputs.

Try it with:

`cargo run --example threaded_example -- --number-of-workers=3`