### PR TITLE
protocol_executions: Remove unused parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,22 @@ From the root directory, you can run: `cargo run --example threaded_example -- -
 ```
 Multi-party ECDSA signing
 
-Usage: threaded_example --number-of-workers <NUMBER_OF_WORKERS> --protocol-executions <PROTOCOL_EXECUTIONS>
+Usage: threaded_example --number-of-workers <NUMBER_OF_WORKERS>
 
 Options:
 -n, --number-of-workers <NUMBER_OF_WORKERS>
 Number of participant worker threads to use
--p, --protocol-executions <PROTOCOL_EXECUTIONS>
-Number of times to perform each sub-protocol of tss-ecdsa. protocol_executions > 1 useful for computing meaningful average execution times
 -h, --help
 Print help
 -V, --version
 Print version
 ```
-For example, `cargo run --example threaded_example -- --number-of-workers 3 --protocol-executions 1` will execute this example using three workers (participants).
+For example, `cargo run --example threaded_example -- --number-of-workers 3` will execute this example using three workers (participants).
 **Note** please pay attention to the `--` in the middle of the command. This is necessary to separate arguments to the `cargo run` command from arguments to this
 CLI example.
 
 This CLI example supports logging via the tracing crate. You can set the env var `RUST_LOG` to a verbosity level to execute with logging turned on:
 For example:
 ```shell
-RUST_LOG=info cargo run --example threaded_example -- --number-of-workers 2 --protocol-executions 1
+RUST_LOG=info cargo run --example threaded_example -- --number-of-workers 2
 ```

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -185,7 +185,9 @@ fn main() -> anyhow::Result<()> {
 
     // Coordinator initiates entire protocol.
     let mut coordinator = Coordinator::new(worker_messages, workers_rx, num_workers);
-    coordinator.tss_ecdsa()?;
+    for _ in 0..cli.protocol_executions {
+        coordinator.tss_ecdsa()?;
+    }
 
     Ok(())
 }

--- a/examples/threaded_example/threaded.rs
+++ b/examples/threaded_example/threaded.rs
@@ -61,11 +61,6 @@ struct Cli {
     /// Number of participant worker threads to use.
     #[arg(short, long)]
     number_of_workers: usize,
-    /// Number of times to perform each sub-protocol of tss-ecdsa.
-    /// protocol_executions > 1 useful for computing meaningful average
-    /// execution times.
-    #[arg(short, long)]
-    protocol_executions: usize,
 }
 
 /// Generic Storage for outputs of specific sub-protocols. Indexed by a `KeyId`
@@ -185,9 +180,7 @@ fn main() -> anyhow::Result<()> {
 
     // Coordinator initiates entire protocol.
     let mut coordinator = Coordinator::new(worker_messages, workers_rx, num_workers);
-    for _ in 0..cli.protocol_executions {
-        coordinator.tss_ecdsa()?;
-    }
+    coordinator.tss_ecdsa()?;
 
     Ok(())
 }


### PR DESCRIPTION
This parameter `protocol_executions` was always there but for some reason it wasn’t used. Removing it.